### PR TITLE
fix(server): contain and sanitise name-derived file paths (#1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "ENACT Test and Simulation Enabler",
   "scripts": {
     "start": "NODE_ENV=production node src/server/app.js",
-    "server": "nodemon src/server/app.js"
+    "server": "nodemon src/server/app.js",
+    "test": "node --test \"test/*.test.js\""
   },
   "nodemonConfig": {
     "verbose": true,

--- a/src/server/routes/data-recorders.js
+++ b/src/server/routes/data-recorders.js
@@ -10,6 +10,11 @@ const {
   deleteFile,
   getObjectId,
 } = require("../../core/utils");
+const {
+  isValidName,
+  resolveWithin,
+  sendBadRequest,
+} = require("./path-safety");
 const dataRecordersPath = `${__dirname}/../data/data-recorders/`;
 let router = express.Router();
 let getLogger = require("../logger");
@@ -80,6 +85,10 @@ const startRecorder = (model, res) => {
       res.send({
         error: " Invalid data recorder model",
       });
+    } else if (!isValidName(name)) {
+      res.status(400).send({
+        error: "Invalid data recorder name",
+      });
     } else {
       const recorderId = getObjectId(name);
       if (allDataRecorders[recorderId]) {
@@ -149,7 +158,10 @@ router.post("/start", (req, res, next) => {
   const { model, dataRecorderFileName } = req.body;
   if (dataRecorderFileName) {
     // start recorder by file name
-    const dataRecorderFile = `${dataRecordersPath}${dataRecorderFileName}`;
+    const dataRecorderFile = resolveWithin(dataRecordersPath, dataRecorderFileName);
+    if (!dataRecorderFile) {
+      return sendBadRequest(res, "Invalid data recorder file name");
+    }
     readJSONFile(dataRecorderFile, (err, data) => {
       if (err) {
         console.error(
@@ -188,12 +200,15 @@ router.get("/models/", (req, res, next) => {
 // Read a specific data recorder by its name:
 router.get("/models/:fileName", function (req, res, next) {
   const { fileName } = req.params;
-  const dataRecorderFile = `${dataRecordersPath}${fileName}`;
+  const dataRecorderFile = resolveWithin(dataRecordersPath, fileName);
+  if (!dataRecorderFile) {
+    return sendBadRequest(res, "Invalid data recorder name");
+  }
   readJSONFile(dataRecorderFile, (err, data) => {
     if (err) {
       console.error("[SERVER]", err);
       res.send({
-        error: err,
+        error: "Cannot read the data recorder file",
       });
     } else {
       res.send({
@@ -222,11 +237,18 @@ const updateDataRecorder = (fileName, dataRecorder, res) => {
       error: `Invalid dataRecorder ${JSON.stringify(dataRecorder)}`,
     });
   }
+  if (!isValidName(name)) {
+    return sendBadRequest(res, "Invalid data recorder name");
+  }
   const newName = `${name}.json`;
+  const oldDataRecorderFile = resolveWithin(dataRecordersPath, fileName);
+  const newDataRecorderFile = resolveWithin(dataRecordersPath, newName);
+  if (!oldDataRecorderFile || !newDataRecorderFile) {
+    return sendBadRequest(res, "Invalid data recorder name");
+  }
   if (newName === fileName) {
-    const dataRecorderFile = `${dataRecordersPath}${fileName}`;
     writeToFile(
-      dataRecorderFile,
+      newDataRecorderFile,
       JSON.stringify(dataRecorder),
       (err, data) => {
         if (err) {
@@ -244,8 +266,6 @@ const updateDataRecorder = (fileName, dataRecorder, res) => {
     );
   } else {
     // new file
-    const oldDataRecorderFile = `${dataRecordersPath}${fileName}`;
-    const newDataRecorderFile = `${dataRecordersPath}${newName}`;
     writeToFile(
       newDataRecorderFile,
       JSON.stringify(dataRecorder),
@@ -276,7 +296,10 @@ const updateDataRecorder = (fileName, dataRecorder, res) => {
 };
 
 const duplicateDataRecorder = (fileName, res) => {
-  const dataRecorderFile = `${dataRecordersPath}${fileName}`;
+  const dataRecorderFile = resolveWithin(dataRecordersPath, fileName);
+  if (!dataRecorderFile) {
+    return sendBadRequest(res, "Invalid data recorder name");
+  }
   readJSONFile(dataRecorderFile, (err, data) => {
     if (err) {
       console.error("[SERVER] Cannot read data recorder: ", err);
@@ -289,9 +312,16 @@ const duplicateDataRecorder = (fileName, res) => {
         ...data,
         name: newName,
       };
+      if (!isValidName(newName)) {
+        return sendBadRequest(res, "Invalid data recorder name");
+      }
       const newFileName = `${newName}.json`;
+      const newDataRecorderFile = resolveWithin(dataRecordersPath, newFileName);
+      if (!newDataRecorderFile) {
+        return sendBadRequest(res, "Invalid data recorder name");
+      }
       writeToFile(
-        `${dataRecordersPath}${newFileName}`,
+        newDataRecorderFile,
         JSON.stringify(newDataRecorder),
         (err, dupDataRecorder) => {
           if (err) {
@@ -343,8 +373,14 @@ router.post("/models", function (req, res, next) {
       error: `Invalid dataRecorder ${JSON.stringify(dataRecorder)}`,
     });
   }
+  if (!isValidName(name)) {
+    return sendBadRequest(res, "Invalid data recorder name");
+  }
   const dataRecorderFileName = `${dataRecorder.name}.json`;
-  const dataRecorderFile = `${dataRecordersPath}${dataRecorderFileName}`;
+  const dataRecorderFile = resolveWithin(dataRecordersPath, dataRecorderFileName);
+  if (!dataRecorderFile) {
+    return sendBadRequest(res, "Invalid data recorder name");
+  }
   writeToFile(dataRecorderFile, JSON.stringify(dataRecorder), (err, data) => {
     if (err) {
       console.error("[SERVER]", err);
@@ -363,7 +399,10 @@ router.post("/models", function (req, res, next) {
 // Delete a data recorder
 router.delete("/models/:fileName", function (req, res, next) {
   const { fileName } = req.params;
-  const dataRecorderFile = `${dataRecordersPath}${fileName}`;
+  const dataRecorderFile = resolveWithin(dataRecordersPath, fileName);
+  if (!dataRecorderFile) {
+    return sendBadRequest(res, "Invalid data recorder name");
+  }
   deleteFile(dataRecorderFile, (err) => {
     if (err) {
       console.error("[SERVER]", err);

--- a/src/server/routes/logs.js
+++ b/src/server/routes/logs.js
@@ -6,6 +6,10 @@ const {
   readDir,
   deleteFile,
 } = require("../../core/utils");
+const {
+  resolveWithin,
+  sendBadRequest,
+} = require("./path-safety");
 
 const _logsPath = `${__dirname}/../logs/`;
 
@@ -38,7 +42,10 @@ const createRouter = (appLog = true) => {
     const {
       fileName
     } = req.params;
-    const logFile = `${logsPath}${fileName}`;
+    const logFile = resolveWithin(logsPath, fileName);
+    if (!logFile) {
+      return sendBadRequest(res, "Invalid log file name");
+    }
     readTextFile(logFile, (err, content) => {
       if (err) {
         console.error("[SERVER]", err);
@@ -59,7 +66,10 @@ const createRouter = (appLog = true) => {
     const {
       fileName
     } = req.params;
-    const logFile = `${logsPath}${fileName}`;
+    const logFile = resolveWithin(logsPath, fileName);
+    if (!logFile) {
+      return sendBadRequest(res, "Invalid log file name");
+    }
     deleteFile(logFile, (err) => {
       if (err) {
         console.error("[SERVER]", err);

--- a/src/server/routes/model.js
+++ b/src/server/routes/model.js
@@ -8,6 +8,11 @@ const {
   readDir,
   deleteFile,
 } = require("../../core/utils");
+const {
+  isValidName,
+  resolveWithin,
+  sendBadRequest,
+} = require("./path-safety");
 const modelsPath = `${__dirname}/../data/models/`;
 let router = express.Router();
 
@@ -37,12 +42,15 @@ router.get("/:fileName", function (req, res, next) {
   const {
     fileName
   } = req.params;
-  const modelFile = `${modelsPath}${fileName}`;
+  const modelFile = resolveWithin(modelsPath, fileName);
+  if (!modelFile) {
+    return sendBadRequest(res, "Invalid model name");
+  }
   readJSONFile(modelFile, (err, data) => {
     if (err) {
       console.error("[SERVER]", err);
       res.send({
-        error: err
+        error: "Cannot read the model file"
       });
     } else {
       res.send({
@@ -54,7 +62,10 @@ router.get("/:fileName", function (req, res, next) {
 });
 
 const duplicateModel = (fileName, res) => {
-  const modelFile = `${modelsPath}${fileName}`;
+  const modelFile = resolveWithin(modelsPath, fileName);
+  if (!modelFile) {
+    return sendBadRequest(res, "Invalid model name");
+  }
   readJSONFile(modelFile, (err, data) => {
     if (err) {
       console.error("[SERVER]", err);
@@ -64,8 +75,15 @@ const duplicateModel = (fileName, res) => {
     } else {
       const newName = `${data.name} [Duplicated]`;
       const newModel = {...data, name: newName};
+      if (!isValidName(newName)) {
+        return sendBadRequest(res, "Invalid model name");
+      }
       const newFileName = `${newName}.json`;
-      writeToFile(`${modelsPath}${newFileName}`, JSON.stringify(newModel), (err, dupModel) => {
+      const newFile = resolveWithin(modelsPath, newFileName);
+      if (!newFile) {
+        return sendBadRequest(res, "Invalid model name");
+      }
+      writeToFile(newFile, JSON.stringify(newModel), (err, dupModel) => {
         if (err) {
           console.error("[SERVER]", err);
           res.send({
@@ -100,9 +118,19 @@ const updateModel = (model, fileName, res) => {
       error: `Invalid model ${JSON.stringify(model)}`
     });
   }
+  if (!isValidName(name)) {
+    return sendBadRequest(res, "Invalid model name");
+  }
   const newName = `${name}.json`;
+  const oldModelFile = resolveWithin(modelsPath, fileName);
+  if (!oldModelFile) {
+    return sendBadRequest(res, "Invalid model name");
+  }
+  const modelFile = resolveWithin(modelsPath, newName);
+  if (!modelFile) {
+    return sendBadRequest(res, "Invalid model name");
+  }
   if (fileName === newName) {
-    const modelFile = `${modelsPath}${fileName}`;
     writeToFile(modelFile, JSON.stringify(model), (err, data) => {
       if (err) {
         console.error("[SERVER]", err);
@@ -117,8 +145,6 @@ const updateModel = (model, fileName, res) => {
     }, true);
   }
   else {
-    const modelFile = `${modelsPath}${newName}`;
-    const oldModelFile = `${modelsPath}${fileName}`;
     writeToFile(modelFile, JSON.stringify(model), (err, data) => {
       if (err) {
         console.error("[SERVER]", err);
@@ -180,9 +206,15 @@ router.post("/", function (req, res, next) {
       error: `Invalid model ${JSON.stringify(model)}`
     });
   }
+  if (!isValidName(name)) {
+    return sendBadRequest(res, "Invalid model name");
+  }
 
   const modelFileName = `${model.name}.json`;
-  const modelFilePath = `${modelsPath}${modelFileName}`;
+  const modelFilePath = resolveWithin(modelsPath, modelFileName);
+  if (!modelFilePath) {
+    return sendBadRequest(res, "Invalid model name");
+  }
   writeToFile(modelFilePath, JSON.stringify(model), (err, data) => {
     if (err) {
       console.error("[SERVER]", err);
@@ -202,7 +234,10 @@ router.delete("/:fileName", function (req, res, next) {
   const {
     fileName
   } = req.params;
-  const modelFile = `${modelsPath}${fileName}`;
+  const modelFile = resolveWithin(modelsPath, fileName);
+  if (!modelFile) {
+    return sendBadRequest(res, "Invalid model name");
+  }
   deleteFile(modelFile, (err) => {
     if (err) {
       console.error("[SERVER]", err);

--- a/src/server/routes/path-safety.js
+++ b/src/server/routes/path-safety.js
@@ -1,0 +1,64 @@
+const path = require("path");
+
+const NAME_MAX_LENGTH = 128;
+
+// Allowlist of characters permitted in user-supplied names before they are
+// used to derive a storage filename. Rejects path separators, control
+// characters and any other value that could escape the intended directory.
+const NAME_ALLOWLIST = /^[A-Za-z0-9][A-Za-z0-9 _\-.()\[\]+@'#]*$/;
+
+/**
+ * Validate a user-supplied name against the allowlist and a length cap.
+ * @param {String} name The name to validate
+ * @returns {Boolean} true if the name may be used to derive a filename
+ */
+const isValidName = (name) => {
+  return (
+    typeof name === "string" &&
+    name.length > 0 &&
+    name.length <= NAME_MAX_LENGTH &&
+    NAME_ALLOWLIST.test(name) &&
+    name !== "." &&
+    name !== ".."
+  );
+};
+
+/**
+ * Resolve a user-supplied relative path against a base directory and verify
+ * the result stays inside the base directory. Handles traversal sequences
+ * (including URL-encoded separators that are decoded before this runs).
+ * @param {String} baseDir The intended base directory
+ * @param {String} relativePath The user-supplied relative path
+ * @returns {String|null} The resolved absolute path, or null if it escapes
+ *                        the base directory
+ */
+const resolveWithin = (baseDir, relativePath) => {
+  if (typeof relativePath !== "string" || relativePath.length === 0) {
+    return null;
+  }
+  const base = path.resolve(baseDir);
+  const resolved = path.resolve(base, relativePath);
+  const rel = path.relative(base, resolved);
+  if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) {
+    return null;
+  }
+  return resolved;
+};
+
+/**
+ * Reject a request with a 400-class status and a message that never
+ * discloses server-side paths.
+ */
+const sendBadRequest = (res, message) => {
+  return res.status(400).send({
+    error: message || "Invalid request",
+  });
+};
+
+module.exports = {
+  NAME_MAX_LENGTH,
+  NAME_ALLOWLIST,
+  isValidName,
+  resolveWithin,
+  sendBadRequest,
+};

--- a/src/server/routes/simulation.js
+++ b/src/server/routes/simulation.js
@@ -4,6 +4,11 @@ const { SIMULATING, OFFLINE } = require("../../core/DeviceStatus");
 let getLogger = require("../logger");
 const Simulation = require("../../core/simulation");
 const { readJSONFile } = require("../../core/utils");
+const {
+  isValidName,
+  resolveWithin,
+  sendBadRequest,
+} = require("./path-safety");
 const { getDataStorage } = require("./db-connector");
 const { getObjectId } = require('../../core/utils');
 
@@ -50,6 +55,9 @@ const startSimulation = (model, options, res, modelFileName = null) => {
       error: "Invalid model",
       model: model,
     });
+  }
+  if (!isValidName(name)) {
+    return sendBadRequest(res, "Invalid model name");
   }
 
   const simId = getObjectId(name);
@@ -122,7 +130,10 @@ router.post("/start", function (req, res, next) {
   simulationStatus = null;
   const { model, modelFileName, options } = req.body;
   if (modelFileName) {
-    const modelFilePath = `${modelsPath}${modelFileName}`;
+    const modelFilePath = resolveWithin(modelsPath, modelFileName);
+    if (!modelFilePath) {
+      return sendBadRequest(res, "Invalid model file name");
+    }
     readJSONFile(modelFilePath, (err, myModel) => {
       if (err) {
         console.error(`Cannot read model ${modelFileName}`, err);

--- a/test/_http.js
+++ b/test/_http.js
@@ -1,0 +1,43 @@
+const http = require("http");
+
+/**
+ * Make an HTTP request against a running server.
+ * @param {http.Server} server The listening server
+ * @param {String} method HTTP method
+ * @param {String} path Request path (may contain URL-encoded sequences)
+ * @param {Object} [body] Optional JSON body
+ * @returns {Promise<{status: Number, body: Object, raw: String}>}
+ */
+const request = (server, method, path, body) =>
+  new Promise((resolve, reject) => {
+    const port = server.address().port;
+    const data = body ? JSON.stringify(body) : null;
+    const options = {
+      hostname: "127.0.0.1",
+      port,
+      path,
+      method,
+      headers: {},
+    };
+    if (data) options.headers["Content-Type"] = "application/json";
+    const req = http.request(options, (res) => {
+      let raw = "";
+      res.on("data", (chunk) => {
+        raw += chunk;
+      });
+      res.on("end", () => {
+        let parsed = null;
+        try {
+          parsed = JSON.parse(raw);
+        } catch (e) {
+          /* not JSON */
+        }
+        resolve({ status: res.statusCode, body: parsed, raw });
+      });
+    });
+    req.on("error", reject);
+    if (data) req.write(data);
+    req.end();
+  });
+
+module.exports = { request };

--- a/test/path-safety.test.js
+++ b/test/path-safety.test.js
@@ -1,0 +1,91 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const {
+  isValidName,
+  resolveWithin,
+  NAME_MAX_LENGTH,
+} = require("../src/server/routes/path-safety");
+
+const BASE = path.resolve("/tmp/opencode/path-safety-unit");
+
+test("isValidName accepts legitimate names", () => {
+  const valid = [
+    "myModel",
+    "Temperature-Controller",
+    "Temperature Controller Recorder",
+    "202402-Temperature-Controller.json",
+    "Topology [Duplicated]",
+    "a_b-c.d(e)[f]+g@h'i#j",
+    "0",
+    "A",
+  ];
+  for (const name of valid) {
+    assert.equal(isValidName(name), true, `expected valid: ${name}`);
+  }
+});
+
+test("isValidName rejects traversal and path separator characters", () => {
+  const invalid = [
+    "",
+    ".",
+    "..",
+    "../etc/passwd",
+    "..%2F..%2Fetc%2Fpasswd",
+    "a/b",
+    "a\\b",
+    "a%2Fb",
+    "/etc/passwd",
+    "sub\\..\\..\\etc",
+    "a\u0000b",
+    "a\nb",
+  ];
+  for (const name of invalid) {
+    assert.equal(isValidName(name), false, `expected invalid: ${JSON.stringify(name)}`);
+  }
+});
+
+test("isValidName rejects values that are not strings", () => {
+  assert.equal(isValidName(null), false);
+  assert.equal(isValidName(undefined), false);
+  assert.equal(isValidName(42), false);
+  assert.equal(isValidName({ name: "x" }), false);
+});
+
+test("isValidName enforces the maximum length", () => {
+  const atLimit = "a".repeat(NAME_MAX_LENGTH);
+  const overLimit = "a".repeat(NAME_MAX_LENGTH + 1);
+  assert.equal(isValidName(atLimit), true);
+  assert.equal(isValidName(overLimit), false);
+});
+
+test("resolveWithin resolves a normal relative path inside the base", () => {
+  const resolved = resolveWithin(BASE, "model.json");
+  assert.equal(resolved, path.resolve(BASE, "model.json"));
+});
+
+test("resolveWithin rejects traversal sequences", () => {
+  const attempts = [
+    "../etc/passwd",
+    "../../etc/passwd",
+    "..",
+    "..%2F..%2Fetc%2Fpasswd",
+    "a/../../etc/passwd",
+    "sub/../../../etc/passwd",
+    "/etc/passwd",
+  ];
+  for (const attempt of attempts) {
+    assert.equal(resolveWithin(BASE, attempt), null, `expected reject: ${attempt}`);
+  }
+});
+
+test("resolveWithin resolves a nested path that stays inside the base", () => {
+  const resolved = resolveWithin(BASE, "subdir/../model.json");
+  assert.equal(resolved, path.resolve(BASE, "model.json"));
+});
+
+test("resolveWithin rejects empty and non-string input", () => {
+  assert.equal(resolveWithin(BASE, ""), null);
+  assert.equal(resolveWithin(BASE, null), null);
+  assert.equal(resolveWithin(BASE, undefined), null);
+});

--- a/test/routes-security.test.js
+++ b/test/routes-security.test.js
@@ -1,0 +1,267 @@
+const { test, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const express = require("express");
+const { request } = require("./_http");
+
+const modelRouter = require("../src/server/routes/model");
+const dataRecorderRouter = require("../src/server/routes/data-recorders");
+const simulationRouter = require("../src/server/routes/simulation");
+const createLogRouter = require("../src/server/routes/logs");
+
+const modelsDir = path.resolve(__dirname, "../src/server/data/models");
+const dataRecordersDir = path.resolve(__dirname, "../src/server/data/data-recorders");
+const repoPackageJson = path.resolve(__dirname, "../package.json");
+
+let server;
+let app;
+
+before(() => {
+  app = express();
+  app.use(express.json());
+  app.use("/api/models", modelRouter);
+  app.use("/api/data-recorders", dataRecorderRouter);
+  app.use("/api/simulation", simulationRouter);
+  app.use("/api/logs/simulations", createLogRouter("simulations"));
+  server = app.listen(0);
+});
+
+after(() => {
+  server.close();
+});
+
+const unique = (prefix) => `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+const inModelsDir = (fileName) => path.join(modelsDir, fileName);
+const inRecordersDir = (fileName) => path.join(dataRecordersDir, fileName);
+
+// ---------------------------------------------------------------------------
+// Issue #1 — containment of URL-parameterised filesystem access
+// ---------------------------------------------------------------------------
+
+test("models GET rejects traversal and does not disclose server paths", async () => {
+  const attempts = [
+    "/api/models/..%2Fpackage.json",
+    "/api/models/%2e%2e%2fpackage.json",
+    "/api/models/..%2F..%2F..%2Fetc%2Fpasswd",
+  ];
+  for (const p of attempts) {
+    const res = await request(server, "GET", p);
+    assert.equal(res.status, 400, `expected 400 for ${p}, got ${res.status} (${res.raw})`);
+    assert.ok(!res.raw.includes("/home/"), `response must not leak server paths: ${res.raw}`);
+    assert.ok(!res.raw.includes("workspace"), `response must not leak server paths: ${res.raw}`);
+    assert.ok(!res.raw.includes("package.json"), `response must not leak the target: ${res.raw}`);
+  }
+});
+
+test("models GET serves a legitimate model unchanged", async () => {
+  const res = await request(server, "GET", "/api/models/202402-Temperature-Controller.json");
+  assert.equal(res.status, 200);
+  assert.equal(res.body.error, null);
+  assert.ok(res.body.model);
+  assert.equal(res.body.model.name, "Temperature-Controller");
+});
+
+test("models DELETE rejects traversal and does not delete outside files", async () => {
+  assert.ok(fs.existsSync(repoPackageJson));
+  const res = await request(server, "DELETE", "/api/models/..%2Fpackage.json");
+  assert.equal(res.status, 400);
+  assert.ok(fs.existsSync(repoPackageJson), "package.json must not be deleted");
+});
+
+test("models DELETE rejects URL-encoded separator traversal", async () => {
+  const res = await request(server, "DELETE", "/api/models/%2e%2e%2fpackage.json");
+  assert.equal(res.status, 400);
+  assert.ok(fs.existsSync(repoPackageJson), "package.json must not be deleted");
+});
+
+test("data-recorders GET rejects traversal", async () => {
+  const res = await request(server, "GET", "/api/data-recorders/models/..%2Fpackage.json");
+  assert.equal(res.status, 400);
+  assert.ok(!res.raw.includes("workspace"));
+});
+
+test("data-recorders GET serves a legitimate recorder unchanged", async () => {
+  const res = await request(server, "GET", "/api/data-recorders/models/TemperatureControllerRecorder.json");
+  assert.equal(res.status, 200);
+  assert.ok(res.body.dataRecorder);
+  assert.equal(res.body.dataRecorder.name, "Temperature Controller Recorder");
+});
+
+test("data-recorders DELETE rejects traversal and does not delete outside files", async () => {
+  const res = await request(server, "DELETE", "/api/data-recorders/models/..%2Fpackage.json");
+  assert.equal(res.status, 400);
+  assert.ok(fs.existsSync(repoPackageJson), "package.json must not be deleted");
+});
+
+test("logs GET rejects traversal and does not disclose server paths", async () => {
+  const res = await request(server, "GET", "/api/logs/simulations/..%2Fpackage.json");
+  assert.equal(res.status, 400);
+  assert.ok(!res.raw.includes("workspace"));
+  assert.ok(!res.raw.includes("package.json"));
+});
+
+test("logs DELETE rejects traversal and does not delete outside files", async () => {
+  const res = await request(server, "DELETE", "/api/logs/simulations/..%2Fpackage.json");
+  assert.equal(res.status, 400);
+  assert.ok(fs.existsSync(repoPackageJson), "package.json must not be deleted");
+});
+
+test("simulation POST /start rejects traversal in body modelFileName", async () => {
+  const res = await request(server, "POST", "/api/simulation/start", {
+    modelFileName: "..%2Fpackage.json",
+  });
+  assert.equal(res.status, 400);
+  assert.ok(fs.existsSync(repoPackageJson));
+});
+
+test("data-recorders POST /start rejects traversal in body dataRecorderFileName", async () => {
+  const res = await request(server, "POST", "/api/data-recorders/start", {
+    dataRecorderFileName: "../../package.json",
+  });
+  assert.equal(res.status, 400);
+  assert.ok(fs.existsSync(repoPackageJson));
+});
+
+// ---------------------------------------------------------------------------
+// Issue #2 — sanitise user-supplied names before deriving storage filenames
+// ---------------------------------------------------------------------------
+
+test("models POST rejects hostile names and creates no file", async () => {
+  const hostile = ["../../escape", "..%2F..%2Fescape", "a/b", "a\\b", "x".repeat(200), ".", ".."];
+  for (const name of hostile) {
+    const res = await request(server, "POST", "/api/models", {
+      model: { name, devices: [] },
+    });
+    assert.equal(res.status, 400, `expected 400 for name ${JSON.stringify(name)}`);
+  }
+  assert.ok(!fs.existsSync(path.resolve(__dirname, "../escape.json")));
+  assert.ok(!fs.existsSync(inModelsDir("escape.json")));
+  assert.ok(!fs.existsSync(path.resolve(__dirname, "../../escape.json")));
+});
+
+test("models create, read, rename and delete with valid names", async () => {
+  const name = unique("sec-model");
+  const create = await request(server, "POST", "/api/models", {
+    model: { name, devices: [] },
+  });
+  assert.equal(create.status, 200);
+  const fileName = create.body.modelFileName;
+  assert.ok(fileName, "expected a modelFileName");
+  assert.ok(fs.existsSync(inModelsDir(fileName)));
+
+  const read = await request(server, "GET", `/api/models/${fileName}`);
+  assert.equal(read.status, 200);
+  assert.equal(read.body.model.name, name);
+
+  const renamed = `${name}-renamed`;
+  const rename = await request(server, "POST", `/api/models/${fileName}`, {
+    model: { name: renamed, devices: [] },
+  });
+  assert.equal(rename.status, 200);
+  assert.ok(!fs.existsSync(inModelsDir(fileName)), "old file must be removed on rename");
+  assert.ok(fs.existsSync(inModelsDir(`${renamed}.json`)), "renamed file must exist");
+
+  const del = await request(server, "DELETE", `/api/models/${renamed}.json`);
+  assert.equal(del.status, 200);
+  assert.ok(!fs.existsSync(inModelsDir(`${renamed}.json`)));
+});
+
+test("models POST duplicate produces a readable duplicated name", async () => {
+  const name = unique("sec-dup");
+  const create = await request(server, "POST", "/api/models", {
+    model: { name, devices: [] },
+  });
+  assert.equal(create.status, 200);
+  const fileName = create.body.modelFileName;
+  try {
+    const dup = await request(server, "POST", `/api/models/${fileName}`, {
+      isDuplicated: true,
+    });
+    assert.equal(dup.status, 200);
+    const dupFileName = dup.body.modelFileName;
+    assert.ok(dupFileName.includes("[Duplicated]"), `expected [Duplicated] in ${dupFileName}`);
+    assert.ok(fs.existsSync(inModelsDir(dupFileName)));
+    await request(server, "DELETE", `/api/models/${encodeURIComponent(dupFileName)}`);
+  } finally {
+    await request(server, "DELETE", `/api/models/${fileName}`);
+  }
+});
+
+test("models rename with a hostile new name is rejected and removes nothing", async () => {
+  const name = unique("sec-rename");
+  const create = await request(server, "POST", "/api/models", {
+    model: { name, devices: [] },
+  });
+  assert.equal(create.status, 200);
+  const fileName = create.body.modelFileName;
+  try {
+    const res = await request(server, "POST", `/api/models/${fileName}`, {
+      model: { name: "../../pwned", devices: [] },
+    });
+    assert.equal(res.status, 400);
+    assert.ok(fs.existsSync(inModelsDir(fileName)), "original file must be untouched");
+    assert.ok(!fs.existsSync(path.resolve(__dirname, "../../pwned.json")));
+    assert.ok(!fs.existsSync(inModelsDir("pwned.json")));
+  } finally {
+    await request(server, "DELETE", `/api/models/${fileName}`);
+  }
+});
+
+test("data-recorders POST /models rejects hostile names and creates no file", async () => {
+  const hostile = ["../../escape", "a/b", "x".repeat(200)];
+  for (const name of hostile) {
+    const res = await request(server, "POST", "/api/data-recorders/models", {
+      dataRecorder: { name, dataRecorders: [] },
+    });
+    assert.equal(res.status, 400, `expected 400 for name ${JSON.stringify(name)}`);
+  }
+  assert.ok(!fs.existsSync(inRecordersDir("escape.json")));
+});
+
+test("data-recorders create and delete with valid names", async () => {
+  const name = unique("sec-dr");
+  const create = await request(server, "POST", "/api/data-recorders/models", {
+    dataRecorder: { name, dataRecorders: [] },
+  });
+  assert.equal(create.status, 200);
+  const fileName = create.body.dataRecorderFileName;
+  assert.ok(fs.existsSync(inRecordersDir(fileName)));
+
+  const del = await request(server, "DELETE", `/api/data-recorders/models/${fileName}`);
+  assert.equal(del.status, 200);
+  assert.ok(!fs.existsSync(inRecordersDir(fileName)));
+});
+
+test("data-recorders rename with hostile new name is rejected and removes nothing", async () => {
+  const name = unique("sec-dr-rename");
+  const create = await request(server, "POST", "/api/data-recorders/models", {
+    dataRecorder: { name, dataRecorders: [] },
+  });
+  assert.equal(create.status, 200);
+  const fileName = create.body.dataRecorderFileName;
+  try {
+    const res = await request(server, "POST", `/api/data-recorders/models/${fileName}`, {
+      dataRecorder: { name: "../../pwned", dataRecorders: [] },
+    });
+    assert.equal(res.status, 400);
+    assert.ok(fs.existsSync(inRecordersDir(fileName)), "original file must be untouched");
+    assert.ok(!fs.existsSync(inRecordersDir("pwned.json")));
+  } finally {
+    await request(server, "DELETE", `/api/data-recorders/models/${fileName}`);
+  }
+});
+
+test("data-recorders start rejects a hostile model name in the body", async () => {
+  const res = await request(server, "POST", "/api/data-recorders/start", {
+    model: { name: "../../pwned", dataRecorders: [] },
+  });
+  assert.equal(res.status, 400);
+});
+
+test("simulation start rejects a hostile topology name in the body", async () => {
+  const res = await request(server, "POST", "/api/simulation/start", {
+    model: { name: "../../pwned", devices: [] },
+  });
+  assert.equal(res.status, 400);
+});


### PR DESCRIPTION
Closes #1
Closes #2

## Summary

Fixes two related P0-critical filesystem-access vulnerabilities in the server API. Route handlers that derive a filesystem path from a request-supplied name (URL parameter or request body) previously did no containment or name validation, letting a crafted name read, write, or delete files outside the intended directory — including via URL-encoded separators. Both issues are resolved together with a shared path-safety helper applied to every affected route family.

## Approach

Added `src/server/routes/path-safety.js` with two primitives:

- `resolveWithin(baseDir, name)` — resolves the path and verifies the result stays inside the base directory (rejects `..` traversal, absolute paths, and URL-encoded separators). Applied to **every** read, write, rename, duplicate, and delete handler in the models, data-recorders, simulation, and logs routers.
- `isValidName(name)` — allowlist of permitted characters plus a 128-char length cap, applied **before any storage filename is derived** from a body-supplied model/data-recorder/topology name. Also protects the log-filename derivation in the start-recorder/start-simulation paths.

Rejected requests return `400 Bad Request` with a generic message that never discloses server paths. Raw `fs` error objects (which embed absolute paths) are no longer echoed to clients on the affected read routes.

The rename/update paths now check **both** the new name (allowlist) and the old name (containment) before any write or unlink, so a hostile rename can neither write nor delete outside the intended directory. Existing records with previously-valid names (spaces, hyphens, brackets, the `[Duplicated]` suffix) remain readable and editable.

## Decision Record

- **Option chosen:** shared helper module + minimal per-handler guard, rather than a monolithic wrapper around fs utilities. Keeps the change small, explicit, and testable per route family while guaranteeing identical behaviour everywhere.
- **Scope:** all four routers that route user input to the filesystem. `logs.js` is included even though the batch listed three shared files, because issue #1 names four routers and logs GET/DELETE build paths from an untrusted route param with the same flaw.
- **Backward compatibility:** URL-parameter handlers use containment only (not the name allowlist) so every previously-created file stays readable/deletable; the allowlist gates only newly-derived filenames from body names.

## Changes

| File | Change |
|------|--------|
| `src/server/routes/path-safety.js` | New helper: `resolveWithin` (containment) and `isValidName` (allowlist + length cap) |
| `src/server/routes/model.js` | Containment on GET/DELETE/duplicate/rename; allowlist validation on create/rename body names; no server-path leakage |
| `src/server/routes/data-recorders.js` | Same treatment for /models and /start; recorder name validated before log filename derivation |
| `src/server/routes/simulation.js` | Containment on body `modelFileName`; topology name validated before log filename derivation |
| `src/server/routes/logs.js` | Containment on GET/DELETE log file routes |
| `package.json` | Added `npm test` script (`node --test`) |
| `test/path-safety.test.js` | Unit tests for containment + allowlist (8) |
| `test/routes-security.test.js` | HTTP integration regression tests per route family (20) |

## Test Results

`npm test` — 28/28 passing:

- Unit: traversal sequences (plain, nested, URL-encoded, absolute), allowlist accept/reject, length cap.
- Integration per route family: models GET/DELETE traversal -> 400, no file deleted, no server path in response; data-recorders GET/DELETE traversal -> 400; logs GET/DELETE traversal -> 400; simulation `POST /start` hostile `modelFileName` -> 400; data-recorders `POST /start` hostile file/recorder name -> 400.
- Integration for issue #2: create/rename/delete with hostile body names -> 400 with nothing created or removed; rename with hostile new name leaves the original file untouched; valid names (incl. spaces and the `[Duplicated]` suffix) still create, read, rename, and delete successfully.
- Existing sample data (`202402-Temperature-Controller.json`, `TemperatureControllerRecorder.json`) still served unchanged.

## Acceptance Criteria Verification

Issue #1:
- [x] Every name-derived path is resolved and rejected outside its intended base directory
- [x] Rejected requests return 400 with no server-path disclosure
- [x] Containment applies to read, write, and delete handlers, including URL-encoded separators
- [x] Regression test asserts containment per route family and fails if the check is removed
- [x] Legitimately valid names resolve and serve unchanged

Issue #2:
- [x] Names are validated against an explicit allowlist and a length cap before deriving a filename
- [x] Failing names are rejected with 400 and no file is created or removed
- [x] The rename path cannot delete outside the intended directory even with hostile names
- [x] Existing records with previously-valid names remain readable and editable
- [x] Regression test covers create, rename, and delete with hostile names