### PR TITLE
docs: document the hardening configuration knobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,27 @@ an untrusted or public network:
 The quick-start `docker run` on this page already reflects this baseline by
 binding to loopback.
 
+## Security-related configuration
+
+The hardening limits are configurable. Every value below has a safe default, so
+an unconfigured deployment is already protected — set these only to relax or
+tighten a limit.
+
+| Variable               | Default           | Purpose                                                                                                                                                                          |
+| ---------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CORS_ALLOWED_ORIGINS` | _(empty)_         | Comma- or whitespace-separated list of origins allowed to call the API from a browser. Empty means same-origin only, and a request from any other origin is rejected with `403`. |
+| `BODY_LIMIT`           | `1mb`             | Largest request body accepted. Anything bigger is rejected with `413` rather than buffered. `MAX_BODY_SIZE` is accepted as an alias.                                             |
+| `RATE_LIMIT_WINDOW_MS` | `900000` (15 min) | Length of the rate-limiting window applied to `/api`.                                                                                                                            |
+| `RATE_LIMIT_MAX`       | `1000`            | Requests allowed per window per client. Going over returns `429`.                                                                                                                |
+
+Values are read from the process environment first, then from `.env`, then from
+these defaults — so a container or a CI job can override a setting without
+editing the operator's `.env` file.
+
+`CORS_ALLOWED_ORIGINS` is only needed when the dashboard is served from a
+different origin than the API. In the shipped image both are on the same port,
+so the default is already correct and no configuration is required.
+
 ## Reporting a security issue
 
 See [SECURITY.md](SECURITY.md) for how to report a vulnerability privately. We

--- a/env.example
+++ b/env.example
@@ -1,3 +1,11 @@
 SERVER_HOST=0.0.0.0
 SERVER_PORT=3004
 DEV_DASHBOARD_PORT=8080
+
+# Optional hardening limits. The defaults shown here are what the server applies
+# when they are unset, so leave them commented out unless you need to change
+# one. See the "Security-related configuration" section of the README.
+#CORS_ALLOWED_ORIGINS=
+#BODY_LIMIT=1mb
+#RATE_LIMIT_WINDOW_MS=900000
+#RATE_LIMIT_MAX=1000


### PR DESCRIPTION
Follow-up to the Phase 0 hardening. The limits added for #3 and #6 were configurable but undocumented — `CORS_ALLOWED_ORIGINS`, `BODY_LIMIT`/`MAX_BODY_SIZE`, `RATE_LIMIT_WINDOW_MS` and `RATE_LIMIT_MAX` appeared in neither the README, `SECURITY.md` nor `env.example`, so an operator had no way to discover them.

## Changes

- **README** gains a `Security-related configuration` section under `# Security`: each variable, its default, the status code it produces (`403` / `413` / `429`), and the `process environment > .env > defaults` precedence rule.
- **env.example** lists the same variables commented out. Leaving them commented means copying the template cannot silently pin a default that later changes in code — the server keeps applying whatever it considers safe.

## Decision Record

- **Commented rather than active entries in `env.example`.** Active entries would be copied into `.env` by the documented `cp env.example .env` step and freeze todays values. Commented entries document without pinning. The three pre-existing keys stay active because `test/env-config.test.js` asserts them verbatim.
- **Placed under `# Security` rather than `### Usage`.** These are hardening limits, and an operator reading the security posture is the one who needs them. `SERVER_HOST` / `SERVER_PORT` stay where they are.
- **No `Closes #N`.** No issue tracked this gap; it was found while reviewing #53. Referencing #3 and #6 for context only.

## Verification

Defaults in the table were confirmed against the running code rather than read off the source:

```
bodyLimit             "1mb"
rateLimitWindowMs     900000
rateLimitMax          1000
corsAllowedOrigins    []
MAX_BODY_SIZE alias   "7mb"   (alias honoured)
```

`403` / `413` are asserted at `src/server/app.js:65` and `:123`, the limiter is scoped at `app.use('/api', apiLimiter)`, and `429` is covered by the e2e `burst traffic is rate-limited` test.

Full suite: 82 tests, 81 pass, 1 skipped (container, no `TAS_IMAGE`), 0 fail — including `DEFAULT_CONFIG is documented in env.example` and `env.example remains as the documented template`. README passes `prettier --check`.