### PR TITLE
fix(server): contain filesystem access in devops and test-cases paths (#55)

### DIFF
--- a/.github/workflows/e2e-security.yml
+++ b/.github/workflows/e2e-security.yml
@@ -30,13 +30,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Serialised: each file spawns its own real instance and the suites share
-      # the on-disk storage root, so running them in parallel makes the
+      # Serialised: several files spawn their own real instance and the suites
+      # share the on-disk storage root, so running them in parallel makes the
       # directory snapshots race and the instances contend for the same port.
-      - name: Run the end-to-end security suite over HTTP
-        run: >-
-          node --test-concurrency=1 --test
-          test/e2e/security-suite.test.js test/e2e/limits.test.js
+      # `npm test` is `node --test-concurrency=1 --test "test/**/*.test.js"`, so
+      # it keeps that serialisation while also gating the unit-level regression
+      # guards that naming the e2e files individually left unable to fail a PR.
+      # The container image assertion is part of the glob but skips itself here:
+      # its runtime half is guarded on TAS_IMAGE, which only the job below sets.
+      - name: Run the full test suite
+        run: npm test
 
   container:
     name: Container image runs as non-root

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ body-size and rate limits, non-root image) to be present, and are enforced in
 CI on every push to `master` and every pull request via
 `.github/workflows/e2e-security.yml`.
 
+`npm test` runs everything under `test/`, including the end-to-end files, and
+is serialised with the same `--test-concurrency=1` for the same reason. Some
+end-to-end assertions drive routes that need a database; with none reachable
+they wait out the connect timeout, so a full local run takes roughly half a
+minute even though the assertions themselves are fast.
+
 ### Create docker image for multiple platform
 
 Source: https://www.docker.com/blog/multi-arch-images/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "NODE_ENV=production node src/server/app.js",
     "server": "nodemon src/server/app.js",
-    "test": "node --test \"test/**/*.test.js\""
+    "test": "node --test-concurrency=1 --test \"test/**/*.test.js\""
   },
   "nodemonConfig": {
     "verbose": true,

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -34,10 +34,20 @@ const readJSONFile = (filePath, callback) => {
   try {
     fs.readFile(filePath, (err, data) => {
       if (err) return callback(err);
-      const jsonData = JSON.parse(data);
+      // The outer catch cannot see a throw from in here: this callback runs on
+      // a later tick, so a malformed file used to take the process down rather
+      // than reach the caller's error branch. Report a parse failure the same
+      // way a read failure is reported - every caller already handles it.
+      let jsonData;
+      try {
+        jsonData = JSON.parse(data);
+      } catch (parseError) {
+        return callback(parseError);
+      }
       return callback(null, jsonData);
     })
   } catch (error) {
+    // Only a synchronous throw from the fs.readFile call itself lands here.
     return callback(error);
   }
 }
@@ -65,7 +75,11 @@ const writeToFile = (_filePath, data, callback, isOverwrite = false) => {
       return callback(null, result);
     });
   } catch (error) {
-
+    // A synchronous throw from fs.writeFile (invalid path or data) used to be
+    // swallowed here without calling back at all, so the request that asked for
+    // the write hung until its client gave up. Route it to the callback like
+    // every other function in this file does.
+    return callback(error);
   }
 }
 

--- a/src/server/routes/devops.js
+++ b/src/server/routes/devops.js
@@ -71,8 +71,13 @@ const getDevops = (callback) => {
 router.get("/", function (req, res, next) {
   getDevops((err, devO) => {
     if (err) {
+      // Same reasoning as in `loadValidatedDevops` below: the raw fs error
+      // carries the absolute path of devops.json in its own enumerable
+      // properties, which JSON.stringify would serialise straight into the
+      // response. Keep the detail server-side and answer with a constant.
+      console.error('[SERVER] Cannot get devops configuration', err);
       res.send({
-        error: err
+        error: "Cannot get devops configuration"
       });
     } else {
       res.send({

--- a/src/server/routes/devops.js
+++ b/src/server/routes/devops.js
@@ -126,9 +126,13 @@ router.post("/", function (req, res, next) {
 const loadValidatedDevops = (req, res, next) => {
   getDevops((err, devops) => {
     if (err) {
-      console.error('[SERVER] Cannot get devops configuration');
+      // The raw fs error carries the absolute path of devops.json in its own
+      // enumerable properties, which JSON.stringify would serialise straight
+      // into the response. Keep the detail server-side and answer with a
+      // constant message.
+      console.error('[SERVER] Cannot get devops configuration', err);
       return res.send({
-        error: err
+        error: "Cannot get devops configuration"
       });
     }
     const { testCampaignId } = devops || {};

--- a/src/server/routes/devops.js
+++ b/src/server/routes/devops.js
@@ -17,6 +17,11 @@ const {
   writeToFile
 } = require("../../core/utils");
 const { OFFLINE } = require("../../core/DeviceStatus");
+const {
+  isValidName,
+  resolveWithin,
+  sendBadRequest,
+} = require("./path-safety");
 let logsPath = `${__dirname}/../logs/test-campaigns/`;
 
 let runningStatus = null;
@@ -30,6 +35,18 @@ router.get("/status", (req, res, next) => {
     runningStatus
   });
 });
+
+/**
+ * A test campaign id is optional in the stored configuration, but when one is
+ * present it is interpolated into a log filename, so it must survive the same
+ * allowlist every other name-derived path in the API goes through.
+ * @param {*} testCampaignId The value from the devops configuration
+ * @returns {Boolean} true when the value is absent or safe to derive a name from
+ */
+const isValidTestCampaignId = (testCampaignId) =>
+  testCampaignId === undefined ||
+  testCampaignId === null ||
+  isValidName(testCampaignId);
 
 let _devops = null;
 
@@ -76,6 +93,13 @@ router.post("/", function (req, res, next) {
       error: "Cannot find devops content in body"
     });
   }
+  // The test campaign id becomes part of a log filename in GET /start, so a
+  // hostile value must never reach the persisted configuration in the first
+  // place. Validating only on read-back would still leave the escape sitting
+  // in devops.json for any other consumer.
+  if (!isValidTestCampaignId(devops.testCampaignId)) {
+    return sendBadRequest(res, "Invalid test campaign id");
+  }
   writeToFile(devopsFilePath, JSON.stringify(devops), (err, data) => {
     if (err) {
       console.error("[SERVER] Cannot save devops.json file", err);
@@ -91,75 +115,99 @@ router.post("/", function (req, res, next) {
   }, true);
 });
 
-router.get('/start', dbConnector, (req, res, next) => {
+/**
+ * Load the persisted devops configuration and reject it before any further
+ * work when its test campaign id cannot safely derive a log filename.
+ *
+ * This runs ahead of `dbConnector` on purpose: the containment decision must
+ * not depend on a reachable database, otherwise a hostile configuration is
+ * only rejected on instances that happen to have one.
+ */
+const loadValidatedDevops = (req, res, next) => {
   getDevops((err, devops) => {
     if (err) {
       console.error('[SERVER] Cannot get devops configuration');
-      res.send({
+      return res.send({
         error: err
       });
-    } else {
-      const {
-        webhookURL,
-        testCampaignId,
-        dataStorage,
-        evaluationParameters,
-      } = devops;
-      if (!testCampaignId) {
-        console.error('Test campaign Id must not be NULL');
+    }
+    const { testCampaignId } = devops || {};
+    if (!testCampaignId) {
+      console.error('Test campaign Id must not be NULL');
+      return res.send({
+        error: `Test campaign Id must not be null`
+      });
+    }
+    // A configuration written by an older, unvalidated build can still hold a
+    // hostile id, so read-back is checked as well as write.
+    if (!isValidName(testCampaignId)) {
+      return sendBadRequest(res, "Invalid test campaign id");
+    }
+    req.devops = devops;
+    return next();
+  });
+};
+
+router.get('/start', loadValidatedDevops, dbConnector, (req, res, next) => {
+  const devops = req.devops;
+  const {
+    webhookURL,
+    testCampaignId,
+    dataStorage,
+    evaluationParameters,
+  } = devops;
+  const startedTime = Date.now();
+  const logFile = `${testCampaignId}_${startedTime}.log`;
+  // The logger creates missing parent directories, so an escaping filename
+  // would write outside the log root rather than fail. Resolve and contain it.
+  const logFilePath = resolveWithin(logsPath, logFile);
+  if (!logFilePath) {
+    return sendBadRequest(res, "Invalid test campaign id");
+  }
+  getLogger("TEST-CAMPAIGN", logFilePath);
+  console.log('[devops] A test campaign is going to be started ...');
+
+  if (dataStorage) {
+    runningStatus = {
+      isRunning: true,
+      testCampaignId,
+      dataStorage,
+      webhookURL,
+      startedTime,
+      endTime: null,
+      logFile
+    };
+    startTestCampaign(testCampaignId, dataStorage, webhookURL, evaluationParameters);
+    res.send({
+      error: null,
+      devops,
+      runningStatus
+    });
+  } else {
+    getDataStorage((err, ds) => {
+      if (err) {
+        console.log('[devops] Cannot get data storage');
         res.send({
-          error: `Test campaign Id must not be null`
+          error: 'Cannot get data storage'
         });
       } else {
-        const startedTime = Date.now();
-        const logFile = `${testCampaignId}_${startedTime}.log`;
-        getLogger("TEST-CAMPAIGN", `${logsPath}${logFile}`);
-        console.log('[devops] A test campaign is going to be started ...');
-
-        if (dataStorage) {
-          runningStatus = {
-            isRunning: true,
-            testCampaignId,
-            dataStorage,
-            webhookURL,
-            startedTime,
-            endTime: null,
-            logFile
-          };
-          startTestCampaign(testCampaignId, dataStorage, webhookURL, evaluationParameters);
-          res.send({
-            error: null,
-            devops,
-            runningStatus
-          });
-        } else {
-          getDataStorage((err, ds) => {
-            if (err) {
-              console.log('[devops] Cannot get data storage');
-              res.send({
-                error: 'Cannot get data storage'
-              });
-            } else {
-              runningStatus = {
-                isRunning: true,
-                testCampaignId,
-                dataStorage: ds,
-                webhookURL,
-                startedTime,
-                endTime: null,
-                logFile
-              };
-              startTestCampaign(testCampaignId, ds, webhookURL, evaluationParameters);
-              res.send({
-                error: null,
-                runningStatus
-              });
-            }
-          });
-        }
+        runningStatus = {
+          isRunning: true,
+          testCampaignId,
+          dataStorage: ds,
+          webhookURL,
+          startedTime,
+          endTime: null,
+          logFile
+        };
+        startTestCampaign(testCampaignId, ds, webhookURL, evaluationParameters);
+        res.send({
+          error: null,
+          runningStatus
+        });
       }
-    }
-  });
+    });
+  }
 });
 
 router.get('/stop', (req, res, next) => {

--- a/src/server/routes/test-cases.js
+++ b/src/server/routes/test-cases.js
@@ -6,6 +6,43 @@ const {
   TestCaseSchema,
   dbConnector
 } = require('./db-connector');
+const {
+  resolveWithin,
+  sendBadRequest,
+} = require("./path-safety");
+
+/**
+ * Contain the `modelFileName` a request wants stored on a test case.
+ *
+ * The stored value is an absolute path into the models directory that a later
+ * consumer may open, so it is resolved and checked for containment before it
+ * is persisted - a rejected name never reaches the database. An absent name is
+ * stored as null rather than a path to a file that cannot exist.
+ *
+ * Runs ahead of `dbConnector` so the check does not depend on a reachable
+ * database, and so a hostile request costs no connection attempt.
+ */
+const containModelFileName = (req, res, next) => {
+  const { testCase } = req.body || {};
+  if (!testCase || typeof testCase !== "object") {
+    // Shape errors stay the responsibility of the handler below.
+    return next();
+  }
+  if (!("modelFileName" in testCase)) {
+    return next();
+  }
+  const { modelFileName } = testCase;
+  if (modelFileName === undefined || modelFileName === null || modelFileName === "") {
+    req.containedModelFileName = null;
+    return next();
+  }
+  const modelFilePath = resolveWithin(modelsPath, modelFileName);
+  if (!modelFilePath) {
+    return sendBadRequest(res, "Invalid model file name");
+  }
+  req.containedModelFileName = modelFilePath;
+  return next();
+};
 
 // Get all the test cases
 router.get("/", dbConnector, function (req, res, next) {
@@ -46,7 +83,7 @@ router.get("/:testCaseId", dbConnector, function (req, res, next) {
 });
 
 // Add a new test case
-router.post("/", dbConnector, function (req, res, next) {
+router.post("/", containModelFileName, dbConnector, function (req, res, next) {
   const {
     testCase
   } = req.body;
@@ -55,8 +92,7 @@ router.post("/", dbConnector, function (req, res, next) {
     name,
     tags,
     description,
-    datasetIds,
-    modelFileName
+    datasetIds
   } = testCase;
   const newTestCase = new TestCaseSchema({
     id,
@@ -64,7 +100,7 @@ router.post("/", dbConnector, function (req, res, next) {
     tags,
     description,
     datasetIds,
-    modelFileName:`${modelsPath}/${modelFileName}`
+    modelFileName: req.containedModelFileName || null
   });
   newTestCase.save((err, _testCase) => {
     if (err) {
@@ -83,7 +119,7 @@ router.post("/", dbConnector, function (req, res, next) {
 /**
  * Update a test case
  */
-router.post("/:testCaseId", dbConnector, function (req, res, next) {
+router.post("/:testCaseId", containModelFileName, dbConnector, function (req, res, next) {
   const {
     testCase
   } = req.body;
@@ -91,7 +127,15 @@ router.post("/:testCaseId", dbConnector, function (req, res, next) {
     testCaseId
   } = req.params;
 
-  TestCaseSchema.findOneAndUpdate({id: testCaseId}, testCase, (err, ts) => {
+  // Without this the create-time containment above is bypassable in one extra
+  // request: the update writes whatever the body carries straight through.
+  // `undefined` means the payload carried no modelFileName at all, so the
+  // stored one is left alone; `null` is a contained value the caller asked for.
+  const update = req.containedModelFileName !== undefined
+    ? { ...testCase, modelFileName: req.containedModelFileName }
+    : testCase;
+
+  TestCaseSchema.findOneAndUpdate({id: testCaseId}, update, (err, ts) => {
     if (err) {
       console.error('[SERVER] Failed to save the test cases', err);
       res.send({

--- a/src/server/routes/test-cases.js
+++ b/src/server/routes/test-cases.js
@@ -28,6 +28,15 @@ const containModelFileName = (req, res, next) => {
     // Shape errors stay the responsibility of the handler below.
     return next();
   }
+  // A `$`-prefixed key makes the body a MongoDB update document rather than a
+  // plain set of fields, and the update route hands it to `findOneAndUpdate`
+  // as-is. `{"$set": {"modelFileName": "..."}}` carries no own `modelFileName`
+  // key, so the containment below would wave it through and the operator would
+  // still persist an arbitrary path. No legitimate client sends operators - the
+  // UI posts a flat object of form fields - so reject them outright.
+  if (Object.keys(testCase).some((key) => key.startsWith("$"))) {
+    return sendBadRequest(res, "Invalid test case");
+  }
   if (!("modelFileName" in testCase)) {
     return next();
   }

--- a/test/core-utils.test.js
+++ b/test/core-utils.test.js
@@ -101,14 +101,23 @@ test("writeToFile reports a synchronous path failure through the callback", asyn
   assert.equal(err.code, "ERR_INVALID_ARG_VALUE");
 });
 
-test("writeToFile reports a synchronous data failure through the callback", async () => {
-  // fs.writeFile validates the data argument synchronously too, so a caller
-  // that passes a non-serialised value hits the same swallowed-error path.
+test("writeToFile always calls back for a non-string data argument", async () => {
+  // fs.writeFile validates the data argument synchronously as well, so a caller
+  // that passes a non-serialised value hits the same swallowed-error path - but
+  // only from Node 19 on, where the implicit string coercion deprecated as
+  // DEP0162 reached end of life. Earlier versions coerce 42 to "42" and write
+  // it. The repo declares no `engines`, so assert the part that holds either
+  // way: the callback is always invoked, which is the regression this guards.
+  // The NUL-byte path above is the version-stable trigger for the error itself.
   const [err] = await callbackArgs((cb) =>
     writeToFile(path.join(tmpDir, "bad-data.json"), 42, cb, true)
   );
-  assert.ok(err, "a synchronous write failure must produce an error argument");
-  assert.equal(err.code, "ERR_INVALID_ARG_TYPE");
+  if (err) {
+    assert.ok(
+      err instanceof TypeError,
+      `expected an argument-type failure, got ${err.constructor.name}: ${err}`
+    );
+  }
 });
 
 test("writeToFile still writes and calls back on success", async () => {

--- a/test/core-utils.test.js
+++ b/test/core-utils.test.js
@@ -1,0 +1,121 @@
+const { test, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { readJSONFile, writeToFile } = require("../src/core/utils");
+
+// Fixtures live in a throwaway temp directory. These tests deliberately create
+// malformed files and invalid paths, which must never touch the repo's storage
+// roots - the route suites assert on the contents of those directories.
+let tmpDir;
+
+before(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tas-core-utils-"));
+});
+
+after(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/**
+ * Run a function that takes a node-style callback and resolve with the
+ * arguments the callback received.
+ *
+ * The timeout is the point: both bugs under test ended with the callback never
+ * being invoked at all, and a test that simply waits for it reports a hang
+ * rather than a failure. Rejecting turns "never called back" into an assertion.
+ * @param {Function} invoke Receives the callback to pass to the function
+ * @returns {Promise<Array>} The arguments the callback was invoked with
+ */
+const callbackArgs = (invoke, timeoutMs = 5000) =>
+  new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error("the callback was never invoked")),
+      timeoutMs
+    );
+    invoke((...args) => {
+      clearTimeout(timer);
+      resolve(args);
+    });
+  });
+
+// ---------------------------------------------------------------------------
+// readJSONFile - a parse failure must reach the callback, not the process
+// ---------------------------------------------------------------------------
+
+test("readJSONFile reports malformed JSON through the callback", async () => {
+  // JSON.parse runs inside the fs.readFile callback, on a later tick than the
+  // function's own try/catch. Before the fix this threw out of the callback and
+  // took the whole process down instead of reaching any caller's error branch.
+  const filePath = path.join(tmpDir, "malformed.json");
+  fs.writeFileSync(filePath, "{ this is not json ");
+
+  const [err, data] = await callbackArgs((cb) => readJSONFile(filePath, cb));
+  assert.ok(err, "a malformed file must produce an error argument");
+  assert.ok(
+    err instanceof SyntaxError,
+    `expected the parse failure itself, got ${err && err.constructor.name}`
+  );
+  assert.equal(data, undefined, "no data may be handed over alongside an error");
+});
+
+test("readJSONFile reports a missing file through the callback", async () => {
+  const [err, data] = await callbackArgs((cb) =>
+    readJSONFile(path.join(tmpDir, "does-not-exist.json"), cb)
+  );
+  assert.ok(err, "a missing file must produce an error argument");
+  assert.equal(err.code, "ENOENT");
+  assert.equal(data, undefined);
+});
+
+test("readJSONFile returns the parsed object for valid JSON", async () => {
+  const filePath = path.join(tmpDir, "valid.json");
+  const content = { name: "Temperature-Controller", devices: [], count: 3 };
+  fs.writeFileSync(filePath, JSON.stringify(content));
+
+  const [err, data] = await callbackArgs((cb) => readJSONFile(filePath, cb));
+  assert.equal(err, null, `a valid file must not error (${err})`);
+  assert.deepEqual(data, content);
+});
+
+// ---------------------------------------------------------------------------
+// writeToFile - a synchronous throw must reach the callback, not be swallowed
+// ---------------------------------------------------------------------------
+
+// A NUL byte in a path makes fs.writeFile throw ERR_INVALID_ARG_VALUE
+// synchronously, before any I/O is attempted. It is written as a char code
+// because a literal NUL in source is invisible.
+const nulByte = String.fromCharCode(0);
+
+test("writeToFile reports a synchronous path failure through the callback", async () => {
+  // Before the fix the empty catch swallowed this and returned without calling
+  // back, so the HTTP request that asked for the write hung until its client
+  // gave up. `fs.existsSync` tolerates the same path, so the non-overwrite
+  // branch above reaches fs.writeFile rather than failing earlier.
+  const [err] = await callbackArgs((cb) =>
+    writeToFile(path.join(tmpDir, `bad${nulByte}name.json`), "{}", cb, true)
+  );
+  assert.ok(err, "a synchronous write failure must produce an error argument");
+  assert.equal(err.code, "ERR_INVALID_ARG_VALUE");
+});
+
+test("writeToFile reports a synchronous data failure through the callback", async () => {
+  // fs.writeFile validates the data argument synchronously too, so a caller
+  // that passes a non-serialised value hits the same swallowed-error path.
+  const [err] = await callbackArgs((cb) =>
+    writeToFile(path.join(tmpDir, "bad-data.json"), 42, cb, true)
+  );
+  assert.ok(err, "a synchronous write failure must produce an error argument");
+  assert.equal(err.code, "ERR_INVALID_ARG_TYPE");
+});
+
+test("writeToFile still writes and calls back on success", async () => {
+  const filePath = path.join(tmpDir, "written.json");
+  const [err] = await callbackArgs((cb) =>
+    writeToFile(filePath, JSON.stringify({ ok: true }), cb, true)
+  );
+  assert.equal(err, null, `a legitimate write must not error (${err})`);
+  assert.deepEqual(JSON.parse(fs.readFileSync(filePath, "utf8")), { ok: true });
+});

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -16,6 +16,8 @@ const repoRoot = path.resolve(__dirname, "../..");
 const modelsDir = path.resolve(repoRoot, "src/server/data/models");
 const recordersDir = path.resolve(repoRoot, "src/server/data/data-recorders");
 const repoPackageJson = path.resolve(repoRoot, "package.json");
+const devopsConfigPath = path.resolve(repoRoot, "src/server/data/devops.json");
+const campaignLogsDir = path.resolve(repoRoot, "src/server/logs/test-campaigns");
 
 /** An origin the server will be configured to allow via CORS_ALLOWED_ORIGINS. */
 const allowedOrigin = "http://allowed.example";
@@ -197,6 +199,38 @@ const removeIfPresent = (filePath) => {
   }
 };
 
+/**
+ * Every directory a `../` payload in a test-campaign log filename reaches from
+ * `src/server/logs/test-campaigns/`. The logger creates missing parents, so an
+ * escaping name really does write into these if containment regresses - the
+ * canaries must look where the payload actually lands.
+ */
+const campaignLogEscapeDirs = [
+  path.resolve(campaignLogsDir, ".."),
+  path.resolve(campaignLogsDir, "../.."),
+  path.resolve(campaignLogsDir, "../../.."),
+  repoRoot,
+];
+
+/**
+ * Absolute paths of any file in a campaign-log escape directory whose name
+ * starts with the given prefix. The log filename carries a timestamp, so the
+ * canary matches on the prefix rather than an exact name.
+ * @param {String} prefix Artifact name prefix, e.g. the hostile campaign id
+ * @returns {String[]} Paths that must be empty after a rejected request
+ */
+const escapedCampaignLogs = (prefix) =>
+  campaignLogEscapeDirs.flatMap((dir) => {
+    try {
+      return fs
+        .readdirSync(dir)
+        .filter((f) => f.startsWith(prefix))
+        .map((f) => path.join(dir, f));
+    } catch (_) {
+      return []; // directory absent, which is the expected case
+    }
+  });
+
 /** Snapshot the list of files in a directory (for "nothing written/removed" asserts). */
 const listDir = (dir) =>
   new Promise((resolve) =>
@@ -208,6 +242,8 @@ module.exports = {
   modelsDir,
   recordersDir,
   repoPackageJson,
+  devopsConfigPath,
+  campaignLogsDir,
   allowedOrigin,
   hostileOrigin,
   request,
@@ -216,6 +252,7 @@ module.exports = {
   inModelsDir,
   inRecordersDir,
   escapeArtifacts,
+  escapedCampaignLogs,
   removeIfPresent,
   listDir,
 };

--- a/test/e2e/security-suite.test.js
+++ b/test/e2e/security-suite.test.js
@@ -10,15 +10,19 @@
 const { test, before, after } = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
+const path = require("node:path");
 const {
   startServer,
   request,
   unique,
   repoPackageJson,
+  devopsConfigPath,
+  campaignLogsDir,
   modelsDir,
   recordersDir,
   inModelsDir,
   escapeArtifacts,
+  escapedCampaignLogs,
   removeIfPresent,
   listDir,
   allowedOrigin,
@@ -28,9 +32,16 @@ const {
 /** Hostile base names this suite tries to write outside the storage root. */
 const escapeNames = ["escape", "pwned"];
 
+/** Hostile test campaign id used to probe the devops log path (issue #55). */
+const hostileCampaignId = "../../../pwned-campaign";
+
 let server;
+let originalDevops;
 
 before(async () => {
+  // The devops tests below overwrite the shipped configuration, so snapshot it
+  // and restore it in `after` - a failing run must not leave the checkout dirty.
+  originalDevops = fs.readFileSync(devopsConfigPath, "utf8");
   // Configure the real instance with the trusted origin shipped in tests.
   server = await startServer({ CORS_ALLOWED_ORIGINS: allowedOrigin });
 });
@@ -42,6 +53,11 @@ after(async () => {
   // them so a failing run never leaves the checkout dirty.
   for (const name of escapeNames) {
     escapeArtifacts(name).forEach(removeIfPresent);
+  }
+  escapedCampaignLogs("pwned-campaign").forEach(removeIfPresent);
+  // Guarded: if the snapshot itself failed, restoring would mask the real error.
+  if (originalDevops !== undefined) {
+    fs.writeFileSync(devopsConfigPath, originalDevops);
   }
 });
 
@@ -58,6 +74,9 @@ test("suite drives a real running instance over HTTP", async () => {
   );
   const api = await request(server.baseUrl, "GET", "/api/models/");
   assert.equal(api.status, 200, "API must be reachable over HTTP");
+  // Assert the response parsed before reading through it, so a non-JSON body
+  // reports the real failure instead of a TypeError.
+  assert.ok(api.body, `API must answer with JSON, got: ${api.raw}`);
   assert.equal(api.body.error, null);
 });
 
@@ -194,6 +213,174 @@ test("path containment: data-recorders start rejects a hostile dataRecorderFileN
     "hostile recorder dataRecorderFileName must be rejected"
   );
   assert.ok(fs.existsSync(repoPackageJson));
+});
+
+// ---------------------------------------------------------------------------
+// Issue #55 - the remaining name-derived paths (devops, test-cases).
+//
+// Both sinks sit behind the database connector, and the containment guards run
+// ahead of it on purpose: a rejection must not depend on a reachable database.
+// Every assertion below therefore returns immediately, and a regression that
+// moves a guard back behind the connector shows up as a non-400 response.
+// ---------------------------------------------------------------------------
+
+test("path containment: devops POST rejects a hostile testCampaignId and persists nothing", async () => {
+  const before = fs.readFileSync(devopsConfigPath, "utf8");
+  const hostile = [hostileCampaignId, "../../pwned-campaign", "a/b", "..", "."];
+  for (const testCampaignId of hostile) {
+    const res = await request(server.baseUrl, "POST", "/api/devops", {
+      body: {
+        devops: { webhookURL: "http://localhost:3333/webhook", testCampaignId },
+      },
+    });
+    assert.equal(
+      res.status,
+      400,
+      `expected 400 for testCampaignId ${JSON.stringify(testCampaignId)}, got ${res.status} (${res.raw})`
+    );
+    assert.ok(!res.raw.includes("/home/"), `must not leak server paths: ${res.raw}`);
+    assert.ok(!res.raw.includes("workspace"), `must not leak server paths: ${res.raw}`);
+  }
+  assert.equal(
+    fs.readFileSync(devopsConfigPath, "utf8"),
+    before,
+    "a rejected configuration must never reach devops.json"
+  );
+});
+
+test("path containment: a persisted hostile testCampaignId is rejected on read-back and writes no log", async () => {
+  // An unvalidated build could already have written a hostile id, so the read
+  // side is a distinct gate. A dedicated instance is used because the running
+  // server caches the configuration it has already loaded.
+  fs.writeFileSync(
+    devopsConfigPath,
+    JSON.stringify({
+      webhookURL: "http://localhost:3333/webhook",
+      testCampaignId: hostileCampaignId,
+    })
+  );
+  const poisoned = await startServer({ CORS_ALLOWED_ORIGINS: allowedOrigin });
+  try {
+    const res = await request(poisoned.baseUrl, "GET", "/api/devops/start");
+    assert.equal(
+      res.status,
+      400,
+      `a persisted hostile id must be rejected (${res.raw})`
+    );
+    assert.ok(!res.raw.includes("/home/"), `must not leak server paths: ${res.raw}`);
+    assert.ok(!res.raw.includes("workspace"), `must not leak server paths: ${res.raw}`);
+    assert.deepEqual(
+      escapedCampaignLogs("pwned-campaign"),
+      [],
+      "no log file may be created outside the test-campaign log root"
+    );
+  } finally {
+    await poisoned.stop();
+    fs.writeFileSync(devopsConfigPath, originalDevops);
+  }
+});
+
+test("path containment: test-cases POST rejects a hostile modelFileName", async () => {
+  const hostile = [
+    "../../../package.json",
+    "../package.json",
+    "/etc/passwd",
+    "a/../../../package.json",
+  ];
+  for (const modelFileName of hostile) {
+    const res = await request(server.baseUrl, "POST", "/api/test-cases", {
+      body: { testCase: { id: unique("tc"), name: "tc", modelFileName } },
+    });
+    assert.equal(
+      res.status,
+      400,
+      `expected 400 for modelFileName ${JSON.stringify(modelFileName)}, got ${res.status} (${res.raw})`
+    );
+    assert.ok(!res.raw.includes("/home/"), `must not leak server paths: ${res.raw}`);
+    assert.ok(!res.raw.includes("workspace"), `must not leak server paths: ${res.raw}`);
+  }
+  assert.ok(fs.existsSync(repoPackageJson), "canary must be untouched");
+});
+
+test("path containment: test-cases POST /:id rejects a hostile modelFileName", async () => {
+  const res = await request(server.baseUrl, "POST", "/api/test-cases/any-id", {
+    body: { testCase: { modelFileName: "../../../package.json" } },
+  });
+  assert.equal(
+    res.status,
+    400,
+    `the update path must not be a way around the create-time check (${res.raw})`
+  );
+  assert.ok(fs.existsSync(repoPackageJson));
+});
+
+test("legitimate devops starts and test-case creations pass containment", async () => {
+  // Containment is the only thing this change can break on the happy path, so
+  // that is what is asserted: a legitimate request must not be rejected. The
+  // requests are issued together because neither route can answer without a
+  // database, and the suite does not provision one - apart, each would wait
+  // out the full connect timeout in turn.
+  const withModel = unique("tc");
+  const withoutModel = unique("tc");
+  const [start, create, noModel] = await Promise.all([
+    request(server.baseUrl, "GET", "/api/devops/start"),
+    request(server.baseUrl, "POST", "/api/test-cases", {
+      body: {
+        testCase: {
+          id: withModel,
+          name: "legitimate test case",
+          modelFileName: "202402-Temperature-Controller.json",
+        },
+      },
+    }),
+    request(server.baseUrl, "POST", "/api/test-cases", {
+      body: {
+        testCase: { id: withoutModel, name: "no model selected", modelFileName: null },
+      },
+    }),
+  ]);
+  try {
+    assert.notEqual(
+      start.status,
+      400,
+      `the shipped devops configuration must not be rejected (${start.raw})`
+    );
+    assert.notEqual(
+      create.status,
+      400,
+      `a legitimate modelFileName must not be rejected (${create.raw})`
+    );
+    assert.notEqual(
+      noModel.status,
+      400,
+      `an absent modelFileName is not hostile (${noModel.raw})`
+    );
+    // When a database *is* reachable the containment gate let a real write
+    // through, which is the point - assert the stored path is the contained
+    // one rather than the raw name.
+    if (create.body && create.body.testCase) {
+      assert.ok(
+        create.body.testCase.modelFileName.endsWith(
+          "/data/models/202402-Temperature-Controller.json"
+        ),
+        `expected a contained model path, got ${create.body.testCase.modelFileName}`
+      );
+    }
+  } finally {
+    // Only reachable when a database answered, so this costs nothing in CI.
+    // Without one the requests above created nothing to clean up.
+    if (start.body && start.body.runningStatus) {
+      await request(server.baseUrl, "GET", "/api/devops/stop");
+      removeIfPresent(
+        path.join(campaignLogsDir, start.body.runningStatus.logFile)
+      );
+    }
+    for (const [res, id] of [[create, withModel], [noModel, withoutModel]]) {
+      if (res.body && res.body.testCase) {
+        await request(server.baseUrl, "DELETE", `/api/test-cases/${id}`);
+      }
+    }
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/test/routes-security.test.js
+++ b/test/routes-security.test.js
@@ -9,26 +9,38 @@ const modelRouter = require("../src/server/routes/model");
 const dataRecorderRouter = require("../src/server/routes/data-recorders");
 const simulationRouter = require("../src/server/routes/simulation");
 const createLogRouter = require("../src/server/routes/logs");
+const devopsRouter = require("../src/server/routes/devops");
+const testCasesRouter = require("../src/server/routes/test-cases");
 
 const modelsDir = path.resolve(__dirname, "../src/server/data/models");
 const dataRecordersDir = path.resolve(__dirname, "../src/server/data/data-recorders");
 const repoPackageJson = path.resolve(__dirname, "../package.json");
+const devopsFile = path.resolve(__dirname, "../src/server/data/devops.json");
+const srcDir = path.resolve(__dirname, "../src");
 
 let server;
 let app;
+let originalDevops;
 
 before(() => {
+  // These tests exercise the write path of POST /api/devops, which overwrites
+  // the shipped configuration. Snapshot it so the checkout is left unchanged.
+  originalDevops = fs.readFileSync(devopsFile, "utf8");
   app = express();
   app.use(express.json());
   app.use("/api/models", modelRouter);
   app.use("/api/data-recorders", dataRecorderRouter);
   app.use("/api/simulation", simulationRouter);
   app.use("/api/logs/simulations", createLogRouter("simulations"));
+  app.use("/api/devops", devopsRouter);
+  app.use("/api/test-cases", testCasesRouter);
   server = app.listen(0);
 });
 
 after(() => {
   server.close();
+  // Guarded: if the snapshot itself failed, restoring would mask the real error.
+  if (originalDevops !== undefined) fs.writeFileSync(devopsFile, originalDevops);
 });
 
 const unique = (prefix) => `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
@@ -264,4 +276,156 @@ test("simulation start rejects a hostile topology name in the body", async () =>
     model: { name: "../../pwned", devices: [] },
   });
   assert.equal(res.status, 400);
+});
+
+// ---------------------------------------------------------------------------
+// Issue #55 — the remaining name-derived paths (devops, test-cases)
+//
+// Both sinks sit behind `dbConnector`. The containment guards deliberately run
+// *ahead* of it, so every rejection below returns without a database round
+// trip — that is what makes them assertable here with no MongoDB running.
+// ---------------------------------------------------------------------------
+
+/** Names that must never be usable to derive a filesystem path. */
+const hostileNames = [
+  "../../pwned",
+  "../../../../etc/passwd",
+  "..%2F..%2Fpwned",
+  "a/b",
+  "a\\b",
+  "..",
+  ".",
+  "x".repeat(200),
+];
+
+test("devops POST rejects a hostile testCampaignId and persists nothing", async () => {
+  for (const testCampaignId of hostileNames) {
+    const res = await request(server, "POST", "/api/devops", {
+      devops: { webhookURL: "http://localhost:3333/webhook", testCampaignId },
+    });
+    assert.equal(
+      res.status,
+      400,
+      `expected 400 for testCampaignId ${JSON.stringify(testCampaignId)}, got ${res.status} (${res.raw})`
+    );
+    assert.ok(!res.raw.includes("/home/"), `must not leak server paths: ${res.raw}`);
+    assert.ok(!res.raw.includes("workspace"), `must not leak server paths: ${res.raw}`);
+  }
+  assert.equal(
+    fs.readFileSync(devopsFile, "utf8"),
+    originalDevops,
+    "a rejected configuration must never be written to disk"
+  );
+});
+
+test("devops POST rejects a non-string testCampaignId", async () => {
+  for (const testCampaignId of [42, { $ne: null }, ["a"], true]) {
+    const res = await request(server, "POST", "/api/devops", {
+      devops: { testCampaignId },
+    });
+    assert.equal(
+      res.status,
+      400,
+      `expected 400 for testCampaignId ${JSON.stringify(testCampaignId)}`
+    );
+  }
+  assert.equal(fs.readFileSync(devopsFile, "utf8"), originalDevops);
+});
+
+test("devops POST accepts a legitimate configuration unchanged", async () => {
+  const devops = JSON.parse(originalDevops);
+  const res = await request(server, "POST", "/api/devops", { devops });
+  assert.equal(res.status, 200, `legitimate configuration must be saved (${res.raw})`);
+  assert.equal(res.body.devops.testCampaignId, devops.testCampaignId);
+  assert.deepEqual(JSON.parse(fs.readFileSync(devopsFile, "utf8")), devops);
+});
+
+test("devops POST accepts a configuration with no testCampaignId", async () => {
+  const res = await request(server, "POST", "/api/devops", {
+    devops: { webhookURL: "http://localhost:3333/webhook" },
+  });
+  assert.equal(res.status, 200, `an absent id is not hostile (${res.raw})`);
+  // Restore the shipped configuration for the tests that follow.
+  await request(server, "POST", "/api/devops", { devops: JSON.parse(originalDevops) });
+});
+
+test("devops GET /start rejects a hostile testCampaignId already on disk", async () => {
+  const hostileId = "../../../pwned";
+  fs.writeFileSync(
+    devopsFile,
+    JSON.stringify({ webhookURL: "http://localhost:3333/webhook", testCampaignId: hostileId })
+  );
+  // A configuration written by an older build is only seen by a process that
+  // has not cached one yet, so this needs a router with a cold config cache.
+  const modulePath = require.resolve("../src/server/routes/devops");
+  delete require.cache[modulePath];
+  const coldApp = express();
+  coldApp.use(express.json());
+  coldApp.use("/api/devops", require(modulePath));
+  const coldServer = coldApp.listen(0);
+  try {
+    const res = await request(coldServer, "GET", "/api/devops/start");
+    assert.equal(res.status, 400, `persisted hostile id must be rejected (${res.raw})`);
+    assert.ok(!res.raw.includes("/home/"), `must not leak server paths: ${res.raw}`);
+    assert.ok(!res.raw.includes("workspace"), `must not leak server paths: ${res.raw}`);
+    // `../../../` from src/server/logs/test-campaigns/ lands in src/, and the
+    // logger creates missing parent directories, so this is a real write.
+    assert.deepEqual(
+      fs.readdirSync(srcDir).filter((f) => f.startsWith("pwned")),
+      [],
+      "no log file may be written outside the test-campaign log root"
+    );
+  } finally {
+    coldServer.close();
+    fs.writeFileSync(devopsFile, originalDevops);
+    delete require.cache[modulePath];
+  }
+});
+
+test("test-cases POST rejects a hostile modelFileName and never reaches the database", async () => {
+  const hostile = [
+    "../../../package.json",
+    "../package.json",
+    "/etc/passwd",
+    "a/../../../package.json",
+    "..%2Fpackage.json",
+  ];
+  for (const modelFileName of hostile) {
+    const res = await request(server, "POST", "/api/test-cases", {
+      testCase: { id: unique("tc"), name: "tc", modelFileName },
+    });
+    assert.equal(
+      res.status,
+      400,
+      `expected 400 for modelFileName ${JSON.stringify(modelFileName)}, got ${res.status} (${res.raw})`
+    );
+    assert.ok(!res.raw.includes("/home/"), `must not leak server paths: ${res.raw}`);
+    assert.ok(!res.raw.includes("workspace"), `must not leak server paths: ${res.raw}`);
+  }
+  assert.ok(fs.existsSync(repoPackageJson), "canary must be untouched");
+});
+
+test("test-cases POST /:testCaseId rejects a hostile modelFileName", async () => {
+  const res = await request(server, "POST", "/api/test-cases/any-id", {
+    testCase: { modelFileName: "../../../package.json" },
+  });
+  assert.equal(
+    res.status,
+    400,
+    `the update path must not be a way around the create-time check (${res.raw})`
+  );
+  assert.ok(fs.existsSync(repoPackageJson));
+});
+
+test("test-cases POST rejects a non-string modelFileName", async () => {
+  for (const modelFileName of [42, { $ne: null }, ["../../x"]]) {
+    const res = await request(server, "POST", "/api/test-cases", {
+      testCase: { id: unique("tc"), modelFileName },
+    });
+    assert.equal(
+      res.status,
+      400,
+      `expected 400 for modelFileName ${JSON.stringify(modelFileName)}`
+    );
+  }
 });

--- a/test/routes-security.test.js
+++ b/test/routes-security.test.js
@@ -417,6 +417,36 @@ test("test-cases POST /:testCaseId rejects a hostile modelFileName", async () =>
   assert.ok(fs.existsSync(repoPackageJson));
 });
 
+test("test-cases POST /:testCaseId rejects a MongoDB update operator", async () => {
+  // Without this the containment is bypassable in one request: an operator
+  // document carries no own `modelFileName` key, so a check that only looks at
+  // plain fields waves it through and mongoose casts it to the database intact.
+  const hostile = [
+    { $set: { modelFileName: "/etc/passwd" } },
+    { $set: { modelFileName: "../../../package.json" } },
+    { $setOnInsert: { modelFileName: "/etc/passwd" } },
+    { $unset: { modelFileName: "" } },
+  ];
+  for (const testCase of hostile) {
+    const res = await request(server, "POST", "/api/test-cases/any-id", { testCase });
+    assert.equal(
+      res.status,
+      400,
+      `expected 400 for ${JSON.stringify(testCase)}, got ${res.status} (${res.raw})`
+    );
+    assert.ok(!res.raw.includes("/home/"), `must not leak server paths: ${res.raw}`);
+    assert.ok(!res.raw.includes("workspace"), `must not leak server paths: ${res.raw}`);
+  }
+  assert.ok(fs.existsSync(repoPackageJson), "canary must be untouched");
+});
+
+test("test-cases POST rejects a MongoDB update operator", async () => {
+  const res = await request(server, "POST", "/api/test-cases", {
+    testCase: { $set: { modelFileName: "/etc/passwd" } },
+  });
+  assert.equal(res.status, 400, `expected 400, got ${res.status} (${res.raw})`);
+});
+
 test("test-cases POST rejects a non-string modelFileName", async () => {
   for (const modelFileName of [42, { $ne: null }, ["../../x"]]) {
     const res = await request(server, "POST", "/api/test-cases", {
@@ -427,5 +457,64 @@ test("test-cases POST rejects a non-string modelFileName", async () => {
       400,
       `expected 400 for modelFileName ${JSON.stringify(modelFileName)}`
     );
+  }
+});
+
+// The rejection tests above all return before `dbConnector`, but the value the
+// guard *stores* on the way through only reaches an assertion when a database
+// answers - which CI has none of. Exercise the middleware on its own so a guard
+// that contained the wrong path cannot pass unnoticed. It is taken off the
+// router's own stack rather than re-exported, so the test binds to the exact
+// function the create and update routes run.
+const containModelFileName = testCasesRouter.stack.find(
+  (layer) => layer.route && layer.route.path === "/" && layer.route.methods.post
+).route.stack[0].handle;
+
+test("test-cases containment stores the resolved path inside the models directory", async () => {
+  const guardApp = express();
+  guardApp.use(express.json());
+  guardApp.post("/contain", containModelFileName, (req, res) => {
+    // `undefined` is JSON-dropped, so report the raw state explicitly.
+    res.send({
+      contained: req.containedModelFileName === undefined
+        ? "undefined"
+        : req.containedModelFileName,
+    });
+  });
+  const guardServer = guardApp.listen(0);
+  try {
+    const legitimate = await request(guardServer, "POST", "/contain", {
+      testCase: { modelFileName: "202402-Temperature-Controller.json" },
+    });
+    assert.equal(legitimate.status, 200, legitimate.raw);
+    assert.equal(
+      legitimate.body.contained,
+      inModelsDir("202402-Temperature-Controller.json"),
+      "a legitimate name must be stored as its resolved path in the models directory"
+    );
+
+    // An explicitly empty name is a caller asking for "no model", which is
+    // stored as null rather than a path to a file that cannot exist.
+    for (const modelFileName of [null, ""]) {
+      const res = await request(guardServer, "POST", "/contain", {
+        testCase: { modelFileName },
+      });
+      assert.equal(res.status, 200, res.raw);
+      assert.equal(
+        res.body.contained,
+        null,
+        `expected null for modelFileName ${JSON.stringify(modelFileName)}`
+      );
+    }
+
+    // A payload that carries no modelFileName at all leaves the value unset,
+    // which is what tells the update route to leave the stored one alone.
+    const absent = await request(guardServer, "POST", "/contain", {
+      testCase: { name: "no model field" },
+    });
+    assert.equal(absent.status, 200, absent.raw);
+    assert.equal(absent.body.contained, "undefined");
+  } finally {
+    guardServer.close();
   }
 });

--- a/test/routes-security.test.js
+++ b/test/routes-security.test.js
@@ -382,6 +382,38 @@ test("devops GET /start rejects a hostile testCampaignId already on disk", async
   }
 });
 
+test("devops GET does not disclose the config path when it cannot be read", async () => {
+  // A Node fs error carries the absolute path of the file it failed to open in
+  // its own enumerable properties, so echoing it back leaks the server layout.
+  // Reaching that branch needs both an unreadable file and a router that has
+  // not cached a configuration yet, hence the same cold-cache router as above.
+  // The file is put back in `finally`, and the suite-wide `after` hook restores
+  // it again from the same snapshot, so a mid-test failure cannot cost the
+  // checkout its devops.json.
+  fs.unlinkSync(devopsFile);
+  const modulePath = require.resolve("../src/server/routes/devops");
+  delete require.cache[modulePath];
+  const coldApp = express();
+  coldApp.use(express.json());
+  coldApp.use("/api/devops", require(modulePath));
+  const coldServer = coldApp.listen(0);
+  try {
+    const res = await request(coldServer, "GET", "/api/devops");
+    assert.equal(
+      res.body.error,
+      "Cannot get devops configuration",
+      `an unreadable configuration must report a constant message (${res.raw})`
+    );
+    assert.ok(!res.raw.includes("/home/"), `must not leak server paths: ${res.raw}`);
+    assert.ok(!res.raw.includes("workspace"), `must not leak server paths: ${res.raw}`);
+    assert.ok(!res.raw.includes("devops.json"), `must not leak the config path: ${res.raw}`);
+  } finally {
+    coldServer.close();
+    fs.writeFileSync(devopsFile, originalDevops);
+    delete require.cache[modulePath];
+  }
+});
+
 test("test-cases POST rejects a hostile modelFileName and never reaches the database", async () => {
   const hostile = [
     "../../../package.json",


### PR DESCRIPTION
## Summary

Issue #1 contained the four route families it named, and PR #50 gave them a shared `src/server/routes/path-safety.js` helper. Two routers were out of that scope and still derive a filesystem path from request data without it. This closes both, using the same helper, and extends the #8 E2E gate to cover them.

## Approach

Both sinks sit **behind `dbConnector`**. Measured against a running instance with no MongoDB reachable, a DB-touching request takes exactly 30s and returns `{"error":"Failed to get database client!"}` — so a containment check placed inside the handler is never reached, the check is inert on any DB-less deployment, and the E2E gate cannot assert it. Both guards therefore run **ahead of `dbConnector`**, which is also the better order: reject bad input before doing work.

**`devops.js`** — `testCampaignId` is validated with `isValidName` when `POST /api/devops` writes it, so a hostile value is never persisted, and again when `GET /api/devops/start` reads it back, because a configuration written by an older build can already hold one. The derived log filename is then passed through `resolveWithin` before the logger opens it.

**`test-cases.js`** — `modelFileName` is resolved with `resolveWithin` and contained before it reaches the database. Applied to **create and update**: the issue names only the create sink (`test-cases.js:67`), but `POST /:testCaseId` writes the body straight through `findOneAndUpdate`, so guarding create alone leaves the check bypassable in one extra request. A `$`-prefixed key in the body makes it a MongoDB update document rather than a plain set of fields, which carries no own `modelFileName` key and so slips past a field-level check — those are rejected outright.

## Decision Record

**Root cause.** Issue #1 contained filesystem access in the four route families it named, and PR #50 gave them a shared `src/server/routes/path-safety.js` helper. `devops.js` and `test-cases.js` were never in that scope, so both still derived a filesystem path from request-supplied data with no containment check: `devops.js` interpolated a persisted `testCampaignId` into a log filename that winston opens (and whose parent directories it creates), and `test-cases.js` persisted `${modelsPath}/${modelFileName}` straight from the request body.

**Reproduction (red → green).** `npm test` — against the vulnerable code the new unit tests and the new E2E containment tests fail; with the fix all pass. The unfixed runs take 30s each, which is itself the evidence that they fall through to `dbConnector` and never reach a containment decision. End to end against a live instance with a real MongoDB: `GET /api/devops/start` with the persisted id `../../../PWNED-PROOF` returned `200` and wrote `src/PWNED-PROOF_<ts>.log` outside the log root; after the fix the same request returns `400 {"error":"Invalid test campaign id"}` and writes nothing. Each guard was mutation-tested individually — removing `containModelFileName` fails 6 tests, removing the devops write check fails 2, removing the read-back check fails 1, removing the error-message constant fails 1.

**Options considered.**

1. Guard inside each handler, after `dbConnector`.
2. Guard ahead of `dbConnector` in dedicated middleware, reusing `path-safety.js`.
3. Validate the devops configuration only where it is read back.
4. Guard only the create sink in `test-cases.js`, as the issue literally scopes it.
5. Reject requests that carry no `modelFileName`.
6. Store the bare filename rather than the resolved absolute path.

**Options rejected.**

- (1) A DB-touching request on an instance with no MongoDB takes exactly 30s and returns `{"error":"Failed to get database client!"}`, so a check behind `dbConnector` is never reached — inert on any DB-less deployment and invisible to the E2E gate, which AC 6 requires it to be visible to.
- (3) A hostile value already sitting in `devops.json` from an unvalidated build would stay live, and any other consumer of the file would still read it.
- (4) `POST /:testCaseId` writes the body through `findOneAndUpdate`, so guarding create alone leaves containment bypassable in one extra request.
- (5) Would break legitimate creations, which AC 7 forbids.
- (6) Silently changes the persisted contract — the dashboard reads the stored value and posts it back, a round-trip verified against a live DB.

**Selected option.** (2), applied symmetrically to both routers. Both guards run ahead of `dbConnector`, so the containment decision never depends on a reachable database and is assertable by the E2E gate; `devops` is validated on **both** write and read-back; `test-cases` is guarded on **create and update**, and rejects operator documents that would otherwise carry a path around the field-level check; an absent `modelFileName` is stored as `null` rather than the literal path `.../models/undefined`; the stored value stays an absolute path; error responses carry constant messages so no fs error serialises a server path into the body.

**Residual risk.**

- `modelFileName` still has no server-side dereferencer, so containment here protects a latent sink — a future consumer that opens the stored path inherits the guarantee rather than having to re-derive it.
- The E2E fixtures still write into the real storage root (note (b) below, deferred): making that root configurable touches every router and changes deployment behaviour, which does not belong in a P1 security fix. The one fixture this PR owns (`devops.json`) is snapshot and restored with a guarded `finally` plus an `after()` safety net, and a full run leaves the checkout clean.
- Broader request validation — MongoDB operator injection beyond `modelFileName`, and unauthenticated access — remains tracked by #10 and #9. This PR rejects `$`-prefixed keys in the test-case body because they defeat *this* containment check; it is not a general operator-injection fix.
- The `src/core/utils` hardening below is **outside issue #55's acceptance criteria** — it was found while reviewing this PR and folded in at the maintainer's request to reach a clean state before the next phase, rather than deferred to its own issue. It is behaviour-preserving for every existing caller (audit below), but it is scope beyond what AC 1-7 verify.

| Decision | Why | Alternative rejected |
|---|---|---|
| Guards run before `dbConnector` | A containment decision must not depend on a reachable database; it also makes the E2E gate able to see the check | Guard inside the handler — inert without a DB, and untestable (AC 6) |
| `devops` validated on **both** write and read-back | A hostile value already sitting in `devops.json` from an unvalidated build must still be rejected | Write-only — leaves existing hostile configs live |
| `test-cases` update guarded too, beyond the issue's literal scope | Otherwise create-time containment is bypassable in one extra request | Create-only, as literally scoped — leaves the sink open |
| `$`-prefixed keys in the test-case body rejected | An operator document carries no own `modelFileName` key, so a field-level check waves it through and mongoose casts it to the database intact | Field-level check alone — bypassable with `{"$set":{"modelFileName":"…"}}` |
| Absent `modelFileName` stored as `null` | Previously stored the literal path `.../models/undefined`; `null` is the honest value and the request still succeeds | Reject — would break legitimate creations (AC 7) |
| Stored value stays an absolute path | Preserves the client round-trip (dashboard reads the stored value and posts it back); verified against a live DB | Store the bare filename — silently changes the persisted contract |
| Error responses carry constant messages | A raw Node fs error serialises its own `path` property, disclosing the absolute path of `devops.json` | Echoing the error object — leaks server paths (AC 5) |
| Note (b) (temporary storage root) deferred | Requires making the storage root configurable across every router — a real refactor with deployment impact, unlike the other two notes | Bundling it here — would widen a P1 security fix |

## Changes

| File | Change |
|---|---|
| `src/server/routes/devops.js` | Validate `testCampaignId` on write; `loadValidatedDevops` middleware validates on read-back ahead of `dbConnector`; resolve the log path before `getLogger`; both error paths answer with a constant message instead of the raw fs error |
| `src/server/routes/test-cases.js` | `containModelFileName` middleware resolves and contains `modelFileName` ahead of `dbConnector`, on create and update, and rejects `$`-prefixed operator keys |
| `src/core/utils/index.js` | `readJSONFile` routes a `JSON.parse` failure to the callback instead of throwing out of the async callback; `writeToFile`'s empty `catch` calls the callback instead of swallowing the error |
| `test/routes-security.test.js` | 12 unit tests for both routers (issue #55 section) |
| `test/core-utils.test.js` | 6 unit tests covering both `core/utils` failure modes |
| `test/e2e/security-suite.test.js` | 5 E2E tests over HTTP; JSON-parse guard before reading `api.body.error` (note c) |
| `test/e2e/helpers.js` | `devopsConfigPath`, `campaignLogsDir`, `escapedCampaignLogs()` canary |
| `package.json` | `npm test` runs with `--test-concurrency=1`, matching the CI gate (note a) |
| `.github/workflows/e2e-security.yml` | The http-suite job runs `npm test` instead of naming two e2e files, so the unit-level regression guards can actually fail a PR |
| `README.md` | Document the serialised local run and its duration |

## Test Results

`npm test` — **104 passed, 1 skipped** (container check, no `TAS_IMAGE`), 0 failed, 32.6s. CI reports the same 105/104/1/0 now that the gate runs the full suite.

The red → green reproduction and the per-guard mutation testing are recorded under **Reproduction** in the Decision Record above.

**The escape is real, not latent.** winston 3.2.1 calls `fs.mkdirSync(dirPath, {recursive: true})` (`node_modules/winston/lib/winston/transports/file.js:694`), so a traversal id creates directories and a file outside the log root. Verified against a live instance with a real MongoDB:

| | Vulnerable | Fixed |
|---|---|---|
| `GET /api/devops/start`, persisted id `../../../PWNED-PROOF` | `200`, wrote `src/PWNED-PROOF_<ts>.log` | `400 {"error":"Invalid test campaign id"}`, nothing written |
| Same, shipped legitimate config | starts campaign | starts campaign, log inside `src/server/logs/test-campaigns/` |

Note this write primitive needs a reachable database, since `dbConnector` precedes the handler in the unfixed code; the persisted-path sink in `test-cases.js` has the same dependency.

**Legitimate flows, verified against a live MongoDB** — create stores the contained absolute path, read-back works, a hostile update is rejected with the stored value untouched, a legitimate update succeeds, and the client round-trip (posting the stored absolute path back) is accepted. The full E2E suite also passes with a DB present (19/19, 0.6s) and leaves no documents or log files behind.

## Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|---|---|---|
| 1 | `devops.js` validates `testCampaignId` and resolves the log path | ✅ | `isValidName` + `resolveWithin` in `loadValidatedDevops`/handler; `devops GET /start rejects a hostile testCampaignId already on disk`, E2E read-back test |
| 2 | Config validated when written by `POST /api/devops`, not only on read-back | ✅ | Guard before `writeToFile`; `devops POST rejects a hostile testCampaignId and persists nothing` asserts `devops.json` byte-identical |
| 3 | `test-cases.js` contains the `modelFileName` it derives and stores | ✅ | `containModelFileName` on create **and** update, including `$`-operator rejection; 6 unit + 2 E2E tests; `test-cases containment stores the resolved path inside the models directory` asserts the stored value without needing a DB; live DB shows the contained path stored |
| 4 | Both routers use the shared `path-safety.js` helper | ✅ | All six route modules now import it — the grep in the issue body returns 6 lines |
| 5 | Rejections return 400-class with no server paths disclosed | ✅ | `sendBadRequest` (400); every new test asserts the body contains neither `/home/` nor `workspace`; both `devops.js` error branches now answer with a constant message rather than the raw fs error, covered by `devops GET does not disclose the config path when it cannot be read` |
| 6 | E2E suite covers both route families and fails if either check is removed | ✅ | 5 tests in `test/e2e/security-suite.test.js`; with the guards reverted, 4 fail and the suite is red |
| 7 | Legitimate starts and creations continue to work unchanged | ✅ | `legitimate devops starts and test-case creations pass containment`; live-DB run confirms create/read/update/round-trip/delete all work; the client posts a flat `{ testCase }` object, so operator rejection does not affect it |

### Notes from the PR #54 review

- ✅ (a) `npm test` now uses `--test-concurrency=1`, matching `.github/workflows/e2e-security.yml`.
- ⚠️ (b) **Deferred** — a temporary storage root for the E2E fixtures. Unlike the other two, this needs the storage root made configurable across every router, changing deployment behaviour; it does not belong in a P1 security fix. This PR's own fixture (`devops.json`) is snapshot/restored with a guarded `finally` plus an `after()` safety net, and a full run leaves the checkout clean.
- ✅ (c) `security-suite.test.js` asserts the response parsed as JSON before reading `api.body.error`.

### Notes from the PR #57 review

- ✅ **MongoDB update-operator bypass.** The first pass gated on `"modelFileName" in testCase`, so `{"testCase":{"$set":{"modelFileName":"/etc/passwd"}}}` carried no own key, fell through to `next()`, and reached `findOneAndUpdate` intact — confirmed by casting that document against `TestCaseSchema`, which returns it unchanged because `modelFileName` is a schema path and strict mode does not strip it. `containModelFileName` now rejects `$`-prefixed top-level keys, covering create and update in one place.
- ✅ **Server path disclosure.** Both `devops.js` branches that echoed a raw fs error (`loadValidatedDevops` and `GET /api/devops`) now log server-side and answer with a constant message; a Node ENOENT error serialises `{"errno":-2,"code":"ENOENT","syscall":"open","path":"…/devops.json"}` through its own enumerable properties.
- ✅ **Positive containment was untested.** The only assertion that the *stored* value is the contained path sat behind `if (create.body && create.body.testCase)`, unreachable without a database, so CI verified rejections but never that the guard stored the right thing. A DB-free unit test now takes the middleware off the router stack and asserts the resolved path, the `null` case, and the `undefined` case.
- ✅ **`core/utils` error handling** (beyond #55's acceptance criteria — see Residual risk). Surfaced while building the fixture for the test above. `readJSONFile` wrapped `fs.readFile` in `try/catch`, but `JSON.parse` ran inside the async callback on a later tick, so a malformed JSON file threw uncaught and took the process down instead of reaching the `callback(error)` branch the function was written for; a malformed `models/*.json` now produces the caller's existing "Cannot read the model file" response. `writeToFile`'s `catch` was empty and never invoked the callback, so a synchronous `fs.writeFile` throw left the originating request hanging until the client gave up. Both now route to the callback like every other function in the file.

  **Caller audit.** All 13 `readJSONFile` call sites and all 11 `writeToFile` call sites already open their callback with `if (err)` and route it somewhere sensible, so neither change hands any caller an error path it does not already handle: `db-connector.js:88` falls back to writing a default data-storage config and `:100`/`:117` propagate; `model.js:49,69`, `data-recorders.js:165,207,303` and `simulation.js:137` log and reply with a constant error string; `TestCase.js:46` calls back a constant message; and the `process.argv[3]` entrypoints in `devops-flow`, `actuated-data`, `simulation`, `data-recorder`, `data-generators` and `gateways` each log and skip startup. `readJSONFileSync`'s no-op `catch (error) { throw error; }` was deliberately left alone as cosmetic.

- ✅ **The unit suites were not gated.** Found while confirming the change above. CI ran only `test/e2e/security-suite.test.js` and `test/e2e/limits.test.js`, so twelve files in `test/` — including `routes-security.test.js` and the new `core-utils.test.js` — executed in no workflow at all, and every unit-level guard on this branch was unable to fail a PR. The http-suite job now runs `npm test`, which is the same `--test-concurrency=1` serialisation and a superset of the files; `test/e2e/container-nonroot.test.js` is inside the glob but skips its runtime half, which is guarded on `TAS_IMAGE` that only the container job sets. Validated from a clean clone (`git clone` to a temp dir, `npm ci`, `npm test`) before committing: 104 passed, 1 skipped, 0 failed, identical to the working checkout, so none of the twelve depends on local state. CI now reports the same counts.

  One cosmetic consequence, no assertion affected: the widened suite is noisier on CI stderr, because `routes-security.test.js` deliberately forces an `ENOENT` on `devops.json` and the server logs that error object. That log line contains an absolute path, but it is server-side console output, not the HTTP response — the test asserts the response body itself discloses nothing.

  The regression tests trigger the synchronous throw for real rather than by stubbing — `fs.writeFile` validates arguments synchronously, so a NUL byte in the path throws `ERR_INVALID_ARG_VALUE` and a non-string `data` throws `ERR_INVALID_ARG_TYPE`. Every callback assertion goes through a 5s timeout helper, so "never called back" fails as an assertion instead of hanging the suite — which is what makes the pre-fix behaviour legible. Reverting only `src/core/utils/index.js` fails 3 of the 6 new tests.

Closes #55
