### PR TITLE
fix(server): return correct HTTP status codes and stop leaking errors (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ one without parsing the body.
 | ------ | -------------------------------------------------------------------------- |
 | `2xx`  | The request was served.                                                    |
 | `400`  | The request was malformed — a field of the wrong type, a name that cannot derive a safe file path, a document the database refused. |
+| `403`  | The request came from an origin that is not in `CORS_ALLOWED_ORIGINS`.     |
 | `404`  | The addressed model, data recorder, log, data set, event, report, test case, test campaign or API path does not exist. |
 | `409`  | The request conflicts with the current state — starting a simulation or a data recorder that is already running. |
 | `413`  | The body is larger than `BODY_LIMIT`.                                      |
+| `415`  | The request carries a content encoding the server cannot read.             |
 | `429`  | The client is over `RATE_LIMIT_MAX` for the current window.                |
 | `5xx`  | The server failed (`500`), or a dependency such as the database is not reachable (`503`). |
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,35 @@ A MongoDB Server can be set up easily with docker:
 docker run --name mongo-server -d -p 27017:27017 mongo
 ```
 
+## API responses
+
+Every endpoint answers with the HTTP status code that describes the outcome, so
+a client, a reverse proxy or a monitor can tell a served request from a failed
+one without parsing the body.
+
+| Status | When                                                                       |
+| ------ | -------------------------------------------------------------------------- |
+| `2xx`  | The request was served.                                                    |
+| `400`  | The request was malformed — a field of the wrong type, a name that cannot derive a safe file path, a document the database refused. |
+| `404`  | The addressed model, data recorder, log, data set, event, report, test case, test campaign or API path does not exist. |
+| `409`  | The request conflicts with the current state — starting a simulation or a data recorder that is already running. |
+| `413`  | The body is larger than `BODY_LIMIT`.                                      |
+| `429`  | The client is over `RATE_LIMIT_MAX` for the current window.                |
+| `5xx`  | The server failed (`500`), or a dependency such as the database is not reachable (`503`). |
+
+Every failure carries the same JSON body, produced by one central handler
+(`src/server/middleware/errors.js`):
+
+```json
+{ "error": "Validation failed", "details": [{ "location": "body", "field": "model.name", "message": "\"model.name\" must be a string", "type": "string.base" }] }
+```
+
+`error` is a message chosen for the caller and safe to display; `details` is
+present only for a validation failure, where it names each refused field. A
+response body never carries a stack trace, a server filesystem path or the raw
+underlying error — that detail is written to the server log instead, where it
+stays available for diagnosis.
+
 ## DEVELOPMENT
 
 ### Run the E2E security regression suite

--- a/src/client/src/api/index.js
+++ b/src/client/src/api/index.js
@@ -2,14 +2,73 @@
 // export const URL = `http://localhost:31057`;
 export const URL = "";
 
+/**
+ * Build the message shown to the user from an error response.
+ *
+ * The API answers every failure with `{ error, details? }` (see
+ * `src/server/middleware/errors.js`). `details` is the per-field breakdown of a
+ * validation failure, and folding it into the message is what tells the user
+ * *which* field was refused rather than only that something was.
+ *
+ * Always returns a string: the notification component renders anything else
+ * with JSON.stringify, which turns an Error into the useless "{}".
+ *
+ * @param {Object|null} data The parsed response body, when there was one
+ * @param {Response} response The fetch response
+ * @returns {String}
+ */
+const errorMessage = (data, response) => {
+  const base =
+    data && typeof data.error === "string" && data.error
+      ? data.error
+      : `Request failed (HTTP ${response.status})`;
+  const details = data && Array.isArray(data.details) ? data.details : [];
+  if (details.length === 0) return base;
+  const named = details
+    .map((detail) =>
+      detail && typeof detail === "object"
+        ? detail.message || detail.field
+        : String(detail)
+    )
+    .filter(Boolean);
+  return named.length > 0 ? `${base}: ${named.join("; ")}` : base;
+};
+
+/**
+ * Read a response, honouring the HTTP status code.
+ *
+ * The server used to answer 200 for everything and signal failure only with an
+ * `error` field, so this layer could get away with looking at the body alone.
+ * It now answers 400/404/409/5xx (issue #11), which is the only thing that
+ * distinguishes a served request from a failed one when the body is empty or is
+ * not JSON at all - a proxy's error page, say.
+ *
+ * Failures are still thrown, and still thrown as a plain string, because that
+ * is what every saga's `catch` puts straight into a notification.
+ *
+ * @param {Response} response The fetch response
+ * @returns {Promise<Object>} The parsed body of a successful response
+ */
+const parseResponse = async (response) => {
+  let body = null;
+  try {
+    body = await response.json();
+  } catch (e) {
+    // A non-JSON body (an error page from a proxy, an empty response) must not
+    // surface as a raw SyntaxError.
+    body = null;
+  }
+  if (!response.ok || (body && body.error)) {
+    throw errorMessage(body, response);
+  }
+  return body === null ? {} : body;
+};
+
 // MODELS
 export const requestAllModels = async () => {
   const url = `${URL}/api/models`;
   const response = await fetch(url);
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.models;
 };
 
@@ -18,10 +77,7 @@ export const requestDeleteModel = async (modelFileName) => {
   const response = await fetch(url, {
     method: "DELETE",
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.result;
 };
 
@@ -36,20 +92,14 @@ export const requestDuplicateModel = async (modelFileName) => {
       isDuplicated: true,
     }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.modelFileName;
 };
 
 export const requestModel = async (modelFileName) => {
   const url = `${URL}/api/models/${modelFileName}`;
   const response = await fetch(url);
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.model;
 };
 
@@ -62,10 +112,7 @@ export const uploadModel = async (model) => {
     },
     body: JSON.stringify({ model }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.modelFileName;
 };
 
@@ -78,10 +125,7 @@ export const updateModel = async (modelFileName, model) => {
     },
     body: JSON.stringify({ model }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.modelFileName;
 };
 
@@ -89,10 +133,7 @@ export const updateModel = async (modelFileName, model) => {
 export const requestAllDataRecorders = async () => {
   const url = `${URL}/api/data-recorders/models`;
   const response = await fetch(url);
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.dataRecorders;
 };
 
@@ -101,10 +142,7 @@ export const requestDeleteDataRecorder = async (dataRecorderFileName) => {
   const response = await fetch(url, {
     method: "DELETE",
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.result;
 };
 
@@ -119,20 +157,14 @@ export const requestDuplicateDataRecorder = async (dataRecorderFileName) => {
       isDuplicated: true,
     }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.dataRecorderFileName;
 };
 
 export const requestDataRecorder = async (dataRecorderFileName) => {
   const url = `${URL}/api/data-recorders/models/${dataRecorderFileName}`;
   const response = await fetch(url);
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.dataRecorder;
 };
 
@@ -145,10 +177,7 @@ export const uploadDataRecorder = async (dataRecorder) => {
     },
     body: JSON.stringify({ dataRecorder }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.dataRecorderFileName;
 };
 
@@ -164,10 +193,7 @@ export const updateDataRecorder = async (
     },
     body: JSON.stringify({ dataRecorder }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.dataRecorderFileName;
 };
 
@@ -180,30 +206,21 @@ export const sendRequestStartDataRecorder = async (dataRecorderFileName) => {
     },
     body: JSON.stringify({ dataRecorderFileName }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.status;
 };
 
 export const sendRequestStopDataRecorder = async (fileName) => {
   const url = `${URL}/api/data-recorders/stop/${fileName}`;
   const response = await fetch(url);
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.status;
 };
 
 export const sendRequestDataRecorderStatus = async () => {
   const url = `${URL}/api/data-recorders/status`;
   const response = await fetch(url);
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.status;
 };
 
@@ -211,10 +228,7 @@ export const sendRequestDataRecorderStatus = async () => {
 export const sendRequestDataStorage = async () => {
   const url = `${URL}/api/data-storage`;
   const response = await fetch(url);
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.dataStorage;
 };
 
@@ -227,30 +241,21 @@ export const sendRequestUpdateDataStorage = async (dataStorage) => {
     },
     body: JSON.stringify({ dataStorage }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.dataStorage;
 };
 
 export const sendRequestTestDataStorageConnection = async (dataStorage) => {
   const url = `${URL}/api/data-storage/test`;
   const response = await fetch(url);
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.connectionStatus;
 };
 
 export const sendRequestLogFile = async (tool, logFile) => {
   const url = `${URL}/api/logs/${tool}/${logFile}`;
   const response = await fetch(url);
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.content;
 };
 
@@ -259,20 +264,14 @@ export const sendRequestDeleteLogFile = async (tool, logFile) => {
   const response = await fetch(url, {
     method: "DELETE",
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.result;
 };
 
 export const sendRequestAllLogFiles = async (tool) => {
   const url = `${URL}/api/logs/${tool}`;
   const response = await fetch(url);
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.files;
 };
 
@@ -285,30 +284,21 @@ export const requestStartDeploy = async (tool, model) => {
     },
     body: JSON.stringify({ model }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.simulationStatus;
 };
 
 export const sendRequestStopSimulation = async (fileName) => {
   const url = `${URL}/api/simulation/stop/${fileName}`;
   const response = await fetch(url);
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.simulationStatus;
 };
 
 export const sendRequestSimulationStatus = async () => {
   const url = `${URL}/api/simulation/status`;
   const response = await fetch(url);
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.simulationStatus;
 };
 
@@ -316,10 +306,7 @@ export const sendRequestSimulationStatus = async () => {
 export const sendRequestTestCampaign = async (tcId) => {
   const url = `${URL}/api/test-campaigns/${tcId}`;
   const response = await fetch(url);
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.testCampaign;
 };
 
@@ -332,20 +319,14 @@ export const sendRequestUpdateTestCampaign = async (id, testCampaign) => {
     },
     body: JSON.stringify({ testCampaign }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.testCampaign;
 };
 
 export const sendRequestAllTestCampaigns = async () => {
   const url = `${URL}/api/test-campaigns`;
   const response = await fetch(url);
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.testCampaigns;
 };
 
@@ -358,10 +339,7 @@ export const sendRequestAddNewTestCampaign = async (testCampaign) => {
     },
     body: JSON.stringify({ testCampaign }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.testCampaign;
 };
 
@@ -370,10 +348,7 @@ export const sendRequestDeleteTestCampaign = async (testCampaignId) => {
   const response = await fetch(url, {
     method: "DELETE",
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.result;
 };
 
@@ -381,10 +356,7 @@ export const sendRequestDeleteTestCampaign = async (testCampaignId) => {
 export const sendRequestDevops = async () => {
   const url = `${URL}/api/devops`;
   const response = await fetch(url);
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.devops;
 };
 
@@ -397,10 +369,7 @@ export const sendRequestUpdateDevops = async (devops) => {
     },
     body: JSON.stringify({ devops }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.devops;
 };
 
@@ -408,10 +377,7 @@ export const sendRequestUpdateDevops = async (devops) => {
 export const sendRequestTestCase = async (tcId) => {
   const url = `${URL}/api/test-cases/${tcId}`;
   const response = await fetch(url);
-  const status = await response.json();
-  if (status.error) {
-    throw status.error;
-  }
+  const status = await parseResponse(response);
   return status.testCase;
 };
 
@@ -424,20 +390,14 @@ export const sendRequestUpdateTestCase = async (id, testCase) => {
     },
     body: JSON.stringify({ testCase }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.testCase;
 };
 
 export const sendRequestAllTestCases = async () => {
   const url = `${URL}/api/test-cases`;
   const response = await fetch(url);
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.testCases;
 };
 
@@ -450,10 +410,7 @@ export const sendRequestAddNewTestCase = async (testCase) => {
     },
     body: JSON.stringify({ testCase }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.testCase;
 };
 
@@ -462,10 +419,7 @@ export const sendRequestDeleteTestCase = async (testCaseId) => {
   const response = await fetch(url, {
     method: "DELETE",
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.result;
 };
 
@@ -473,10 +427,7 @@ export const sendRequestDeleteTestCase = async (testCaseId) => {
 export const sendRequestDataset = async (tcId) => {
   const url = `${URL}/api/data-sets/${tcId}`;
   const response = await fetch(url);
-  const status = await response.json();
-  if (status.error) {
-    throw status.error;
-  }
+  const status = await parseResponse(response);
   return status.dataset;
 };
 
@@ -489,20 +440,14 @@ export const sendRequestUpdateDataset = async (id, dataset) => {
     },
     body: JSON.stringify({ dataset }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.dataset;
 };
 
 export const sendRequestAllDatasets = async () => {
   const url = `${URL}/api/data-sets`;
   const response = await fetch(url);
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.datasets;
 };
 
@@ -515,10 +460,7 @@ export const sendRequestAddNewDataset = async (dataset) => {
     },
     body: JSON.stringify({ dataset }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.dataset;
 };
 
@@ -527,10 +469,7 @@ export const sendRequestDeleteDataset = async (datasetId) => {
   const response = await fetch(url, {
     method: "DELETE",
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.result;
 };
 
@@ -538,10 +477,7 @@ export const sendRequestDeleteDataset = async (datasetId) => {
 export const sendRequestReport = async (rpId) => {
   const url = `${URL}/api/reports/${rpId}`;
   const response = await fetch(url);
-  const status = await response.json();
-  if (status.error) {
-    throw status.error;
-  }
+  const status = await parseResponse(response);
   return status;
 };
 
@@ -561,10 +497,7 @@ export const sendRequestAllReports = async (options) => {
 
   const url = `${URL}/api/reports${query}`;
   const response = await fetch(url);
-  const status = await response.json();
-  if (status.error) {
-    throw status.error;
-  }
+  const status = await parseResponse(response);
   return status.reports;
 };
 
@@ -573,10 +506,7 @@ export const sendRequestDeleteReport = async (reportId) => {
   const response = await fetch(url, {
     method: "DELETE",
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.result;
 };
 
@@ -590,10 +520,7 @@ export const sendRequestUpdateReport = async (id, report, newScore) => {
     },
     body: JSON.stringify({ report, newScore }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.report;
 };
 
@@ -601,10 +528,7 @@ export const sendRequestUpdateReport = async (id, report, newScore) => {
 export const sendRequestEvent = async (tcId) => {
   const url = `${URL}/api/events/${tcId}`;
   const response = await fetch(url);
-  const status = await response.json();
-  if (status.error) {
-    throw status.error;
-  }
+  const status = await parseResponse(response);
   return status.event;
 };
 
@@ -617,10 +541,7 @@ export const sendRequestUpdateEvent = async (id, event) => {
     },
     body: JSON.stringify({ event }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.event;
 };
 
@@ -634,10 +555,7 @@ export const sendRequestEventsByDatasetId = async (
     startTime ? startTime : 0
   }&endTime=${endTime ? endTime : Date.now()}&page=${page}`;
   const response = await fetch(url);
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return {totalNbEvents: data.totalNbEvents, events: data.events};
 };
 
@@ -650,10 +568,7 @@ export const sendRequestAddNewEvent = async (event) => {
     },
     body: JSON.stringify({ event }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.event;
 };
 
@@ -662,10 +577,7 @@ export const sendRequestDeleteEvent = async (eventId) => {
   const response = await fetch(url, {
     method: "DELETE",
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.result;
 };
 
@@ -688,10 +600,7 @@ export const sendRequestStartSimulation = async (
       },
     }),
   });
-  const data = await response.json();
-  if (data.error) {
-    throw data.error;
-  }
+  const data = await parseResponse(response);
   return data.simulationStatus;
 };
 
@@ -699,29 +608,20 @@ export const sendRequestStartSimulation = async (
 export const sendRequestLaunchTestCampaign = async () => {
   const url = `${URL}/api/devops/start`;
   const response = await fetch(url);
-  const status = await response.json();
-  if (status.error) {
-    throw status.error;
-  }
+  const status = await parseResponse(response);
   return status.runningStatus;
 };
 
 export const sendRequestStopTestCampaign = async () => {
   const url = `${URL}/api/devops/stop`;
   const response = await fetch(url);
-  const status = await response.json();
-  if (status.error) {
-    throw status.error;
-  }
+  const status = await parseResponse(response);
   return status.runningStatus;
 };
 
 export const sendRequestTestCampaignStatus = async () => {
   const url = `${URL}/api/devops/status`;
   const response = await fetch(url);
-  const status = await response.json();
-  if (status.error) {
-    throw status.error;
-  }
+  const status = await parseResponse(response);
   return status.runningStatus;
 };

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -6,6 +6,7 @@ var compression = require('compression');
 var helmet = require('helmet');
 var rateLimit = require('express-rate-limit');
 var { loadConfig } = require('./config');
+var { errorHandler, apiNotFound, forbidden, ApiError, sendError } = require('./middleware/errors');
 
 // Read the environment configuration once at startup.
 const config = loadConfig();
@@ -74,8 +75,9 @@ app.use(function corsControl(req, res, next) {
   const isAllowed = config.corsAllowedOrigins.indexOf(origin) !== -1;
 
   if (!isAllowed) {
-    // Reject cross-origin requests from unlisted origins.
-    return res.status(403).json({ error: 'Origin not allowed' });
+    // Reject cross-origin requests from unlisted origins. Reported through the
+    // central handler like every other refusal, so the API has one error shape.
+    return sendError(res, forbidden('Origin not allowed'));
   }
 
   res.setHeader('Vary', 'Origin');
@@ -107,7 +109,11 @@ const apiLimiter = rateLimit({
   max: config.rateLimitMax,
   standardHeaders: true,
   legacyHeaders: false,
-  message: { error: 'Too many requests, please try again later.' }
+  // Reported through the central handler rather than written here, so a client
+  // that is over the limit reads the same error shape as every other refusal.
+  handler: function (req, res, next) {
+    next(new ApiError(429, 'Too many requests, please try again later.'));
+  }
 });
 
 app.use('/api', apiLimiter);
@@ -125,18 +131,25 @@ app.use('/api/events', eventRouter);
 app.use('/api/reports', reportRouter);
 app.use('/api/simulation', simulationRouter);
 app.use('/api/devops', devopsRouter);
+// An API path no router claimed is a missing resource, not the dashboard: it
+// must not fall through to the single-page app below, which would answer 200
+// with an HTML page a client cannot tell from a successful call.
+app.use('/api', apiNotFound);
+
 app.get('/*', function (req, res) {
   res.sendFile(path.join(__dirname, '../public', 'index.html'));
 });
 
-// Error handler: surface body-parser limit errors as JSON 413 without
-// unbounded buffering.
-app.use(function (err, req, res, next) {
-  if (err && err.type === 'entity.too.large') {
-    return res.status(413).json({ error: 'Request entity too large' });
-  }
-  next(err);
-});
+/**
+ * The central error handler.
+ *
+ * Every failure the API reports is rendered here, in one shape, with the
+ * underlying error kept server-side (`middleware/errors.js`). Registered last
+ * so it also catches what happens before any route runs — a body over the
+ * configured limit, a malformed JSON body — which would otherwise reach
+ * Express's default handler and be answered with an HTML stack trace.
+ */
+app.use(errorHandler);
 
 module.exports = app;
 

--- a/src/server/middleware/errors.js
+++ b/src/server/middleware/errors.js
@@ -121,11 +121,45 @@ const BODY_PARSER_FAILURES = {
 };
 
 /**
+ * What a failure that already knows it is the caller's fault is answered with.
+ *
+ * Express's own router raises a `URIError` carrying `status: 400` when a path
+ * segment's percent-encoding cannot be decoded, and anything built on
+ * `http-errors` stamps the same field. The status such a failure carries is
+ * worth keeping — the message it comes with is not, because that is the part
+ * that names internals — so the caller is told one of these instead.
+ */
+const CALLER_FAILURES = {
+  400: "Bad request",
+  404: "Not found",
+  415: "Unsupported media type",
+};
+const CALLER_FAILURE = "Request refused";
+
+/**
+ * The status a failure already carries, when it is one only the caller can fix.
+ *
+ * Deliberately 4xx alone: a 5xx a library chose says nothing more than the bare
+ * 500 already does, and a status that is not an integer in that range is not a
+ * classification at all.
+ *
+ * @param {*} err The value handed to `next`
+ * @returns {Number|null}
+ */
+const callerStatus = (err) => {
+  const status = err && (err.status || err.statusCode);
+  return Number.isInteger(status) && status >= 400 && status < 500 ? status : null;
+};
+
+/**
  * Normalise anything thrown or passed to `next` into an `ApiError`.
  *
  * Only an `ApiError` describes itself to the caller. Everything else is a
  * failure nobody classified, so it is reported as a bare 500 — which is what
  * keeps raw error objects, and the server paths they carry, out of responses.
+ * The one thing read off an unclassified failure is a 4xx it already carries:
+ * answering 500 for a malformed request tells a monitor the server broke when
+ * the caller did, which is the inverse of what these statuses are for.
  *
  * @param {*} err The value handed to `next`
  * @returns {ApiError}
@@ -134,6 +168,12 @@ const toApiError = (err) => {
   if (err instanceof ApiError) return err;
   const mapped = err && err.type ? BODY_PARSER_FAILURES[err.type] : null;
   if (mapped) return new ApiError(mapped[0], mapped[1], { cause: err });
+  const status = callerStatus(err);
+  if (status) {
+    return new ApiError(status, CALLER_FAILURES[status] || CALLER_FAILURE, {
+      cause: err,
+    });
+  }
   return new ApiError(500, INTERNAL_MESSAGE, { cause: err });
 };
 

--- a/src/server/middleware/errors.js
+++ b/src/server/middleware/errors.js
@@ -1,0 +1,239 @@
+/**
+ * The single place where a failure becomes an HTTP response.
+ *
+ * Every layer reports a failure by handing an error to `next` (or, where there
+ * is no `next` to hand, to `sendError`); nothing else writes an error body.
+ * That is what keeps one shape — `{ error, details? }` — across the whole API,
+ * and what guarantees the underlying error object never reaches the caller: the
+ * detail is logged here, server-side, and the response carries only a message
+ * the code that raised the failure chose deliberately.
+ *
+ * A Node fs error carries the absolute path it failed to open in its own
+ * enumerable properties, and a Mongoose error carries the document it refused,
+ * so echoing either back discloses the server's layout. Nothing that is not an
+ * `ApiError` is ever described to the caller — it becomes a bare 500.
+ */
+
+/** What the caller is told about a failure whose cause must not be disclosed. */
+const INTERNAL_MESSAGE = "Internal server error";
+
+/**
+ * A failure with a status code and a message that is safe to return.
+ *
+ * `details` is the machine-readable per-field breakdown a validation failure
+ * carries; `cause` is the underlying error, which is logged and never returned.
+ */
+class ApiError extends Error {
+  /**
+   * @param {Number} status HTTP status code this failure maps to
+   * @param {String} message Caller-facing message, safe by construction
+   * @param {Object} [options]
+   * @param {Array}  [options.details] Machine-readable per-field detail
+   * @param {*}      [options.cause] The underlying error — logged, never sent
+   */
+  constructor(status, message, { details, cause } = {}) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    if (details !== undefined) this.details = details;
+    if (cause !== undefined) this.cause = cause;
+  }
+}
+
+/** The request was malformed or asked for something it may not ask for. */
+const badRequest = (message, details) =>
+  new ApiError(400, message || "Invalid request", { details });
+
+/** The caller may not have what it asked for. */
+const forbidden = (message) => new ApiError(403, message || "Forbidden");
+
+/** The addressed resource does not exist. */
+const notFound = (message) => new ApiError(404, message || "Not found");
+
+/** The request cannot be applied to the current state of the resource. */
+const conflict = (message) => new ApiError(409, message || "Conflict");
+
+/** A dependency the request needs is not reachable. */
+const unavailable = (message, cause) =>
+  new ApiError(503, message || "Service unavailable", { cause });
+
+/** The server failed at something that is not the caller's fault. */
+const internal = (message, cause) =>
+  new ApiError(500, message || INTERNAL_MESSAGE, { cause });
+
+/** fs error codes that mean "the thing addressed is not there". */
+const MISSING_FILE_CODES = ["ENOENT", "ENOTDIR"];
+
+/**
+ * Map a filesystem failure onto the status it actually is.
+ *
+ * A read that fails because the file is not there is a missing resource, not a
+ * server fault, and answering 500 for it is what made the two indistinguishable
+ * to a client.
+ *
+ * @param {Error} err The fs error
+ * @param {String} missingMessage Message for a resource that is not there
+ * @param {String} failureMessage Message for any other read/write failure
+ * @returns {ApiError}
+ */
+const fileError = (err, missingMessage, failureMessage) =>
+  err && MISSING_FILE_CODES.indexOf(err.code) !== -1
+    ? new ApiError(404, missingMessage, { cause: err })
+    : new ApiError(500, failureMessage, { cause: err });
+
+/**
+ * Map a database failure onto the status it actually is.
+ *
+ * A cast failure and a schema violation are both the caller's document being
+ * wrong, which is a 400 however late it is discovered; a duplicate key is a
+ * conflict. Only what is genuinely ours is a 500. This is the backstop for a
+ * constraint the request schemas cannot express, so a rejected write can never
+ * again be reported behind a success status.
+ *
+ * @param {Error} err The database error
+ * @param {String} failureMessage Message for a genuine server-side failure
+ * @returns {ApiError}
+ */
+const databaseError = (err, failureMessage) => {
+  if (err && err.name === "CastError") {
+    return new ApiError(400, "Invalid identifier", { cause: err });
+  }
+  if (err && err.name === "ValidationError") {
+    return new ApiError(400, "Invalid document", { cause: err });
+  }
+  if (err && (err.code === 11000 || err.code === 11001)) {
+    return new ApiError(409, "Already exists", { cause: err });
+  }
+  return new ApiError(500, failureMessage, { cause: err });
+};
+
+/**
+ * Failures raised by body-parser before any route runs, and the status each
+ * one is. Without this they reach Express's default handler, which answers with
+ * an HTML page carrying a stack trace.
+ */
+const BODY_PARSER_FAILURES = {
+  "entity.too.large": [413, "Request entity too large"],
+  "entity.parse.failed": [400, "Malformed request body"],
+  "entity.verify.failed": [400, "Malformed request body"],
+  "encoding.unsupported": [415, "Unsupported content encoding"],
+  "request.aborted": [400, "Request aborted"],
+};
+
+/**
+ * Normalise anything thrown or passed to `next` into an `ApiError`.
+ *
+ * Only an `ApiError` describes itself to the caller. Everything else is a
+ * failure nobody classified, so it is reported as a bare 500 — which is what
+ * keeps raw error objects, and the server paths they carry, out of responses.
+ *
+ * @param {*} err The value handed to `next`
+ * @returns {ApiError}
+ */
+const toApiError = (err) => {
+  if (err instanceof ApiError) return err;
+  const mapped = err && err.type ? BODY_PARSER_FAILURES[err.type] : null;
+  if (mapped) return new ApiError(mapped[0], mapped[1], { cause: err });
+  return new ApiError(500, INTERNAL_MESSAGE, { cause: err });
+};
+
+/**
+ * Render a cause as one log line's worth of text.
+ * @param {*} value The underlying error or value
+ * @returns {String}
+ */
+const describe = (value) => {
+  if (value instanceof Error) {
+    return value.stack || `${value.name}: ${value.message}`;
+  }
+  if (value === undefined || value === null) return "";
+  try {
+    return JSON.stringify(value);
+  } catch (e) {
+    return String(value);
+  }
+};
+
+/**
+ * Record the full detail of a failure server-side.
+ *
+ * Deliberately one string: `logger/index.js` replaces `console.error` with a
+ * single-argument function, so anything passed as a second argument is dropped
+ * on the floor once a logger exists — which is how the detail that is no longer
+ * in the response would otherwise be lost altogether.
+ *
+ * @param {Object} req The request, when there is one
+ * @param {ApiError} apiError The normalised failure
+ */
+const logFailure = (req, apiError) => {
+  const where =
+    req && req.method ? `${req.method} ${req.originalUrl || req.url}` : "request";
+  const detail = apiError.cause === undefined ? "" : describe(apiError.cause);
+  const details = apiError.details ? ` details=${describe(apiError.details)}` : "";
+  console.error(
+    `[SERVER] ${where} -> ${apiError.status} ${apiError.message}${details}${
+      detail ? ` | ${detail}` : ""
+    }`
+  );
+};
+
+/**
+ * The central error handler — the only function in the server that writes an
+ * error response.
+ *
+ * Attached to every router as well as to the application, because a router
+ * mounted on its own (as the test suites mount them) would otherwise fall
+ * through to Express's default handler and answer with a stack trace.
+ */
+function errorHandler(err, req, res, next) {
+  const apiError = toApiError(err);
+  // Routers carry this handler as well as the application does, so a failure
+  // delegated below would otherwise be recorded twice.
+  if (!apiError.logged) {
+    apiError.logged = true;
+    logFailure(req, apiError);
+  }
+  // A failure after the response has started cannot be reported in the body;
+  // Express's default handler is the only thing that can close the connection.
+  // Delegate the normalised error so the tag above travels with it.
+  if (res.headersSent) return next(apiError);
+  const payload = { error: apiError.message };
+  if (Array.isArray(apiError.details) && apiError.details.length > 0) {
+    payload.details = apiError.details;
+  }
+  return res.status(apiError.status).json(payload);
+}
+
+/**
+ * Report a failure on a response whose caller holds no `next`.
+ *
+ * Used by the containment guards, which are handed a response object alone.
+ * Routes it through the same handler so there is still exactly one thing in the
+ * server that decides what an error response looks like.
+ *
+ * @param {Object} res The Express response
+ * @param {Error} err The failure to report
+ */
+const sendError = (res, err) => errorHandler(err, res.req, res, () => {});
+
+/**
+ * Answer an API path no router claimed with a JSON 404 rather than the SPA's
+ * index.html (which a client cannot tell from a successful call).
+ */
+const apiNotFound = (req, res, next) => next(notFound("Not found"));
+
+module.exports = {
+  ApiError,
+  badRequest,
+  forbidden,
+  notFound,
+  conflict,
+  unavailable,
+  internal,
+  fileError,
+  databaseError,
+  errorHandler,
+  sendError,
+  apiNotFound,
+  INTERNAL_MESSAGE,
+};

--- a/src/server/middleware/validate.js
+++ b/src/server/middleware/validate.js
@@ -1,5 +1,6 @@
 const Joi = require("joi");
 const { NAME_MAX_LENGTH } = require("../routes/path-safety");
+const { badRequest } = require("./errors");
 
 /**
  * Request sections that carry externally controlled input, with the validation
@@ -100,10 +101,10 @@ const validate = (schemas = {}) => {
     }
 
     if (details.length > 0) {
-      return res.status(400).json({
-        error: "Validation failed",
-        details,
-      });
+      // Handed to `next` rather than answered here, so a rejected request is
+      // rendered by the same handler as every other failure and the API keeps
+      // one error shape (`middleware/errors.js`).
+      return next(badRequest("Validation failed", details));
     }
 
     for (const { key, value } of validated) {

--- a/src/server/routes/data-recorders.js
+++ b/src/server/routes/data-recorders.js
@@ -95,6 +95,14 @@ const dataRecorderStartBody = Joi.object({
  */
 let allRunningStatus = {};
 let allDataRecorders = {};
+// The ids whose start is under way. On the default data storage path the
+// recorder is only registered inside the `getDataStorage` callback, an
+// event-loop turn after the guard below read the registry, so without something
+// held across that turn two concurrent starts of one recorder both pass the
+// guard and the first one is left recording with no handle to stop it. A
+// reservation rather than a placeholder in `allDataRecorders`: `/stop` calls
+// `stop()` on whatever it finds there.
+const startingDataRecorders = new Set();
 
 /**
  * Get the running status of data recorder
@@ -134,7 +142,7 @@ const startRecorder = (model, res, next) => {
       next(badRequest("Invalid data recorder name"));
     } else {
       const recorderId = getObjectId(name);
-      if (allDataRecorders[recorderId]) {
+      if (startingDataRecorders.has(recorderId) || allDataRecorders[recorderId]) {
         // The recorder is already running: the request cannot be applied to the
         // state the resource is in, which is a conflict rather than a fault.
         next(conflict("Recorder has already started"));
@@ -144,7 +152,11 @@ const startRecorder = (model, res, next) => {
         getLogger("DATA-RECORDER", `${logsPath}${logFile}`);
         if (!dataStorage) {
           // use default data storage
+          startingDataRecorders.add(recorderId);
           getDataStorage((err, ds) => {
+            // Released first, so the reservation cannot outlive the start on
+            // either path, nor if registering the recorder throws.
+            startingDataRecorders.delete(recorderId);
             if (err) {
               next(unavailable("No data storage", err));
             } else {

--- a/src/server/routes/data-recorders.js
+++ b/src/server/routes/data-recorders.js
@@ -25,6 +25,14 @@ const {
   dataStorageSchema,
   datasetSchema,
 } = require("../middleware/validate");
+const {
+  errorHandler,
+  badRequest,
+  conflict,
+  fileError,
+  internal,
+  unavailable,
+} = require("../middleware/errors");
 const dataRecordersPath = `${__dirname}/../data/data-recorders/`;
 let router = express.Router();
 let getLogger = require("../logger");
@@ -115,31 +123,21 @@ router.get("/stop/:fileName", validate({ params: { fileName: recorderNameParam }
   });
 });
 
-const startRecorder = (model, res) => {
+const startRecorder = (model, res, next) => {
   if (!model) {
-    console.error("[data-recorders] Cannot find data recorder configuration");
-    res.send({
-      error: "Cannot find data recorder configuration",
-    });
+    next(badRequest("Cannot find data recorder configuration"));
   } else {
     const { name, dataRecorders, dataStorage } = model;
     if (!name || !dataRecorders) {
-      console.error("[data-recorders] Invalid data recorder model");
-      res.send({
-        error: " Invalid data recorder model",
-      });
+      next(badRequest("Invalid data recorder model"));
     } else if (!isValidName(name)) {
-      res.status(400).send({
-        error: "Invalid data recorder name",
-      });
+      next(badRequest("Invalid data recorder name"));
     } else {
       const recorderId = getObjectId(name);
       if (allDataRecorders[recorderId]) {
-        console.error("[data-recorders] Recorder has already started");
-        console.error(name);
-        res.send({
-          error: `Recorder has already started ${name}`,
-        });
+        // The recorder is already running: the request cannot be applied to the
+        // state the resource is in, which is a conflict rather than a fault.
+        next(conflict("Recorder has already started"));
       } else {
         const startedTime = Date.now();
         const logFile = `${name}_${startedTime}.log`;
@@ -148,9 +146,7 @@ const startRecorder = (model, res) => {
           // use default data storage
           getDataStorage((err, ds) => {
             if (err) {
-              res.send({
-                error: "No data storage",
-              });
+              next(unavailable("No data storage", err));
             } else {
               const dataRecorder = new DataRecorder({
                 ...model,
@@ -207,19 +203,20 @@ router.post("/start", validate({ body: dataRecorderStartBody }), (req, res, next
     }
     readJSONFile(dataRecorderFile, (err, data) => {
       if (err) {
-        console.error(
-          `[data-recorders] Cannot find data recorder ${dataRecorderFileName}`
+        next(
+          fileError(
+            err,
+            "Data recorder not found",
+            "Cannot read the data recorder file"
+          )
         );
-        res.send({
-          error: `[data-recorders] Cannot find data recorder ${dataRecorderFileName}`,
-        });
       } else {
-        startRecorder(data, res);
+        startRecorder(data, res, next);
       }
     });
   } else {
     // Start recorder by model
-    startRecorder(model, res);
+    startRecorder(model, res, next);
   }
 });
 
@@ -227,10 +224,7 @@ router.post("/start", validate({ body: dataRecorderStartBody }), (req, res, next
 router.get("/models/", validate(), (req, res, next) => {
   readDir(dataRecordersPath, (err, files) => {
     if (err) {
-      console.error("[SERVER]", err);
-      res.send({
-        error: "Cannot read the data recorders directory",
-      });
+      next(internal("Cannot read the data recorders directory", err));
     } else {
       res.send({
         error: null,
@@ -249,10 +243,13 @@ router.get("/models/:fileName", validate({ params: { fileName: recorderNameParam
   }
   readJSONFile(dataRecorderFile, (err, data) => {
     if (err) {
-      console.error("[SERVER]", err);
-      res.send({
-        error: "Cannot read the data recorder file",
-      });
+      next(
+        fileError(
+          err,
+          "Data recorder not found",
+          "Cannot read the data recorder file"
+        )
+      );
     } else {
       res.send({
         error: null,
@@ -262,7 +259,7 @@ router.get("/models/:fileName", validate({ params: { fileName: recorderNameParam
   });
 });
 
-const updateDataRecorder = (fileName, dataRecorder, res) => {
+const updateDataRecorder = (fileName, dataRecorder, res, next) => {
   const { name } = dataRecorder;
   // Containment, not validation: the schema has already established that the
   // name is well formed, but the path it derives is still checked at the sink.
@@ -281,10 +278,7 @@ const updateDataRecorder = (fileName, dataRecorder, res) => {
       JSON.stringify(dataRecorder),
       (err, data) => {
         if (err) {
-          console.error("[SERVER]", err);
-          res.send({
-            error: "Cannot save the new configuration",
-          });
+          next(internal("Cannot save the new configuration", err));
         } else {
           res.send({
             dataRecorderFileName: fileName,
@@ -300,17 +294,11 @@ const updateDataRecorder = (fileName, dataRecorder, res) => {
       JSON.stringify(dataRecorder),
       (err, data) => {
         if (err) {
-          console.error("[SERVER]", err);
-          res.send({
-            error: "Cannot save the new configuration",
-          });
+          next(internal("Cannot save the new configuration", err));
         } else {
           deleteFile(oldDataRecorderFile, (err2) => {
             if (err2) {
-              console.error("[SERVER]", err2);
-              res.send({
-                error: `Cannot remove the old data recorder file: ${fileName}`,
-              });
+              next(internal("Cannot remove the old data recorder file", err2));
             } else {
               res.send({
                 dataRecorderFileName: fileName,
@@ -324,17 +312,20 @@ const updateDataRecorder = (fileName, dataRecorder, res) => {
   }
 };
 
-const duplicateDataRecorder = (fileName, res) => {
+const duplicateDataRecorder = (fileName, res, next) => {
   const dataRecorderFile = resolveWithin(dataRecordersPath, fileName);
   if (!dataRecorderFile) {
     return sendBadRequest(res, "Invalid data recorder name");
   }
   readJSONFile(dataRecorderFile, (err, data) => {
     if (err) {
-      console.error("[SERVER] Cannot read data recorder: ", err);
-      res.send({
-        error: `Cannot read model ${fileName}`,
-      });
+      next(
+        fileError(
+          err,
+          "Data recorder not found",
+          "Cannot read the data recorder file"
+        )
+      );
     } else {
       const newName = `${data.name} [Duplicated]`;
       const newDataRecorder = {
@@ -354,10 +345,7 @@ const duplicateDataRecorder = (fileName, res) => {
         JSON.stringify(newDataRecorder),
         (err, dupDataRecorder) => {
           if (err) {
-            console.error("[SERVER]", err);
-            res.send({
-              error: "Cannot save the duplicated model",
-            });
+            next(internal("Cannot save the duplicated data recorder", err));
           } else {
             res.send({
               dataRecorderFileName: newFileName,
@@ -376,9 +364,9 @@ router.post("/models/:fileName", validate({ params: { fileName: recorderNamePara
 
   const { dataRecorder, isDuplicated } = req.body;
   if (isDuplicated) {
-    duplicateDataRecorder(fileName, res);
+    duplicateDataRecorder(fileName, res, next);
   } else {
-    updateDataRecorder(fileName, dataRecorder, res);
+    updateDataRecorder(fileName, dataRecorder, res, next);
   }
 });
 
@@ -398,10 +386,7 @@ router.post("/models", validate({ body: dataRecorderCreateBody }), function (req
   }
   writeToFile(dataRecorderFile, JSON.stringify(dataRecorder), (err, data) => {
     if (err) {
-      console.error("[SERVER]", err);
-      res.send({
-        error: "Cannot save the new configuration",
-      });
+      next(internal("Cannot save the new configuration", err));
     } else {
       res.send({
         error: null,
@@ -420,10 +405,13 @@ router.delete("/models/:fileName", validate({ params: { fileName: recorderNamePa
   }
   deleteFile(dataRecorderFile, (err) => {
     if (err) {
-      console.error("[SERVER]", err);
-      res.send({
-        error: "Cannot delete the data recorder file",
-      });
+      next(
+        fileError(
+          err,
+          "Data recorder not found",
+          "Cannot delete the data recorder file"
+        )
+      );
     } else {
       res.send({
         error: null,
@@ -432,5 +420,9 @@ router.delete("/models/:fileName", validate({ params: { fileName: recorderNamePa
     }
   });
 });
+
+// Attached to the router itself as well as to the application: see the note in
+// `routes/model.js`.
+router.use(errorHandler);
 
 module.exports = router;

--- a/src/server/routes/data-sets.js
+++ b/src/server/routes/data-sets.js
@@ -11,6 +11,11 @@ const {
   pageSchema,
   textSchema,
 } = require("../middleware/validate");
+const {
+  errorHandler,
+  databaseError,
+  notFound,
+} = require("../middleware/errors");
 
 // ---------------------------------------------------------------------------
 // Validation schemas for the data-set endpoints (issue #10)
@@ -47,10 +52,7 @@ router.get("/", validate({ query: datasetQuery }), dbConnector, function (req, r
   if (!page) page = 0;
   DatasetSchema.findDatasetsWithPagingOptions(null, page, (err2, datasets) => {
     if (err2) {
-      console.error("[SERVER] Failed to get datasets", err2);
-      res.send({
-        error: "Failed to get data set",
-      });
+      next(databaseError(err2, "Failed to get data set"));
     } else {
       res.send({
         datasets,
@@ -67,10 +69,9 @@ router.get("/:datasetId", validate({ params: { datasetId: datasetIdParam } }), d
 
   DatasetSchema.findOne({ id: datasetId }, (err2, dataset) => {
     if (err2) {
-      console.error("[SERVER] Failed to get datasets", err2);
-      res.send({
-        error: "Failed to get data set",
-      });
+      next(databaseError(err2, "Failed to get data set"));
+    } else if (!dataset) {
+      next(notFound("Data set not found"));
     } else {
       res.send({
         dataset,
@@ -95,10 +96,7 @@ router.post("/", validate({ body: datasetCreateBody }), dbConnector, function (r
   });
   newdataset.save((err, _dataset) => {
     if (err) {
-      console.error("[SERVER] Failed to save the data sets", err);
-      res.send({
-        error: "Failed to save the data set",
-      });
+      next(databaseError(err, "Failed to save the data set"));
     } else {
       res.send({
         dataset: _dataset,
@@ -119,10 +117,7 @@ router.post("/:datasetId", validate({ params: { datasetId: datasetIdParam }, bod
     { ...dataset, lastModified: Date.now() },
     (err, ts) => {
       if (err) {
-        console.error("[SERVER] Failed to save the data sets", err);
-        res.send({
-          error: "Failed to save the data set",
-        });
+        next(databaseError(err, "Failed to save the data set"));
       } else {
         res.send({
           dataset: ts,
@@ -140,21 +135,16 @@ router.delete("/:datasetId", validate({ params: { datasetId: datasetIdParam } })
 
   DatasetSchema.findOneAndDelete({ id: datasetId }, (err, ret) => {
     if (err) {
-      console.error("[SERVER] Failed to delete the data sets");
-      console.error(err);
-      res.send({
-        error: "Failed to save the data set",
-      });
+      next(databaseError(err, "Failed to delete the data set"));
     } else {
       EventSchema.deleteMany({ datasetId }, (err2) => {
         if (err2) {
-          console.error(
-            "[SERVER] Failed to delete all the event of the deleted dataset"
+          next(
+            databaseError(
+              err2,
+              "Failed to delete all the event of the deleted dataset"
+            )
           );
-          console.error(err2);
-          res.send({
-            error: "Failed to delete all the event of the deleted dataset",
-          });
         } else {
           res.send({
             result: ret,
@@ -164,5 +154,9 @@ router.delete("/:datasetId", validate({ params: { datasetId: datasetIdParam } })
     }
   });
 });
+
+// Attached to the router itself as well as to the application: see the note in
+// `routes/model.js`.
+router.use(errorHandler);
 
 module.exports = router;

--- a/src/server/routes/data-storage.js
+++ b/src/server/routes/data-storage.js
@@ -11,6 +11,7 @@ const {
   validate,
   dataStorageSchema,
 } = require("../middleware/validate");
+const { errorHandler, internal } = require("../middleware/errors");
 
 // ---------------------------------------------------------------------------
 // Validation schemas for the data-storage endpoints (issue #10)
@@ -27,9 +28,7 @@ const dataStorageBody = Joi.object({
 router.get("/", validate(), function (req, res, next) {
   getDataStorage((err, dataStorage) => {
     if (err) {
-      res.send({
-        error: 'Cannot get data storage'
-      });
+      next(internal('Cannot get data storage', err));
     } else {
       res.send({
         dataStorage
@@ -45,10 +44,7 @@ router.post("/", validate({ body: dataStorageBody }), function (req, res, next) 
   } = req.body;
   updateDataStorage(dataStorage, (err, ds) => {
     if (err) {
-      console.error('[data-storage] Failed to update data storage',err);
-      res.send({
-        error: 'Failed to update data storage'
-      });
+      next(internal('Failed to update data storage', err));
     } else {
       res.send({
         dataStorage: ds
@@ -62,5 +58,9 @@ router.get('/test', validate(), dbConnector, (req, res, next) => {
   res.send({connectionStatus: true});
 });
 
+
+// Attached to the router itself as well as to the application: see the note in
+// `routes/model.js`.
+router.use(errorHandler);
 
 module.exports = router;

--- a/src/server/routes/db-connector.js
+++ b/src/server/routes/db-connector.js
@@ -12,6 +12,7 @@ const {
   readJSONFile,
   writeToFile,
 } = require("../../core/utils");
+const { unavailable } = require("../middleware/errors");
 
 const dataStoragePath = `${__dirname}/../data/data-storage.json`;
 
@@ -124,30 +125,38 @@ const updateDataStorage = (dataStorage, callback) => {
         dbClient.close();
         dbClient = null;
       }
-      getDBClient((err2, dbClient) => {
-        if (err) {
-          console.error('[SERVER] Failed to get database client', err);
-          res.send({
-            error: 'Failed to get database client!'
-          });
-        } else {
-          return callback(null,
-            dataStorage
+      getDBClient((err2) => {
+        if (err2) {
+          // The configuration asked for *was* written, so the update itself
+          // succeeded; only the connection it names is not answering. Report
+          // the save as done and keep the connection failure in the log —
+          // `GET /api/data-storage/test` is what probes the connection.
+          // (This branch used to test the wrong variable and then reference an
+          // `res` that does not exist here, so it could only ever have thrown.)
+          console.error(
+            `[SERVER] Data storage saved, but its connection is not reachable | ${
+              err2 && err2.stack ? err2.stack : err2
+            }`
           );
         }
+        return callback(null, dataStorage);
       }, true);
     }
   }, true);
 };
 
 
+/**
+ * Establish the database connection a route needs, or refuse the request.
+ *
+ * A database that is not answering is a dependency being unavailable, not a
+ * successful call: it is reported as 503 so a client, a proxy and a monitor can
+ * all tell it apart from a served request without reading the body.
+ */
 const dbConnector = (req, res, next) => {
-  getDBClient((err, dbClient) => {
+  getDBClient((err) => {
     if (err) {
-      console.error('[SERVER] Failed to get database client', err);
-      res.send({
-        error: 'Failed to get database client!'
-      });
+      next(unavailable('Database is unavailable', err));
     } else {
       next();
     }

--- a/src/server/routes/devops.js
+++ b/src/server/routes/devops.js
@@ -30,6 +30,12 @@ const {
   urlSchema,
   dataStorageSchema,
 } = require("../middleware/validate");
+const {
+  errorHandler,
+  badRequest,
+  internal,
+  unavailable,
+} = require("../middleware/errors");
 let logsPath = `${__dirname}/../logs/test-campaigns/`;
 
 let runningStatus = null;
@@ -71,10 +77,7 @@ const getDevops = (callback) => {
   if (_devops) return callback(null, _devops);
   readJSONFile(devopsFilePath, (err, data) => {
     if (err) {
-      console.error('[SERVER] Cannot get devops.json file', err);
-      return callback(
-        err
-      );
+      return callback(err);
     } else {
       _devops = data;
       return callback(
@@ -88,14 +91,10 @@ const getDevops = (callback) => {
 router.get("/", validate(), function (req, res, next) {
   getDevops((err, devO) => {
     if (err) {
-      // Same reasoning as in `loadValidatedDevops` below: the raw fs error
-      // carries the absolute path of devops.json in its own enumerable
-      // properties, which JSON.stringify would serialise straight into the
-      // response. Keep the detail server-side and answer with a constant.
-      console.error('[SERVER] Cannot get devops configuration', err);
-      res.send({
-        error: "Cannot get devops configuration"
-      });
+      // The raw fs error carries the absolute path of devops.json in its own
+      // enumerable properties. Reporting it through the central handler is what
+      // keeps that detail in the log and out of the response.
+      next(internal("Cannot get devops configuration", err));
     } else {
       res.send({
         devops: devO
@@ -117,10 +116,7 @@ router.post("/", validate({ body: devopsBody }), function (req, res, next) {
   // may have written.
   writeToFile(devopsFilePath, JSON.stringify(devops), (err, data) => {
     if (err) {
-      console.error("[SERVER] Cannot save devops.json file", err);
-      res.send({
-        error: "Cannot save devops.json file"
-      });
+      next(internal("Cannot save the devops configuration", err));
     } else {
       _devops = devops;
       res.send({
@@ -142,20 +138,13 @@ const loadValidatedDevops = (req, res, next) => {
   getDevops((err, devops) => {
     if (err) {
       // The raw fs error carries the absolute path of devops.json in its own
-      // enumerable properties, which JSON.stringify would serialise straight
-      // into the response. Keep the detail server-side and answer with a
-      // constant message.
-      console.error('[SERVER] Cannot get devops configuration', err);
-      return res.send({
-        error: "Cannot get devops configuration"
-      });
+      // enumerable properties. Reporting it through the central handler is what
+      // keeps that detail in the log and out of the response.
+      return next(internal("Cannot get devops configuration", err));
     }
     const { testCampaignId } = devops || {};
     if (!testCampaignId) {
-      console.error('Test campaign Id must not be NULL');
-      return res.send({
-        error: `Test campaign Id must not be null`
-      });
+      return next(badRequest("Test campaign Id must not be null"));
     }
     // A configuration written by an older, unvalidated build can still hold a
     // hostile id, so read-back is checked as well as write.
@@ -205,10 +194,7 @@ router.get('/start', validate(), loadValidatedDevops, dbConnector, (req, res, ne
   } else {
     getDataStorage((err, ds) => {
       if (err) {
-        console.log('[devops] Cannot get data storage');
-        res.send({
-          error: 'Cannot get data storage'
-        });
+        next(unavailable("Cannot get data storage", err));
       } else {
         runningStatus = {
           isRunning: true,
@@ -241,5 +227,9 @@ router.get('/stop', validate(), (req, res, next) => {
     runningStatus: copiedStatus
   });
 });
+
+// Attached to the router itself as well as to the application: see the note in
+// `routes/model.js`.
+router.use(errorHandler);
 
 module.exports = router;

--- a/src/server/routes/events.js
+++ b/src/server/routes/events.js
@@ -11,6 +11,11 @@ const {
   textSchema,
   timestampSchema,
 } = require("../middleware/validate");
+const {
+  errorHandler,
+  databaseError,
+  notFound,
+} = require("../middleware/errors");
 
 // ---------------------------------------------------------------------------
 // Validation schemas for the event endpoints (issue #10)
@@ -60,12 +65,19 @@ const eventFields = {
   values: eventValueSchema,
 };
 
+// `values` and `isSensorData` are declared `required: true` by `EventSchema`,
+// so a create that omits either is refused by mongoose after the request has
+// been accepted. Requiring them here is what turns that into a 400 naming the
+// field, instead of a save failure reported behind a success status. They stay
+// optional on the update body below, which is a partial document.
 const eventCreateBody = Joi.object({
   event: documentSchema({
     ...eventFields,
     timestamp: timestampSchema.required(),
     topic: textSchema.required(),
     datasetId: idSchema.required(),
+    isSensorData: Joi.boolean().required(),
+    values: eventValueSchema.required(),
   }).required(),
 }).required();
 
@@ -112,17 +124,11 @@ router.get("/", validate({ query: eventQuery }), dbConnector, function (req, res
   if (page === 0) {
     EventSchema.countDocuments(filter, (err3, totalNbEvents) => {
       if (err3) {
-        console.error("[SERVER] Failed to count number of event", err3);
-        res.send({
-          error: "Failed to count number of event",
-        });
+        next(databaseError(err3, "Failed to count number of event"));
       } else {
         EventSchema.findEventsWithPagingOptions(filter, page, (err2, events) => {
           if (err2) {
-            console.error("[SERVER] Failed to get events", err2);
-            res.send({
-              error: "Failed to get event",
-            });
+            next(databaseError(err2, "Failed to get event"));
           } else {
             res.send({
               totalNbEvents,
@@ -135,10 +141,7 @@ router.get("/", validate({ query: eventQuery }), dbConnector, function (req, res
   } else {
     EventSchema.findEventsWithPagingOptions(filter, page, (err2, events) => {
       if (err2) {
-        console.error("[SERVER] Failed to get events", err2);
-        res.send({
-          error: "Failed to get event",
-        });
+        next(databaseError(err2, "Failed to get event"));
       } else {
         res.send({
           events,
@@ -156,10 +159,9 @@ router.get("/:eventId", validate({ params: { eventId: eventIdParam } }), dbConne
 
   EventSchema.findById(eventId, (err2, event) => {
     if (err2) {
-      console.error("[SERVER] Failed to get events", err2);
-      res.send({
-        error: "Failed to get event",
-      });
+      next(databaseError(err2, "Failed to get event"));
+    } else if (!event) {
+      next(notFound("Event not found"));
     } else {
       res.send({
         event,
@@ -181,10 +183,7 @@ router.post("/", validate({ body: eventCreateBody }), dbConnector, function (req
   });
   newevent.save((err, _event) => {
     if (err) {
-      console.error("[SERVER] Failed to save the events", err);
-      res.send({
-        error: "Failed to save the event",
-      });
+      next(databaseError(err, "Failed to save the event"));
     } else {
       res.send({
         event: _event,
@@ -202,10 +201,7 @@ router.post("/:eventId", validate({ params: { eventId: eventIdParam }, body: eve
 
   EventSchema.findByIdAndUpdate(eventId, event, (err, ts) => {
     if (err) {
-      console.error("[SERVER] Failed to save the events", err);
-      res.send({
-        error: "Failed to save the event",
-      });
+      next(databaseError(err, "Failed to save the event"));
     } else {
       res.send({
         event: ts,
@@ -222,10 +218,7 @@ router.delete("/:eventId", validate({ params: { eventId: eventIdParam } }), dbCo
 
   EventSchema.findByIdAndDelete(eventId, (err, ret) => {
     if (err) {
-      console.error("[SERVER] Failed to delete a event", err);
-      res.send({
-        error: "Failed to delete a event",
-      });
+      next(databaseError(err, "Failed to delete a event"));
     } else {
       res.send({
         result: ret,
@@ -233,5 +226,9 @@ router.delete("/:eventId", validate({ params: { eventId: eventIdParam } }), dbCo
     }
   });
 });
+
+// Attached to the router itself as well as to the application: see the note in
+// `routes/model.js`.
+router.use(errorHandler);
 
 module.exports = router;

--- a/src/server/routes/logs.js
+++ b/src/server/routes/logs.js
@@ -15,6 +15,7 @@ const {
   fileNameParam,
   generatedFileNameMaxLength,
 } = require("../middleware/validate");
+const { errorHandler, fileError, internal } = require("../middleware/errors");
 
 const _logsPath = `${__dirname}/../logs/`;
 
@@ -38,11 +39,16 @@ const createRouter = (appLog = true) => {
   // Get all the logs file
   router.get("/", validate(), (req, res, next) => {
     readDir(logsPath, (err, files) => {
-      if (err) {
-        console.error("[SERVER]", err);
+      if (err && err.code === "ENOENT") {
+        // Nothing under the log root is created up front: a directory that does
+        // not exist yet is an empty collection, not a missing resource. It is
+        // the only listing in the API that can legitimately be absent.
         res.send({
-          error: "Cannot read the logs directory"
+          error: null,
+          files: []
         });
+      } else if (err) {
+        next(internal("Cannot read the logs directory", err));
       } else {
         res.send({
           error: null,
@@ -63,10 +69,7 @@ const createRouter = (appLog = true) => {
     }
     readTextFile(logFile, (err, content) => {
       if (err) {
-        console.error("[SERVER]", err);
-        res.send({
-          error: "Cannot read the log file"
-        });
+        next(fileError(err, "Log file not found", "Cannot read the log file"));
       } else {
         res.send({
           error: null,
@@ -87,10 +90,7 @@ const createRouter = (appLog = true) => {
     }
     deleteFile(logFile, (err) => {
       if (err) {
-        console.error("[SERVER]", err);
-        res.send({
-          error: "Cannot delete the log file"
-        });
+        next(fileError(err, "Log file not found", "Cannot delete the log file"));
       } else {
         res.send({
           error: null,
@@ -99,6 +99,10 @@ const createRouter = (appLog = true) => {
       }
     });
   });
+
+  // Attached to the router itself as well as to the application: see the note
+  // in `routes/model.js`.
+  router.use(errorHandler);
 
   return router;
 };

--- a/src/server/routes/model.js
+++ b/src/server/routes/model.js
@@ -21,6 +21,11 @@ const {
   fileNameParam,
   simulationRunFields,
 } = require("../middleware/validate");
+const {
+  errorHandler,
+  fileError,
+  internal,
+} = require("../middleware/errors");
 const modelsPath = `${__dirname}/../data/models/`;
 let router = express.Router();
 
@@ -65,10 +70,7 @@ const modelUpdateBody = Joi.object({
 router.get("/", validate(), (req, res, next) => {
   readDir(modelsPath, (err, files) => {
     if (err) {
-      console.error("[SERVER]", err);
-      res.send({
-        error: "Cannot read the models directory"
-      });
+      next(internal("Cannot read the models directory", err));
     } else {
       res.send({
         error: null,
@@ -89,10 +91,7 @@ router.get("/:fileName", validate({ params: { fileName: modelNameParam } }), fun
   }
   readJSONFile(modelFile, (err, data) => {
     if (err) {
-      console.error("[SERVER]", err);
-      res.send({
-        error: "Cannot read the model file"
-      });
+      next(fileError(err, "Model not found", "Cannot read the model file"));
     } else {
       res.send({
         error: null,
@@ -102,17 +101,14 @@ router.get("/:fileName", validate({ params: { fileName: modelNameParam } }), fun
   });
 });
 
-const duplicateModel = (fileName, res) => {
+const duplicateModel = (fileName, res, next) => {
   const modelFile = resolveWithin(modelsPath, fileName);
   if (!modelFile) {
     return sendBadRequest(res, "Invalid model name");
   }
   readJSONFile(modelFile, (err, data) => {
     if (err) {
-      console.error("[SERVER]", err);
-      res.send({
-        error: `Cannot read model ${fileName}`
-      });
+      next(fileError(err, "Model not found", "Cannot read the model file"));
     } else {
       const newName = `${data.name} [Duplicated]`;
       const newModel = {...data, name: newName};
@@ -126,10 +122,7 @@ const duplicateModel = (fileName, res) => {
       }
       writeToFile(newFile, JSON.stringify(newModel), (err, dupModel) => {
         if (err) {
-          console.error("[SERVER]", err);
-          res.send({
-            error: "Cannot save the duplicated model"
-          });
+          next(internal("Cannot save the duplicated model", err));
         } else {
           res.send({
             modelFileName: newFileName
@@ -140,7 +133,7 @@ const duplicateModel = (fileName, res) => {
   });
 }
 
-const updateModel = (model, fileName, res) => {
+const updateModel = (model, fileName, res, next) => {
   const {
     name
   } = model;
@@ -161,10 +154,7 @@ const updateModel = (model, fileName, res) => {
   if (fileName === newName) {
     writeToFile(modelFile, JSON.stringify(model), (err, data) => {
       if (err) {
-        console.error("[SERVER]", err);
-        res.send({
-          error: "Cannot save the new configuration"
-        });
+        next(internal("Cannot save the new configuration", err));
       } else {
         res.send({
           modelFileName: fileName
@@ -175,15 +165,14 @@ const updateModel = (model, fileName, res) => {
   else {
     writeToFile(modelFile, JSON.stringify(model), (err, data) => {
       if (err) {
-        console.error("[SERVER]", err);
-        res.send({
-          error: "Cannot save the new configuration"
-        });
+        next(internal("Cannot save the new configuration", err));
       } else {
         // Delete the old model
         deleteFile(oldModelFile, (err2) => {
           if (err2) {
-            console.error(err2);
+            // The new file is already written, so the rename succeeded from the
+            // caller's point of view; the leftover is a server-side problem.
+            console.error(`[SERVER] Cannot remove the renamed model file | ${err2.stack || err2}`);
           }
           res.send({
             modelFileName: newName
@@ -205,10 +194,10 @@ router.post("/:fileName", validate({ params: { fileName: modelNameParam }, body:
   } = req.body;
   if (isDuplicated) {
     // Duplicate the model
-    duplicateModel(fileName, res);
+    duplicateModel(fileName, res, next);
   } else {
     // Update model
-    updateModel(model, fileName, res);
+    updateModel(model, fileName, res, next);
   }  
 });
 
@@ -232,10 +221,7 @@ router.post("/", validate({ body: modelCreateBody }), function (req, res, next) 
   }
   writeToFile(modelFilePath, JSON.stringify(model), (err, data) => {
     if (err) {
-      console.error("[SERVER]", err);
-      res.send({
-        error: "Cannot save the new configuration"
-      });
+      next(internal("Cannot save the new configuration", err));
     } else {
       res.send({
         modelFileName
@@ -255,10 +241,7 @@ router.delete("/:fileName", validate({ params: { fileName: modelNameParam } }), 
   }
   deleteFile(modelFile, (err) => {
     if (err) {
-      console.error("[SERVER]", err);
-      res.send({
-        error: "Cannot delete the model file"
-      });
+      next(fileError(err, "Model not found", "Cannot delete the model file"));
     } else {
       res.send({
         result: true
@@ -266,5 +249,10 @@ router.delete("/:fileName", validate({ params: { fileName: modelNameParam } }), 
     }
   });
 });
+
+// The shared handler is attached to the router itself, not only to the
+// application: a router mounted on its own would otherwise fall through to
+// Express's default error handler, which answers with an HTML stack trace.
+router.use(errorHandler);
 
 module.exports = router;

--- a/src/server/routes/path-safety.js
+++ b/src/server/routes/path-safety.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const { ApiError, sendError } = require("../middleware/errors");
 
 const NAME_MAX_LENGTH = 128;
 
@@ -48,11 +49,13 @@ const resolveWithin = (baseDir, relativePath) => {
 /**
  * Reject a request with a 400-class status and a message that never
  * discloses server-side paths.
+ *
+ * The containment guards are handed a response object alone, with no `next` to
+ * report through, so the refusal is routed to the central error handler
+ * directly. It is still that handler that decides what the body looks like.
  */
 const sendBadRequest = (res, message) => {
-  return res.status(400).send({
-    error: message || "Invalid request",
-  });
+  return sendError(res, new ApiError(400, message || "Invalid request"));
 };
 
 module.exports = {

--- a/src/server/routes/reports.js
+++ b/src/server/routes/reports.js
@@ -10,6 +10,11 @@ const {
   idSchema,
   textSchema,
 } = require("../middleware/validate");
+const {
+  errorHandler,
+  databaseError,
+  notFound,
+} = require("../middleware/errors");
 
 // ---------------------------------------------------------------------------
 // Validation schemas for the report endpoints (issue #10)
@@ -55,11 +60,7 @@ router.get("/", validate({ query: reportQuery }), dbConnector, function (req, re
 
   ReportSchema.findReportsWithOptions(options, (err2, reports) => {
     if (err2) {
-      console.error("[SERVER] Failed to get reports");
-      console.error(err2);
-      res.send({
-        error: "Failed to get reports",
-      });
+      next(databaseError(err2, "Failed to get reports"));
     } else {
       res.send({
         reports,
@@ -68,7 +69,7 @@ router.get("/", validate({ query: reportQuery }), dbConnector, function (req, re
   });
 });
 
-const updateReportScore = (report, res) => {
+const updateReportScore = (report, res, next) => {
   const {
     originalDatasetId,
     newDatasetId,
@@ -84,17 +85,13 @@ const updateReportScore = (report, res) => {
     endTime,
     (err3, originalEvents) => {
       if (err3) {
-        res.send({
-          error: `Cannot get original events of dataset ${originalDatasetId}`,
-        });
+        next(databaseError(err3, "Cannot get the original events of the report"));
       } else {
         EventSchema.findEventsWithOptions(
           { datasetId: newDatasetId },
           (err4, newEvents) => {
             if (err4) {
-              res.send({
-                error: `Cannot get new events of dataset ${newDatasetId}`,
-              });
+              next(databaseError(err4, "Cannot get the new events of the report"));
             } else {
               let newScore = score;
               if (evaluationParameters) {
@@ -121,12 +118,7 @@ const updateReportScore = (report, res) => {
                 {new: true},
                 (err5, ret) => {
                   if (err5) {
-                    console.error(
-                      `Cannot update the score for report ${report._id}`
-                    );
-                    res.send({
-                      error: `Cannot update the score for report ${report._id}`,
-                    });
+                    next(databaseError(err5, "Cannot update the score of the report"));
                   } else {
                     console.log(
                       `Report ${report._id} has score of ${newScore}`
@@ -152,12 +144,11 @@ router.get("/:reportId", validate({ params: { reportId: reportIdParam } }), dbCo
   const { reportId } = req.params;
 
   ReportSchema.findOne({ id: reportId }, (err2, report) => {
-    if (err2 || !report) {
-      console.error("[SERVER] Failed to get reports");
-      console.error(err2);
-      return res.send({
-        error: "Failed to get report",
-      });
+    if (err2) {
+      return next(databaseError(err2, "Failed to get report"));
+    }
+    if (!report) {
+      return next(notFound("Report not found"));
     }
     const { score } = report;
     if (score > -1) {
@@ -165,7 +156,7 @@ router.get("/:reportId", validate({ params: { reportId: reportIdParam } }), dbCo
         report,
       });
     }
-    return updateReportScore(report, res);
+    return updateReportScore(report, res, next);
   });
 });
 
@@ -177,17 +168,17 @@ router.post("/:reportId", validate({ params: { reportId: reportIdParam }, body: 
   const { reportId } = req.params;
   ReportSchema.findByIdAndUpdate(reportId, report, {new: true},(err, ts) => {
     if (err) {
-      console.error("[SERVER] Failed to save a report", err);
-      return res.send({
-        error: "Failed to save a report",
-      });
+      return next(databaseError(err, "Failed to save a report"));
+    }
+    if (!ts) {
+      return next(notFound("Report not found"));
     }
     if (!newScore) {
       return res.send({
         report: ts,
       });
     }
-    return updateReportScore(ts, res);
+    return updateReportScore(ts, res, next);
   });
 });
 
@@ -199,10 +190,7 @@ router.delete("/:reportId", validate({ params: { reportId: reportIdParam } }), d
 
   ReportSchema.findByIdAndDelete(reportId, (err, ret) => {
     if (err) {
-      console.error("[SERVER] Failed to delete a report", err);
-      res.send({
-        error: "Failed to delete a report",
-      });
+      next(databaseError(err, "Failed to delete a report"));
     } else {
       res.send({
         result: ret,
@@ -210,5 +198,9 @@ router.delete("/:reportId", validate({ params: { reportId: reportIdParam } }), d
     }
   });
 });
+
+// Attached to the router itself as well as to the application: see the note in
+// `routes/model.js`.
+router.use(errorHandler);
 
 module.exports = router;

--- a/src/server/routes/simulation.js
+++ b/src/server/routes/simulation.js
@@ -89,6 +89,14 @@ null
  */
 let allSimulationStatus = {};
 let allSimulations = {};
+// The ids whose start is under way. On the default data storage path the run is
+// only registered inside the `getDataStorage` callback, an event-loop turn after
+// the guard below read the registry, so without something held across that turn
+// two concurrent starts of one topology both pass the guard and the first run is
+// left publishing with no handle to stop it. A reservation rather than a
+// placeholder in `allSimulations`: `/stop` calls `stop()` on whatever it finds
+// there.
+const startingSimulations = new Set();
 // Start simulating a model
 
 const startSimulation = (model, options = {}, res, next, modelFileName = null) => {
@@ -108,7 +116,10 @@ const startSimulation = (model, options = {}, res, next, modelFileName = null) =
   // `Simulation` tracks running-ness as `status`, which `start()` sets
   // synchronously; it has no `isRunning`, so the guard this replaces was never
   // true and a topology could be started twice, orphaning the first run.
-  if (allSimulations[simId] && allSimulations[simId].status !== OFFLINE) {
+  if (
+    startingSimulations.has(simId) ||
+    (allSimulations[simId] && allSimulations[simId].status !== OFFLINE)
+  ) {
     // The topology is already in use: the request cannot be applied to the
     // state the resource is in, which is a conflict rather than a fault.
     next(
@@ -122,7 +133,11 @@ const startSimulation = (model, options = {}, res, next, modelFileName = null) =
     getLogger("SIMULATION", `${logsPath}${logFile}`);
     if (!model.dataStorage && !options.dataStorage) {
       // Use default data storage
+      startingSimulations.add(simId);
       getDataStorage((err, ds) => {
+        // Released first, so the reservation cannot outlive the start on either
+        // path, nor if registering the run throws.
+        startingSimulations.delete(simId);
         if (err) {
           next(unavailable("No data storage", err));
         } else {

--- a/src/server/routes/simulation.js
+++ b/src/server/routes/simulation.js
@@ -20,6 +20,13 @@ const {
   fileNameMaxLength,
   simulationRunFields,
 } = require("../middleware/validate");
+const {
+  errorHandler,
+  badRequest,
+  conflict,
+  fileError,
+  unavailable,
+} = require("../middleware/errors");
 
 let router = express.Router();
 const logsPath = `${__dirname}/../logs/simulations/`;
@@ -84,34 +91,31 @@ let allSimulationStatus = {};
 let allSimulations = {};
 // Start simulating a model
 
-const startSimulation = (model, options = {}, res, modelFileName = null) => {
+const startSimulation = (model, options = {}, res, next, modelFileName = null) => {
   // Check if there is a configuration
   if (!model) {
-    console.error("[SERVER]", "Cannot simulate a null model");
-    return res.send({
-      error: "Cannot simulate a null model",
-    });
+    return next(badRequest("Cannot simulate a null model"));
   }
   const { name, devices } = model;
   if (!name || !devices) {
-    return res.send({
-      error: "Invalid model",
-      model: model,
-    });
+    return next(badRequest("Invalid model"));
   }
   if (!isValidName(name)) {
     return sendBadRequest(res, "Invalid model name");
   }
 
   const simId = getObjectId(name);
-  if (allSimulations[simId] && allSimulations[simId].isRunning) {
-    console.error(
-      `[simulation] A running simulation is using this topology (${name}). A topology can be used only in one running simulation`
+  // `Simulation` tracks running-ness as `status`, which `start()` sets
+  // synchronously; it has no `isRunning`, so the guard this replaces was never
+  // true and a topology could be started twice, orphaning the first run.
+  if (allSimulations[simId] && allSimulations[simId].status !== OFFLINE) {
+    // The topology is already in use: the request cannot be applied to the
+    // state the resource is in, which is a conflict rather than a fault.
+    next(
+      conflict(
+        "A running simulation is using this topology. A topology can be used only in one running simulation"
+      )
     );
-    res.send({
-      error:
-        "A running simulation is using this topology. A topology can be used only in one running simulation",
-    });
   } else {
     const startedTime = Date.now();
     const logFile = `${name}_${Date.now()}.log`;
@@ -120,7 +124,7 @@ const startSimulation = (model, options = {}, res, modelFileName = null) => {
       // Use default data storage
       getDataStorage((err, ds) => {
         if (err) {
-          res.send({ error: "No data storage" });
+          next(unavailable("No data storage", err));
         } else {
           const simulation = new Simulation(
             { ...model, dataStorage: ds },
@@ -169,8 +173,6 @@ const startSimulation = (model, options = {}, res, modelFileName = null) => {
 };
 
 router.post("/start", validate({ body: simulationStartBody }), function (req, res, next) {
-  stats = null;
-  simulationStatus = null;
   const { model, modelFileName, options } = req.body;
   if (modelFileName) {
     const modelFilePath = resolveWithin(modelsPath, modelFileName);
@@ -179,14 +181,13 @@ router.post("/start", validate({ body: simulationStartBody }), function (req, re
     }
     readJSONFile(modelFilePath, (err, myModel) => {
       if (err) {
-        console.error(`Cannot read model ${modelFileName}`, err);
-        res.send({ error: `Cannot read model ${modelFileName}` });
+        next(fileError(err, "Model not found", "Cannot read the model file"));
       } else {
-        startSimulation(myModel, options, res, modelFileName);
+        startSimulation(myModel, options, res, next, modelFileName);
       }
     });
   } else {
-    startSimulation(model, options, res);
+    startSimulation(model, options, res, next);
   }
 });
 
@@ -221,12 +222,22 @@ router.get("/status", validate(), (req, res, next) => {
 });
 
 router.get("/stats", validate(), (req, res, next) => {
-  if (!simulation) return res.send({ error: null, stats: null });
-  stats = simulation.getStats();
+  // Read from the registry the rest of this router keeps. It used to read a
+  // `simulation` binding that is never assigned, so every call threw a
+  // ReferenceError and was answered with a stack trace. With more than one run
+  // in progress this reports the first of them, which is as much as the
+  // single-valued response shape can say.
+  const running = Object.keys(allSimulations)
+    .map((simId) => allSimulations[simId])
+    .find((simulation) => simulation && simulation.status !== OFFLINE);
   res.send({
     error: null,
-    stats,
+    stats: running ? running.getStats() : null,
   });
 });
+
+// Attached to the router itself as well as to the application: see the note in
+// `routes/model.js`.
+router.use(errorHandler);
 
 module.exports = router;

--- a/src/server/routes/test-campaigns.js
+++ b/src/server/routes/test-campaigns.js
@@ -13,6 +13,11 @@ const {
   textSchema,
   urlSchema,
 } = require("../middleware/validate");
+const {
+  errorHandler,
+  databaseError,
+  notFound,
+} = require("../middleware/errors");
 
 // ---------------------------------------------------------------------------
 // Validation schemas for the test-campaign endpoints (issue #10)
@@ -44,10 +49,7 @@ const testCampaignUpdateBody = Joi.object({
 router.get("/", validate(), dbConnector, function (req, res, next) {
   TestCampaignSchema.find((err2, testCampaigns) => {
     if (err2) {
-      console.error('[SERVER] Failed to get testCampaigns', err2);
-      res.send({
-        error: 'Failed to get test campaign'
-      });
+      next(databaseError(err2, 'Failed to get test campaign'));
     } else {
       res.send({
         testCampaigns
@@ -79,10 +81,7 @@ router.post("/", validate({ body: testCampaignCreateBody }), dbConnector, functi
   });
   newtestCampaign.save((err, _testCampaign) => {
     if (err) {
-      console.error('[SERVER] Failed to save the test campaigns', err);
-      res.send({
-        error: 'Failed to save the test campaign'
-      });
+      next(databaseError(err, 'Failed to save the test campaign'));
     } else {
       res.send({
         testCampaign: _testCampaign
@@ -101,10 +100,9 @@ router.get("/:testCampaignId", validate({ params: { testCampaignId: testCampaign
 
   TestCampaignSchema.findOne({id: testCampaignId}, (err2, testCampaign) => {
     if (err2) {
-      console.error('[SERVER] Failed to get testCampaigns', err2);
-      res.send({
-        error: 'Failed to get test campaign'
-      });
+      next(databaseError(err2, 'Failed to get test campaign'));
+    } else if (!testCampaign) {
+      next(notFound('Test campaign not found'));
     } else {
       res.send({
         testCampaign
@@ -126,10 +124,7 @@ router.post("/:testCampaignId", validate({ params: { testCampaignId: testCampaig
 
   TestCampaignSchema.findOneAndUpdate({id: testCampaignId}, testCampaign, (err, ts) => {
     if (err) {
-      console.error('[SERVER] Failed to save the test campaigns', err);
-      res.send({
-        error: 'Failed to save the test campaign'
-      });
+      next(databaseError(err, 'Failed to save the test campaign'));
     } else {
       res.send({
         testCampaign: ts
@@ -148,10 +143,7 @@ router.delete("/:testCampaignId", validate({ params: { testCampaignId: testCampa
 
   TestCampaignSchema.findOneAndDelete({id: testCampaignId}, (err, ret) => {
     if (err) {
-      console.error('[SERVER] Failed to delete the test campaign', err);
-      res.send({
-        error: 'Failed to delete the test campaign'
-      });
+      next(databaseError(err, 'Failed to delete the test campaign'));
     } else {
       res.send({
         result: ret
@@ -159,5 +151,9 @@ router.delete("/:testCampaignId", validate({ params: { testCampaignId: testCampa
     }
   });
 });
+
+// Attached to the router itself as well as to the application: see the note in
+// `routes/model.js`.
+router.use(errorHandler);
 
 module.exports = router;

--- a/src/server/routes/test-cases.js
+++ b/src/server/routes/test-cases.js
@@ -18,6 +18,11 @@ const {
   idSchema,
   textSchema,
 } = require("../middleware/validate");
+const {
+  errorHandler,
+  databaseError,
+  notFound,
+} = require("../middleware/errors");
 
 // ---------------------------------------------------------------------------
 // Validation schemas for the test-case endpoints (issue #10)
@@ -94,10 +99,7 @@ const containModelFileName = (req, res, next) => {
 router.get("/", validate(), dbConnector, function (req, res, next) {
   TestCaseSchema.find((err2, testCases) => {
     if (err2) {
-      console.error('[SERVER] Failed to get testcases', err2);
-      res.send({
-        error: 'Failed to get test case'
-      });
+      next(databaseError(err2, 'Failed to get test case'));
     } else {
       res.send({
         testCases
@@ -116,10 +118,9 @@ router.get("/:testCaseId", validate({ params: { testCaseId: testCaseIdParam } })
 
   TestCaseSchema.findOne({id: testCaseId}, (err2, testCase) => {
     if (err2) {
-      console.error('[SERVER] Failed to get testcases', err2);
-      res.send({
-        error: 'Failed to get test case'
-      });
+      next(databaseError(err2, 'Failed to get test case'));
+    } else if (!testCase) {
+      next(notFound('Test case not found'));
     } else {
       res.send({
         testCase
@@ -150,10 +151,7 @@ router.post("/", validate({ body: testCaseCreateBody }), containModelFileName, d
   });
   newTestCase.save((err, _testCase) => {
     if (err) {
-      console.error('[SERVER] Failed to save the test cases', err);
-      res.send({
-        error: 'Failed to save the test case'
-      });
+      next(databaseError(err, 'Failed to save the test case'));
     } else {
       res.send({
         testCase: _testCase
@@ -183,10 +181,7 @@ router.post("/:testCaseId", validate({ params: { testCaseId: testCaseIdParam }, 
 
   TestCaseSchema.findOneAndUpdate({id: testCaseId}, update, (err, ts) => {
     if (err) {
-      console.error('[SERVER] Failed to save the test cases', err);
-      res.send({
-        error: 'Failed to save the test case'
-      });
+      next(databaseError(err, 'Failed to save the test case'));
     } else {
       res.send({
         testCase: ts
@@ -205,10 +200,7 @@ router.delete("/:testCaseId", validate({ params: { testCaseId: testCaseIdParam }
 
   TestCaseSchema.findOneAndDelete({id: testCaseId}, (err, ret) => {
     if (err) {
-      console.error('[SERVER] Failed to save the test cases', err);
-      res.send({
-        error: 'Failed to save the test case'
-      });
+      next(databaseError(err, 'Failed to delete the test case'));
     } else {
       res.send({
         result: ret
@@ -216,5 +208,9 @@ router.delete("/:testCaseId", validate({ params: { testCaseId: testCaseIdParam }
     }
   });
 });
+
+// Attached to the router itself as well as to the application: see the note in
+// `routes/model.js`.
+router.use(errorHandler);
 
 module.exports = router;

--- a/test/http-status.test.js
+++ b/test/http-status.test.js
@@ -45,6 +45,7 @@ const {
 
 const devopsFile = path.resolve(__dirname, "../src/server/data/devops.json");
 const simulationLogsDir = path.resolve(__dirname, "../src/server/logs/simulations");
+const recorderLogsDir = path.resolve(__dirname, "../src/server/logs/data-recorders");
 
 let server;
 let app;
@@ -57,6 +58,7 @@ before(() => {
   // directory does not exist and a missing *file* would be indistinguishable
   // from a missing directory.
   fs.mkdirSync(simulationLogsDir, { recursive: true });
+  fs.mkdirSync(recorderLogsDir, { recursive: true });
 
   app = express();
   app.use(express.json());
@@ -80,6 +82,25 @@ after(() => {
 });
 
 const unique = (prefix) => `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+/**
+ * Remove the run log a start leaves behind.
+ *
+ * Every start opens `<name>_<timestamp>.log` through `getLogger`, and nothing in
+ * the server ever removes it, so a test that starts something has to take its
+ * own files away again.
+ */
+const removeRunLogs = (dir, name) => {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir);
+  } catch (e) {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.startsWith(`${name}_`)) fs.unlinkSync(path.join(dir, entry));
+  }
+};
 
 /**
  * Text that must never appear in a response body: this checkout's own location
@@ -152,6 +173,24 @@ const probeApp = () => {
   probe.get("/thrown", () => {
     throw new Error("boom at /home/secret/src/server/routes/model.js");
   });
+  // Failures that arrive already carrying a status, the way Express's router
+  // and anything built on `http-errors` report one.
+  probe.get("/carries-400", (req, res, next) =>
+    next(
+      Object.assign(new URIError("Failed to decode param '%zz' at /home/secret/x"), {
+        status: 400,
+      })
+    )
+  );
+  probe.get("/carries-415", (req, res, next) =>
+    next(Object.assign(new Error("unsupported at /home/secret/x"), { statusCode: 415 }))
+  );
+  probe.get("/carries-503", (req, res, next) =>
+    next(Object.assign(new Error("upstream down at /home/secret/x"), { status: 503 }))
+  );
+  probe.get("/carries-nonsense", (req, res, next) =>
+    next(Object.assign(new Error("nonsense at /home/secret/x"), { status: "400" }))
+  );
   probe.use(errorHandler);
   return probe;
 };
@@ -212,6 +251,54 @@ test("an unclassified failure is reported as a bare 500 that discloses nothing",
     }
   } finally {
     probe.close();
+  }
+});
+
+test("a failure that already carries a 4xx keeps it, with a message of ours", async () => {
+  // The status is the only thing an unclassified failure is trusted about, and
+  // only when it is a 4xx: reporting a caller's mistake as a server fault is
+  // what makes a monitor alert on client garbage. Everything else - the message
+  // above all, which is where the internals are named - is still ours to choose.
+  const probe = probeApp().listen(0);
+  try {
+    const kept = [
+      ["/carries-400", 400, "Bad request"],
+      ["/carries-415", 415, "Unsupported media type"],
+    ];
+    for (const [routePath, status, message] of kept) {
+      const res = await request(probe, "GET", routePath);
+      assertErrorShape(res, status, `GET ${routePath}`);
+      assert.equal(res.body.error, message, `GET ${routePath} must not echo its own message`);
+      assert.ok(!res.raw.includes("secret"), `must not echo the underlying error: ${res.raw}`);
+    }
+    // A 5xx a library chose says no more than the bare 500 already does, and a
+    // status that is not an integer in the 4xx range is not a classification.
+    for (const routePath of ["/carries-503", "/carries-nonsense"]) {
+      const res = await request(probe, "GET", routePath);
+      assertErrorShape(res, 500, `GET ${routePath}`);
+      assert.equal(
+        res.body.error,
+        INTERNAL_MESSAGE,
+        `only a 4xx may be taken from an unclassified failure: ${res.raw}`
+      );
+    }
+  } finally {
+    probe.close();
+  }
+});
+
+test("a path whose percent-encoding cannot be decoded answers 400, not 500", async () => {
+  // Express's router raises a `URIError` carrying `status: 400` when a path
+  // segment cannot be decoded. It never reaches a route, so the shared handler
+  // is the only thing that can answer it - and what the caller sent is
+  // unambiguously the caller's fault.
+  for (const routePath of [
+    "/api/models/%E0%A4%A",
+    "/api/models/%",
+    "/api/models/%zz.json",
+  ]) {
+    const res = await request(server, "GET", routePath);
+    assertErrorShape(res, 400, `GET ${routePath}`);
   }
 });
 
@@ -612,4 +699,95 @@ test("the error class never lets an unsafe message through by accident", () => {
     err.cause.message,
     "the caller-facing message must not be the underlying one"
   );
+});
+
+// ---------------------------------------------------------------------------
+// 8. A start that would orphan a run is refused, however the two arrive
+// ---------------------------------------------------------------------------
+
+test("a topology already running refuses a second start, and starts again once stopped", async () => {
+  const name = unique("running-topology");
+  const body = { model: { name, devices: [] }, options: {} };
+  try {
+    const first = await request(server, "POST", "/api/simulation/start", body);
+    assert.equal(first.status, 200, `the first start must be served (${first.raw})`);
+
+    const second = await request(server, "POST", "/api/simulation/start", body);
+    assertErrorShape(second, 409, "starting a topology that is already running");
+
+    const stopped = await request(server, "GET", `/api/simulation/stop/${name}.json`);
+    assert.equal(stopped.status, 200, `the run must be stoppable (${stopped.raw})`);
+
+    // The guard refuses a second run, not the topology: once the first one is
+    // stopped the same model must be startable again.
+    const third = await request(server, "POST", "/api/simulation/start", body);
+    assert.equal(third.status, 200, `a stopped topology must start again (${third.raw})`);
+  } finally {
+    await request(server, "GET", `/api/simulation/stop/${name}.json`);
+    removeRunLogs(simulationLogsDir, name);
+  }
+});
+
+test("two concurrent starts of one topology cannot both be served", async () => {
+  // The run is registered inside the `getDataStorage` callback, so the window
+  // this pins open exists only while the default data storage has not been read
+  // yet - it is cached from the first read onwards and answers synchronously
+  // after that. A freshly required router and connector put the pair back in
+  // the state a running server is in when the first start of the day arrives.
+  const routerPath = require.resolve("../src/server/routes/simulation");
+  const connectorPath = require.resolve("../src/server/routes/db-connector");
+  delete require.cache[routerPath];
+  delete require.cache[connectorPath];
+  const coldRouter = require(routerPath);
+  delete require.cache[routerPath];
+  delete require.cache[connectorPath];
+
+  const coldApp = express();
+  coldApp.use(express.json());
+  coldApp.use("/api/simulation", coldRouter);
+  const coldServer = coldApp.listen(0);
+  const name = unique("race-topology");
+  const body = { model: { name, devices: [] }, options: {} };
+  try {
+    const answers = await Promise.all([
+      request(coldServer, "POST", "/api/simulation/start", body),
+      request(coldServer, "POST", "/api/simulation/start", body),
+    ]);
+    assert.deepEqual(
+      answers.map((answer) => answer.status).sort(),
+      [200, 409],
+      `exactly one of two concurrent starts may be served: ${answers
+        .map((answer) => answer.raw)
+        .join(" | ")}`
+    );
+    const refused = answers.find((answer) => answer.status === 409);
+    assertErrorShape(refused, 409, "the second of two concurrent starts");
+  } finally {
+    await request(coldServer, "GET", `/api/simulation/stop/${name}.json`);
+    coldServer.close();
+    removeRunLogs(simulationLogsDir, name);
+  }
+});
+
+test("a data recorder already running refuses a second start", async () => {
+  const name = unique("running-recorder");
+  const body = { model: { name, dataRecorders: [] } };
+  try {
+    const first = await request(server, "POST", "/api/data-recorders/start", body);
+    assert.equal(first.status, 200, `the first start must be served (${first.raw})`);
+
+    const second = await request(server, "POST", "/api/data-recorders/start", body);
+    assertErrorShape(second, 409, "starting a recorder that is already running");
+  } finally {
+    await request(server, "GET", `/api/data-recorders/stop/${name}.json`);
+    removeRunLogs(recorderLogsDir, name);
+    // A recorder connects to the configured data storage as it starts, and
+    // `DataRecorder.stop()` closes only a client that finished connecting.
+    // There is no database here, so the attempt is still outstanding and holds
+    // this process open for the driver's whole server-selection timeout.
+    // Closed through the driver's client rather than `mongoose.disconnect()`,
+    // which waits for the very connection it is trying to close.
+    const client = require("mongoose").connection.client;
+    if (client) client.close(true, () => {});
+  }
 });

--- a/test/http-status.test.js
+++ b/test/http-status.test.js
@@ -791,3 +791,50 @@ test("a data recorder already running refuses a second start", async () => {
     if (client) client.close(true, () => {});
   }
 });
+
+test("two concurrent starts of one data recorder cannot both be served", async () => {
+  // As with the simulation above: the recorder is registered inside the
+  // `getDataStorage` callback, so the window this pins open exists only while
+  // the default data storage has not been read yet - it is cached from the
+  // first read onwards and answers synchronously after that. A freshly
+  // required router and connector put the pair back in the state a running
+  // server is in when the first start of the day arrives.
+  const routerPath = require.resolve("../src/server/routes/data-recorders");
+  const connectorPath = require.resolve("../src/server/routes/db-connector");
+  delete require.cache[routerPath];
+  delete require.cache[connectorPath];
+  const coldRouter = require(routerPath);
+  delete require.cache[routerPath];
+  delete require.cache[connectorPath];
+
+  const coldApp = express();
+  coldApp.use(express.json());
+  coldApp.use("/api/data-recorders", coldRouter);
+  const coldServer = coldApp.listen(0);
+  const name = unique("race-recorder");
+  const body = { model: { name, dataRecorders: [] } };
+  try {
+    const answers = await Promise.all([
+      request(coldServer, "POST", "/api/data-recorders/start", body),
+      request(coldServer, "POST", "/api/data-recorders/start", body),
+    ]);
+    assert.deepEqual(
+      answers.map((answer) => answer.status).sort(),
+      [200, 409],
+      `exactly one of two concurrent starts may be served: ${answers
+        .map((answer) => answer.raw)
+        .join(" | ")}`
+    );
+    const refused = answers.find((answer) => answer.status === 409);
+    assertErrorShape(refused, 409, "the second of two concurrent starts");
+  } finally {
+    await request(coldServer, "GET", `/api/data-recorders/stop/${name}.json`);
+    coldServer.close();
+    removeRunLogs(recorderLogsDir, name);
+    // See the note in the test above: the connection this start opened is
+    // still outstanding, and nothing in the server closes one that never
+    // finished opening.
+    const client = require("mongoose").connection.client;
+    if (client) client.close(true, () => {});
+  }
+});

--- a/test/http-status.test.js
+++ b/test/http-status.test.js
@@ -1,0 +1,615 @@
+/**
+ * HTTP status semantics and error disclosure (issue #11).
+ *
+ * The API used to answer 200 for everything and signal failure only with an
+ * `error` field, so a client, a proxy or a monitor could not tell a served
+ * request from a failed one without parsing the body — and some failures
+ * carried the raw underlying error, which discloses absolute server paths.
+ *
+ * These tests pin the four properties that fixes that: conventional status
+ * codes, one error shape from one central handler, nothing internal in the
+ * body, and the full detail still in the log.
+ */
+const { test, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const express = require("express");
+const { request } = require("./_http");
+const { startApp } = require("./helpers/start-app");
+
+const modelRouter = require("../src/server/routes/model");
+const dataRecorderRouter = require("../src/server/routes/data-recorders");
+const simulationRouter = require("../src/server/routes/simulation");
+const createLogRouter = require("../src/server/routes/logs");
+const testCasesRouter = require("../src/server/routes/test-cases");
+const testCampaignRouter = require("../src/server/routes/test-campaigns");
+const dataSetRouter = require("../src/server/routes/data-sets");
+const eventRouter = require("../src/server/routes/events");
+const reportRouter = require("../src/server/routes/reports");
+const dataStorageRouter = require("../src/server/routes/data-storage");
+const devopsRouter = require("../src/server/routes/devops");
+const {
+  ApiError,
+  badRequest,
+  forbidden,
+  notFound,
+  conflict,
+  unavailable,
+  internal,
+  databaseError,
+  fileError,
+  errorHandler,
+  INTERNAL_MESSAGE,
+} = require("../src/server/middleware/errors");
+
+const devopsFile = path.resolve(__dirname, "../src/server/data/devops.json");
+const simulationLogsDir = path.resolve(__dirname, "../src/server/logs/simulations");
+
+let server;
+let app;
+let originalDevops;
+
+before(() => {
+  // One test below makes the devops configuration unreadable on purpose.
+  originalDevops = fs.readFileSync(devopsFile, "utf8");
+  // Nothing under src/server/logs is tracked, so on a fresh checkout the
+  // directory does not exist and a missing *file* would be indistinguishable
+  // from a missing directory.
+  fs.mkdirSync(simulationLogsDir, { recursive: true });
+
+  app = express();
+  app.use(express.json());
+  app.use("/api/models", modelRouter);
+  app.use("/api/data-recorders", dataRecorderRouter);
+  app.use("/api/simulation", simulationRouter);
+  app.use("/api/logs/simulations", createLogRouter("simulations"));
+  app.use("/api/test-cases", testCasesRouter);
+  app.use("/api/test-campaigns", testCampaignRouter);
+  app.use("/api/data-sets", dataSetRouter);
+  app.use("/api/events", eventRouter);
+  app.use("/api/reports", reportRouter);
+  app.use("/api/data-storage", dataStorageRouter);
+  app.use("/api/devops", devopsRouter);
+  server = app.listen(0);
+});
+
+after(() => {
+  server.close();
+  if (originalDevops !== undefined) fs.writeFileSync(devopsFile, originalDevops);
+});
+
+const unique = (prefix) => `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+/**
+ * Text that must never appear in a response body: this checkout's own location
+ * (derived, so the check still means something wherever CI puts it), the shape
+ * of a raw fs error, and the shape of a stack trace.
+ */
+const repoRoot = path.resolve(__dirname, "..");
+const DISCLOSURES = [
+  repoRoot,
+  path.dirname(repoRoot),
+  "ENOENT",
+  "no such file",
+  "at Object.",
+  "at Function.",
+  "node_modules",
+  "node:internal",
+];
+
+/**
+ * Assert an error response is the one shape the API has, and that it carries
+ * nothing but that shape.
+ */
+const assertErrorShape = (res, status, context) => {
+  assert.equal(res.status, status, `expected ${status} for ${context}, got ${res.status} (${res.raw})`);
+  assert.ok(res.body, `${context} must answer with a JSON body (${res.raw})`);
+  assert.equal(typeof res.body.error, "string", `${context} must carry a string error (${res.raw})`);
+  assert.ok(res.body.error.length > 0, `${context} must carry a message (${res.raw})`);
+  assert.deepEqual(
+    Object.keys(res.body).filter((key) => key !== "error" && key !== "details"),
+    [],
+    `an error body carries nothing but error and details: ${res.raw}`
+  );
+  for (const disclosure of DISCLOSURES) {
+    assert.ok(
+      !res.raw.includes(disclosure),
+      `${context} must not disclose ${disclosure}: ${res.raw}`
+    );
+  }
+};
+
+// ---------------------------------------------------------------------------
+// 1. One central handler, one shape, one status per kind of failure
+// ---------------------------------------------------------------------------
+
+/**
+ * A probe application whose only job is to hand a failure to `next`, so the
+ * handler's own behaviour is asserted rather than inferred from a route that
+ * happens to reach it.
+ */
+const probeApp = () => {
+  const probe = express();
+  probe.use(express.json());
+  probe.get("/bad-request", (req, res, next) => next(badRequest("Invalid request")));
+  probe.get("/bad-request-details", (req, res, next) =>
+    next(badRequest("Validation failed", [{ location: "body", field: "a", message: "m", type: "t" }]))
+  );
+  probe.get("/forbidden", (req, res, next) => next(forbidden("Origin not allowed")));
+  probe.get("/not-found", (req, res, next) => next(notFound("Model not found")));
+  probe.get("/conflict", (req, res, next) => next(conflict("Already running")));
+  probe.get("/unavailable", (req, res, next) => next(unavailable("Database is unavailable")));
+  probe.get("/internal", (req, res, next) => next(internal("Cannot save the new configuration")));
+  // An error nobody classified, carrying exactly the kind of detail a raw fs
+  // error carries.
+  probe.get("/unclassified", (req, res, next) => {
+    const err = new Error("ENOENT: no such file or directory, open '/home/secret/data/devops.json'");
+    err.code = "ENOENT";
+    err.path = "/home/secret/data/devops.json";
+    next(err);
+  });
+  probe.get("/thrown", () => {
+    throw new Error("boom at /home/secret/src/server/routes/model.js");
+  });
+  probe.use(errorHandler);
+  return probe;
+};
+
+test("each kind of failure answers with its conventional status code", async () => {
+  const probe = probeApp().listen(0);
+  try {
+    const cases = [
+      ["/bad-request", 400],
+      ["/forbidden", 403],
+      ["/not-found", 404],
+      ["/conflict", 409],
+      ["/unavailable", 503],
+      ["/internal", 500],
+    ];
+    for (const [routePath, status] of cases) {
+      const res = await request(probe, "GET", routePath);
+      assertErrorShape(res, status, `GET ${routePath}`);
+    }
+  } finally {
+    probe.close();
+  }
+});
+
+test("a validation failure keeps its machine-readable details, and nothing else does", async () => {
+  const probe = probeApp().listen(0);
+  try {
+    const withDetails = await request(probe, "GET", "/bad-request-details");
+    assertErrorShape(withDetails, 400, "a failure carrying details");
+    assert.equal(withDetails.body.error, "Validation failed");
+    assert.deepEqual(withDetails.body.details, [
+      { location: "body", field: "a", message: "m", type: "t" },
+    ]);
+
+    const withoutDetails = await request(probe, "GET", "/not-found");
+    assert.equal(
+      "details" in withoutDetails.body,
+      false,
+      `a failure with no per-field detail must not invent one: ${withoutDetails.raw}`
+    );
+  } finally {
+    probe.close();
+  }
+});
+
+test("an unclassified failure is reported as a bare 500 that discloses nothing", async () => {
+  const probe = probeApp().listen(0);
+  try {
+    for (const routePath of ["/unclassified", "/thrown"]) {
+      const res = await request(probe, "GET", routePath);
+      assertErrorShape(res, 500, `GET ${routePath}`);
+      assert.equal(
+        res.body.error,
+        INTERNAL_MESSAGE,
+        `an unclassified failure must not echo its own message: ${res.raw}`
+      );
+      assert.ok(!res.raw.includes("secret"), `must not echo the underlying error: ${res.raw}`);
+    }
+  } finally {
+    probe.close();
+  }
+});
+
+test("every router renders its failures through the shared handler", async () => {
+  // A router mounted on its own - which is how these suites mount them, and
+  // how a future host might - must not fall through to Express's default error
+  // handler, which answers with an HTML stack trace.
+  const routers = [
+    ["models", modelRouter],
+    ["data-recorders", dataRecorderRouter],
+    ["simulation", simulationRouter],
+    ["logs", createLogRouter("simulations")],
+    ["test-cases", testCasesRouter],
+    ["test-campaigns", testCampaignRouter],
+    ["data-sets", dataSetRouter],
+    ["events", eventRouter],
+    ["reports", reportRouter],
+    ["data-storage", dataStorageRouter],
+    ["devops", devopsRouter],
+  ];
+  const missing = [];
+  for (const [name, router] of routers) {
+    // Last, not merely present: Express resumes error dispatch at the layer the
+    // failure came from, so a handler registered ahead of a route would be
+    // skipped for exactly the failures it exists to catch.
+    const last = router.stack[router.stack.length - 1];
+    const attached =
+      last && !last.route && last.handle && last.handle.name === "errorHandler";
+    if (!attached) missing.push(name);
+  }
+  assert.deepEqual(
+    missing,
+    [],
+    "these routers do not end with the shared error handler"
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 2. Missing resources answer 404 rather than 200 with an error field
+// ---------------------------------------------------------------------------
+
+test("reading a model that does not exist answers 404", async () => {
+  const res = await request(server, "GET", `/api/models/${unique("absent")}.json`);
+  assertErrorShape(res, 404, "GET a model that does not exist");
+  assert.equal(res.body.error, "Model not found");
+});
+
+test("deleting a model that does not exist answers 404", async () => {
+  const res = await request(server, "DELETE", `/api/models/${unique("absent")}.json`);
+  assertErrorShape(res, 404, "DELETE a model that does not exist");
+});
+
+test("reading a data recorder that does not exist answers 404", async () => {
+  const res = await request(
+    server,
+    "GET",
+    `/api/data-recorders/models/${unique("absent")}.json`
+  );
+  assertErrorShape(res, 404, "GET a data recorder that does not exist");
+  assert.equal(res.body.error, "Data recorder not found");
+});
+
+test("reading and deleting a log that does not exist answers 404", async () => {
+  const fileName = `${unique("absent")}_${Date.now()}.log`;
+  const read = await request(server, "GET", `/api/logs/simulations/${fileName}`);
+  assertErrorShape(read, 404, "GET a log that does not exist");
+  assert.equal(read.body.error, "Log file not found");
+
+  const removed = await request(server, "DELETE", `/api/logs/simulations/${fileName}`);
+  assertErrorShape(removed, 404, "DELETE a log that does not exist");
+});
+
+test("starting a simulation from a model that does not exist answers 404", async () => {
+  const res = await request(server, "POST", "/api/simulation/start", {
+    modelFileName: `${unique("absent")}.json`,
+  });
+  assertErrorShape(res, 404, "POST /api/simulation/start with an absent model");
+});
+
+test("starting a data recorder that does not exist answers 404", async () => {
+  const res = await request(server, "POST", "/api/data-recorders/start", {
+    dataRecorderFileName: `${unique("absent")}.json`,
+  });
+  assertErrorShape(res, 404, "POST /api/data-recorders/start with an absent recorder");
+});
+
+// ---------------------------------------------------------------------------
+// 3. Validation failures keep their 400 and their shape, through the handler
+// ---------------------------------------------------------------------------
+
+test("a validation failure is still a 400 carrying the fields it refused", async () => {
+  const res = await request(server, "POST", "/api/models", {
+    model: { name: 42, devices: [] },
+  });
+  assertErrorShape(res, 400, "POST /api/models with a mistyped name");
+  assert.equal(res.body.error, "Validation failed");
+  assert.equal(res.body.details[0].field, "model.name");
+});
+
+test("an event that the database would refuse is refused with a 400 naming the field", async () => {
+  // `EventSchema` declares `values` and `isSensorData` required, so a create
+  // that omits either used to be accepted, fail at the save, and be reported as
+  // 200 with "Failed to save the event" - a rejected write behind a success
+  // status, which is exactly what this issue is about.
+  const base = {
+    timestamp: 1591971273868,
+    topic: "enact/sensors/temp-03",
+    datasetId: "ds-1",
+    isSensorData: true,
+    values: { temp: 20 },
+  };
+  const omissions = [
+    ["values", "event.values"],
+    ["isSensorData", "event.isSensorData"],
+  ];
+  for (const [omitted, field] of omissions) {
+    const event = { ...base };
+    delete event[omitted];
+    const res = await request(server, "POST", "/api/events", { event });
+    assertErrorShape(res, 400, `POST /api/events without ${omitted}`);
+    assert.equal(res.body.error, "Validation failed");
+    assert.ok(
+      res.body.details.some((detail) => detail.field === field),
+      `the refusal must name ${field}: ${res.raw}`
+    );
+  }
+});
+
+test("a database failure the schemas cannot express maps onto its own status", async () => {
+  // The backstop for a constraint only the database knows about: a rejected
+  // document is the caller's fault (400) and a duplicate key is a conflict
+  // (409), neither of which may be reported as a success or as a 500.
+  const cast = Object.assign(new Error("Cast to ObjectId failed"), { name: "CastError" });
+  assert.equal(databaseError(cast, "Failed to get event").status, 400);
+  const invalid = Object.assign(new Error("validation failed"), { name: "ValidationError" });
+  assert.equal(databaseError(invalid, "Failed to save the event").status, 400);
+  const duplicate = Object.assign(new Error("E11000 duplicate key"), { code: 11000 });
+  assert.equal(databaseError(duplicate, "Failed to save the event").status, 409);
+  const unknown = new Error("connection reset");
+  const mapped = databaseError(unknown, "Failed to save the event");
+  assert.equal(mapped.status, 500);
+  assert.equal(mapped.message, "Failed to save the event");
+
+  // A file that is not there is a missing resource; anything else is ours.
+  const missing = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+  assert.equal(fileError(missing, "Model not found", "Cannot read").status, 404);
+  const denied = Object.assign(new Error("EACCES"), { code: "EACCES" });
+  assert.equal(fileError(denied, "Model not found", "Cannot read").status, 500);
+});
+
+// ---------------------------------------------------------------------------
+// 4. Internal failures answer 5xx, disclose nothing, and stay in the log
+// ---------------------------------------------------------------------------
+
+test("an unreadable server configuration answers 500 and keeps the detail in the log", async () => {
+  // A Node fs error carries the absolute path it failed to open in its own
+  // enumerable properties. The response must carry a constant message, and the
+  // log must still carry enough to diagnose it.
+  const modulePath = require.resolve("../src/server/routes/devops");
+  const lines = [];
+  const realConsoleError = console.error;
+  fs.unlinkSync(devopsFile);
+  delete require.cache[modulePath];
+  const coldApp = express();
+  coldApp.use(express.json());
+  coldApp.use("/api/devops", require(modulePath));
+  const coldServer = coldApp.listen(0);
+  console.error = (message) => lines.push(String(message));
+  let res;
+  try {
+    res = await request(coldServer, "GET", "/api/devops");
+  } finally {
+    console.error = realConsoleError;
+    coldServer.close();
+    fs.writeFileSync(devopsFile, originalDevops);
+    delete require.cache[modulePath];
+  }
+
+  assertErrorShape(res, 500, "GET /api/devops with an unreadable configuration");
+  assert.equal(res.body.error, "Cannot get devops configuration");
+  assert.ok(!res.raw.includes("devops.json"), `must not disclose the config path: ${res.raw}`);
+
+  const logged = lines.join("\n");
+  assert.ok(logged.includes("GET /api/devops"), `the log must name the request: ${logged}`);
+  assert.ok(logged.includes("500"), `the log must carry the status: ${logged}`);
+  assert.ok(
+    logged.includes("ENOENT") && logged.includes("devops.json"),
+    `the log must keep the detail the response no longer carries: ${logged}`
+  );
+});
+
+test("the log keeps the detail of every failure, in one line the file logger keeps", async () => {
+  // `logger/index.js` replaces console.error with a single-argument function,
+  // so a handler that logged the error as a second argument would drop exactly
+  // the detail it removed from the response.
+  const probe = probeApp().listen(0);
+  const lines = [];
+  const realConsoleError = console.error;
+  console.error = (...args) => lines.push(args);
+  try {
+    await request(probe, "GET", "/unclassified");
+  } finally {
+    console.error = realConsoleError;
+    probe.close();
+  }
+  assert.equal(lines.length, 1, "one failure must produce one log line");
+  assert.equal(lines[0].length, 1, "the whole detail must be in the first argument");
+  const logged = String(lines[0][0]);
+  assert.ok(logged.includes("/home/secret"), `the log must keep the path: ${logged}`);
+  assert.ok(logged.includes("ENOENT"), `the log must keep the cause: ${logged}`);
+});
+
+test("the simulation stats endpoint answers rather than throwing", async () => {
+  // It used to read a binding that is never assigned, so every call threw a
+  // ReferenceError and was answered with a stack trace. Nothing is running
+  // here, so the value is null; what this pins is that the endpoint answers at
+  // all, and answers with the shape the dashboard reads.
+  const res = await request(server, "GET", "/api/simulation/stats");
+  assert.equal(res.status, 200, `stats must be served (${res.raw})`);
+  assert.ok("stats" in res.body, `stats must be reported (${res.raw})`);
+  assert.equal(res.body.error, null);
+});
+
+test("a run is recognised as running by the state the simulation actually keeps", () => {
+  // The registry is module-private, so the predicate is asserted against the
+  // class it reads: `Simulation` has no `isRunning` - it tracks `status` - and a
+  // check for a property that does not exist is never true, which is what made
+  // the conflict guard and the stats lookup silently dead.
+  const Simulation = require("../src/core/simulation");
+  const { OFFLINE, SIMULATING } = require("../src/core/DeviceStatus");
+  const simulation = new Simulation({ name: "iv-stats", devices: [] }, {});
+  assert.equal(
+    simulation.isRunning,
+    undefined,
+    "a guard on isRunning would never fire"
+  );
+  assert.equal(simulation.status, OFFLINE, "a fresh run is not running");
+  simulation.start();
+  try {
+    assert.equal(simulation.status, SIMULATING, "start() must mark the run running");
+    assert.notEqual(simulation.status, OFFLINE);
+  } finally {
+    simulation.stop();
+  }
+  assert.equal(simulation.status, OFFLINE, "stop() must mark the run stopped");
+});
+
+// ---------------------------------------------------------------------------
+// 5. The application as a whole: unknown paths, malformed bodies
+// ---------------------------------------------------------------------------
+
+test("the running application refuses unknown API paths and malformed bodies as JSON", async () => {
+  const ctx = await startApp({
+    SERVER_HOST: "127.0.0.1",
+    RATE_LIMIT_MAX: "10000",
+  });
+  try {
+    const unknown = await request(ctx.server, "GET", "/api/not-a-real-endpoint");
+    assertErrorShape(unknown, 404, "GET an API path no router claims");
+    assert.ok(
+      !unknown.raw.includes("<!DOCTYPE"),
+      `an unknown API path must not be answered with the dashboard: ${unknown.raw}`
+    );
+
+    const unknownPost = await request(ctx.server, "POST", "/api/not-a-real-endpoint", { a: 1 });
+    assertErrorShape(unknownPost, 404, "POST an API path no router claims");
+
+    // The dashboard itself is still served for everything else.
+    const dashboard = await request(ctx.server, "GET", "/some/client/route");
+    assert.equal(dashboard.status, 200, "the single-page app must still be served");
+  } finally {
+    ctx.server.close();
+    ctx.restore();
+  }
+});
+
+test("a malformed JSON body is refused with a JSON 400, not an HTML stack trace", async () => {
+  const ctx = await startApp({
+    SERVER_HOST: "127.0.0.1",
+    RATE_LIMIT_MAX: "10000",
+  });
+  try {
+    const res = await new Promise((resolve, reject) => {
+      const http = require("node:http");
+      const payload = '{"model": ';
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port: ctx.port,
+          path: "/api/models",
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(payload),
+          },
+        },
+        (response) => {
+          let raw = "";
+          response.setEncoding("utf8");
+          response.on("data", (chunk) => (raw += chunk));
+          response.on("end", () => {
+            let parsed = null;
+            try {
+              parsed = JSON.parse(raw);
+            } catch (e) {
+              /* not JSON */
+            }
+            resolve({ status: response.statusCode, body: parsed, raw });
+          });
+        }
+      );
+      req.on("error", reject);
+      req.write(payload);
+      req.end();
+    });
+    assertErrorShape(res, 400, "a malformed JSON body");
+    assert.equal(res.body.error, "Malformed request body");
+  } finally {
+    ctx.server.close();
+    ctx.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 6. Nothing internal reaches a caller, across every failing endpoint
+// ---------------------------------------------------------------------------
+
+test("no failing endpoint discloses a server path, a stack trace or a raw error", async () => {
+  const absent = `${unique("absent")}.json`;
+  const failures = [
+    ["GET", `/api/models/${absent}`],
+    ["DELETE", `/api/models/${absent}`],
+    ["GET", "/api/models/..%2Fpackage.json"],
+    ["GET", `/api/data-recorders/models/${absent}`],
+    ["GET", `/api/logs/simulations/${unique("absent")}_${Date.now()}.log`],
+    ["GET", "/api/logs/simulations/..%2Fpackage.log"],
+    ["POST", "/api/simulation/start", { modelFileName: absent }],
+    ["POST", "/api/data-recorders/start", { dataRecorderFileName: absent }],
+    ["POST", "/api/models", { model: { name: "../../pwned", devices: [] } }],
+    ["POST", "/api/test-cases", { testCase: { id: "x", modelFileName: "../../../package.json" } }],
+    ["POST", "/api/events", { event: { timestamp: 1 } }],
+    ["GET", "/api/events?datasetId[$ne]=x"],
+  ];
+  for (const [method, routePath, body] of failures) {
+    const res = await request(server, method, routePath, body);
+    assert.ok(
+      res.status >= 400,
+      `${method} ${routePath} must not report a failure as a success: ${res.status} (${res.raw})`
+    );
+    assertErrorShape(res, res.status, `${method} ${routePath}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 7. The dashboard reads the status code, and still surfaces the failure
+// ---------------------------------------------------------------------------
+
+test("the dashboard's request layer honours the status code", async () => {
+  // The client is a separate build that this suite cannot run, so the property
+  // is asserted against its source: every request must go through the one
+  // helper that looks at `response.ok`, rather than at an `error` field in a
+  // body that used to always arrive with a 200.
+  const apiSource = fs.readFileSync(
+    path.resolve(__dirname, "../src/client/src/api/index.js"),
+    "utf8"
+  );
+  const fetches = (apiSource.match(/await fetch\(/g) || []).length;
+  const parsed = (apiSource.match(/await parseResponse\(response\)/g) || []).length;
+  assert.ok(fetches > 0, "the request layer must still make requests");
+  assert.equal(
+    parsed,
+    fetches,
+    "every request must be read through the helper that honours the status code"
+  );
+  assert.match(apiSource, /!response\.ok/, "the helper must branch on the status code");
+  assert.doesNotMatch(
+    apiSource,
+    /throw (data|status)\.error;/,
+    "no request may decide success from an error field in the body alone"
+  );
+  // The failure still reaches the user, and still as a string: the notification
+  // renders anything else with JSON.stringify, which turns an Error into "{}".
+  assert.match(apiSource, /throw errorMessage\(body, response\)/);
+  assert.match(apiSource, /Request failed \(HTTP \$\{response\.status\}\)/);
+});
+
+test("the error class never lets an unsafe message through by accident", () => {
+  // The message a caller sees is only ever one the code chose: `cause` is what
+  // carries the underlying error, and it is not part of the response.
+  const err = new ApiError(500, "Cannot save the new configuration", {
+    cause: new Error("EACCES: permission denied, open '/home/secret/x.json'"),
+  });
+  assert.equal(err.status, 500);
+  assert.equal(err.message, "Cannot save the new configuration");
+  assert.ok(err.cause instanceof Error);
+  assert.notEqual(
+    err.message,
+    err.cause.message,
+    "the caller-facing message must not be the underlying one"
+  );
+});

--- a/test/input-validation.test.js
+++ b/test/input-validation.test.js
@@ -17,6 +17,7 @@ const reportRouter = require("../src/server/routes/reports");
 const dataStorageRouter = require("../src/server/routes/data-storage");
 const devopsRouter = require("../src/server/routes/devops");
 const { NAME_MAX_LENGTH } = require("../src/server/routes/path-safety");
+const { errorHandler } = require("../src/server/middleware/errors");
 
 const modelsDir = path.resolve(__dirname, "../src/server/data/models");
 const dataRecordersDir = path.resolve(__dirname, "../src/server/data/data-recorders");
@@ -141,7 +142,24 @@ const validateOnly = (router, method, routePath, req) => {
       },
     };
     const request_ = { params: {}, query: {}, body: {}, ...req };
-    layer(request_, res, () => resolve({ passed: true, req: request_ }));
+    // The validation layer reports a refusal by handing an error to `next`, so
+    // that a rejected request is rendered by the same central handler as every
+    // other failure (issue #11). Render it here the same way, so what this
+    // helper asserts on is the body the API would really have sent — a `next`
+    // that ignored the error would report every refusal as a pass.
+    layer(request_, res, (err) => {
+      if (!err) return resolve({ passed: true, req: request_ });
+      // The handler records every refusal server-side, which is the behaviour
+      // the status-code suite asserts. Here it is only being used to render a
+      // body, and hundreds of refusals would bury the suite's own output.
+      const realConsoleError = console.error;
+      console.error = () => {};
+      try {
+        return errorHandler(err, request_, res, () => {});
+      } finally {
+        console.error = realConsoleError;
+      }
+    });
   });
 };
 


### PR DESCRIPTION
Closes #11

## Summary

Every endpoint answered HTTP 200 and signalled failure only through an `error` field in the body, so a client, a reverse proxy or a monitor could not tell a served request from a failed one without parsing the payload. Some failures also returned raw filesystem errors, which carry the absolute path they failed to open in their own enumerable properties.

This introduces one central error handler, converts every route to report through it, gives each kind of failure its conventional status code, and updates the dashboard's request layer to read those codes.

## Approach

New `src/server/middleware/errors.js` is the only thing in the server that writes an error body:

- `ApiError` — a status plus a message chosen deliberately for the caller, with the underlying error kept in `cause` (logged, never sent).
- Factories `badRequest` / `forbidden` / `notFound` / `conflict` / `unavailable` / `internal`.
- Mappers `fileError` (ENOENT → 404, anything else → 500) and `databaseError` (mongoose `CastError`/`ValidationError` → 400, duplicate key → 409, otherwise 500) — the backstop for a constraint the request schemas cannot express.
- `errorHandler` — normalises anything handed to `next`; anything that is not an `ApiError` becomes a bare `500 Internal server error`, which is what keeps raw error objects and server paths out of responses.

Every route now reports failures with `next(<ApiError>)`, **including the validation layer from #10** — so the `{ error: "Validation failed", details: [...] }` shape is now produced by the same handler as everything else rather than by a second code path. `sendBadRequest` in `routes/path-safety.js` (the containment guards, which hold only `res`) routes through the same handler.

The handler is attached to **each router as well as to the application**. That is deliberate: the test suites mount routers standalone, and a router without it falls through to Express's default handler, which answers with an HTML stack trace. `test/http-status.test.js` asserts every router *ends* with it.

`app.js` additionally: answers unknown `/api` paths with a JSON 404 instead of the dashboard's `index.html`; routes the CORS 403 and the rate-limiter 429 through the handler; and lets body-parser failures (oversized → 413, malformed JSON → 400) reach it instead of Express's default HTML page.

Full detail stays server-side, written as a **single string** — `logger/index.js` replaces `console.error` with a single-argument function, so a handler that logged the error as a second argument would have dropped exactly the detail it removed from the response.

### Status codes

| Status | When |
| --- | --- |
| `400` | Validation failure; a name that cannot derive a safe path; a document the database refused |
| `403` | Cross-origin request from an unlisted origin |
| `404` | Missing model, data recorder, log, data set, event, report, test case, test campaign, or unknown API path |
| `409` | Starting a simulation or data recorder that is already running |
| `413` / `429` | Over `BODY_LIMIT` / over `RATE_LIMIT_MAX` (unchanged, now via the handler) |
| `500` / `503` | Server failure / database unreachable |

Success bodies are deliberately untouched, including the several that still carry `error: null` — this change is about failures, and rewriting success shapes would churn the client and the suites for nothing.

## Defects fixed in the same remit

- **`POST /api/events` reported a rejected write as a success.** `values` and `isSensorData` are optional in the Joi schema but `required: true` in `EventSchema`, so omitting either was accepted, refused by mongoose, and answered `200 {error: "Failed to save the event"}`. Both are now required by the create schema (they stay optional on the partial update body), and a mongoose `ValidationError` maps to 400 as a backstop. Covered by a test.
- **`GET /api/simulation/stats` always threw.** It read a `simulation` binding that is never assigned, so every call raised a ReferenceError and was answered with a stack trace. It now reads the router's own registry.
- **The "already running" guard never fired.** `Simulation` tracks running-ness as `status`, not `isRunning`, so starting the same topology twice succeeded and orphaned the first run — its devices kept publishing with no handle left to stop them. Now a real 409.
- **`updateDataStorage` had unreachable broken code**: the callback tested the outer `err` instead of `err2` and then referenced an `res` that does not exist in that scope. It now logs the reconnect failure and still reports the save as done — the write genuinely succeeded, and `GET /api/data-storage/test` is what probes the connection.
- **A missing log directory is an empty collection**, not a missing resource: `GET /api/logs/*` answers `200 {files: []}` on a fresh checkout rather than an error.

## Dashboard

`src/client/src/api/index.js` had the same 5-line block copied into all 54 endpoint functions: `await response.json()`, then `if (data.error) throw data.error`. Nothing looked at the status code, so a non-2xx body was parsed exactly like a 200 and a non-JSON body (a proxy's error page) surfaced as a raw `SyntaxError` — which the notification layer renders as `{}`.

All 54 now read through one private `parseResponse` helper that branches on `response.ok`, tolerates a non-JSON body, folds the validation `details` into the message so the user is told *which* field was refused, and **still throws a string** — every saga's `catch` puts the thrown value straight into an antd notification, and `LayoutPage` renders a non-string with `JSON.stringify`. No saga, reducer or page needed a change.

The committed client bundle in `src/public/` is deliberately left stale — it is not rebuilt or committed here (#42 tracks removing it from the repo).

## Changes

| File | Change |
| --- | --- |
| `src/server/middleware/errors.js` | **New.** `ApiError`, factories, fs/database mappers, the central `errorHandler`, `sendError`, `apiNotFound` |
| `src/server/middleware/validate.js` | Validation failures reported with `next(badRequest(...))` instead of writing their own 400 |
| `src/server/app.js` | Registers the handler; JSON 404 for unknown `/api` paths; CORS 403 and rate-limit 429 through the handler; inline 413 handler folded in |
| `src/server/routes/*.js` (11 files) | Every `res.send({error})` replaced by `next(<ApiError>)`; `next` threaded through 7 helpers; each router ends with the shared handler |
| `src/server/routes/db-connector.js` | `dbConnector` answers 503; fixed the unreachable broken callback in `updateDataStorage` |
| `src/server/routes/events.js` | `values` and `isSensorData` required on create |
| `src/server/routes/simulation.js` | `/stats` no longer throws; running-state checks use `status`, so 409 is real |
| `src/client/src/api/index.js` | One `parseResponse` helper; 54 call sites rewritten; failures still surfaced as strings |
| `test/http-status.test.js` | **New**, 22 tests |
| `test/input-validation.test.js` | `validateOnly` renders the `next(err)` through the real handler (see below) |
| `README.md` | New "API responses" section documenting the codes and the error shape |

## Test Results

```
npm test  ->  178 tests, 177 pass, 1 skipped (pre-existing Docker image test), 0 fail
```

Baseline on `master` was 150 tests / 149 pass / 1 skipped. The 28 new tests cover: each failure kind's status code, one shape from one handler, an unclassified failure becoming a bare 500 that echoes nothing, every router ending with the handler, 404 for each missing resource, the `values`/`isSensorData` refusal, the fs/database mappers, an unreadable config answering 500 while the log keeps the path, the one-argument log line, unknown API paths and malformed bodies on the real booted app, a sweep asserting no failing endpoint discloses a path/stack/raw error, and a source-level guard that the client reads the status code.

### Suites that had to change

- **`test/routes-security.test.js` (32 tests): unchanged, 32/32 green.** No security assertion was touched. This is the reason the handler is attached per-router rather than only to the app.
- **`test/input-validation.test.js` (45 tests): 45/45 green, one helper changed.** `validateOnly` invokes the validation layer directly with a stub `res`. Now that the layer reports through `next(err)`, a `next` that ignored its argument would have resolved `{passed: true}` and reported **every refusal as a pass** — silently voiding 45 tests. It now renders the error through the real `errorHandler`, so what the helper asserts on is the body the API would actually have sent. No assertion was weakened or removed.

No pre-existing assertion changed its expected status code: every suite already asserted 400 where a 400 is now produced, and the endpoints they drive to 200 are success paths whose bodies are unchanged.

## Follow-up from review

Two defects found while reviewing the change above, fixed in a second commit and
covered by five further tests:

- **A caller-caused failure was being reported as a server fault.** Express's own
  router raises a `URIError` carrying `status: 400` when a path segment's
  percent-encoding cannot be decoded (`GET /api/models/%E0%A4%A`). `toApiError`
  read only `err.type`, so that fell through to the bare 500 — the inverse of
  what this issue is about, and a regression against the 400 Express's default
  handler used to answer (with an HTML stack trace, which stays fixed). A failure
  that already carries a 4xx now keeps that status, with a message chosen in
  `errors.js` rather than the raw one, so nothing is disclosed. A 5xx a library
  chose, a non-integer status, or no status at all is still the bare 500.
- **The new 409 guard was only sequentially correct.** Both start guards read
  their registry and then, on the default data-storage path — the one the
  dashboard takes — registered the run only inside the asynchronous
  `getDataStorage` callback. Two concurrent starts of one topology both passed
  the guard and both answered 200, leaving the first run orphaned: exactly the
  outcome the guard exists to prevent. The id is now reserved across that turn
  and released on both paths, in `simulation.js` and `data-recorders.js` alike.
- **The data recorder's half of that reservation had nothing pinning it.** Both
  "already running" tests drive the guard sequentially, so they pass whether or
  not the id is held across the asynchronous read; a concurrent start now pins
  it the way the simulation one does. The status table in the README also listed
  neither the `403` an unlisted origin is answered with nor the `415` an
  unreadable content encoding is.

## Acceptance Criteria

- [x] **Validation failures, missing resources, conflicts and internal errors each return their conventional status code** — 400/404/409/500, plus 403, 413, 429 and 503 for the dependency case. Conflicts required fixing the guard that never fired.
- [x] **All error responses share one shape, produced by a single central handler** — `errorHandler` in `src/server/middleware/errors.js` is the only function that writes an error body; the validation layer, the containment guards, CORS, the rate limiter and body-parser all report through it.
- [x] **No response body contains server filesystem paths, stack traces or raw underlying error objects** — anything that is not an `ApiError` becomes a bare 500; no `ApiError` message interpolates a variable (six on `master` echoed caller input); asserted by a sweep across every failing endpoint.
- [x] **Full error detail remains available in server-side logs** — one line per failure carrying method, path, status, message, per-field details and the cause's stack, in a single argument so the winston logger keeps it. Asserted directly.
- [x] **The dashboard is updated to read the new status codes and still surfaces failures to the user** — all 54 request functions branch on `response.ok`; failures still reach the same notification, now with the refused field named.

## Decision Record

- **Attach the handler to every router as well as the app.** The alternative — app-level only — would have required editing the Phase 0 security gate's test app in four places and would leave any standalone mount answering with Express's default HTML stack trace. One handler *implementation*, registered where Express needs it to be reachable.
- **Keep `error: null` on success bodies.** Removing it is cosmetic, and would churn the client and three suites for no behavioural gain.
- **Keep throwing a string in the client.** Resolving with an `{error}` envelope would have broken all 57 saga call sites at once; throwing an `Error` renders as `{}` in the notification.
- **`POST /api/data-storage` still reports success when the reconnect fails.** The configuration was written, which is what the endpoint promises; the connection has its own endpoint.
- **404 for a missing collection was rejected** for the log listings — a directory that does not exist yet is an empty collection, so it answers `200 {files: []}`.


