### PR TITLE
feat(server): add authentication and session protection to the API (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ one without parsing the body.
 | ------ | -------------------------------------------------------------------------- |
 | `2xx`  | The request was served.                                                    |
 | `400`  | The request was malformed — a field of the wrong type, a name that cannot derive a safe file path, a document the database refused. |
-| `403`  | The request came from an origin that is not in `CORS_ALLOWED_ORIGINS`.     |
+| `401`  | The request carries no valid session. Log in at `POST /api/auth/login`; a session that has expired or been logged out reads the same. |
+| `403`  | The request came from an origin that is not in `CORS_ALLOWED_ORIGINS`, or a state-changing request did not carry a valid `X-CSRF-Token`. |
 | `404`  | The addressed model, data recorder, log, data set, event, report, test case, test campaign or API path does not exist. |
 | `409`  | The request conflicts with the current state — starting a simulation or a data recorder that is already running. |
 | `413`  | The body is larger than `BODY_LIMIT`.                                      |
@@ -161,33 +162,154 @@ The noderedflow is the default flow when open the nodered application
 
 # Security
 
-## No built-in authentication
+## Authentication
 
-The TaS service currently ships **without any built-in authentication or
-authorization**. The web dashboard, the REST API, the MQTT broker, and Node-RED
-do not require credentials, and there is no user/role model. In practice:
+Every API endpoint requires an authenticated session. TaS is single-tenant:
+there is one administrator account, and it is provisioned from configuration
+rather than from anything in this repository, so a checkout never carries a
+working credential and two deployments never share one.
 
-- Any client that can reach the HTTP/WebSocket end-points can view and modify
-  the dashboard, models, data recorders, and simulations.
-- Any client that can reach the MQTT port can publish and subscribe as a broker
-  client.
+### Provisioning the administrator credential
+
+The preferred form is a pre-computed hash, so the plaintext only ever exists on
+the machine where it was generated:
+
+```
+node -e "console.log(require('./src/server/auth/passwords').hashPassword(process.argv[1]))" 'your-password-here'
+# scrypt$16384$8$1$<salt>$<hash>
+```
+
+Put the result in `AUTH_ADMIN_PASSWORD_HASH`:
+
+```
+AUTH_ADMIN_USERNAME=admin
+AUTH_ADMIN_PASSWORD_HASH=scrypt$16384$8$1$...
+```
+
+For a first start, `AUTH_ADMIN_PASSWORD` accepts a plaintext instead. It is
+hashed once at startup and the plaintext is discarded immediately — it is never
+stored, never logged and never returned — but it does sit in the environment of
+the running process, which is why the hashed form is preferred.
+
+With neither set the server still starts, says so loudly on stderr, and refuses
+every API request: an appliance that cannot be configured is safer than one that
+opens itself up.
+
+### What answers without a session
+
+The allowlist is explicit, lives in one place (`src/server/middleware/auth.js`)
+and holds exactly three endpoints:
+
+| Endpoint             | Why it is public                                                        |
+| -------------------- | ----------------------------------------------------------------------- |
+| `GET /api/health`    | Liveness probe for an orchestrator or monitor. Reports `{"status":"ok"}` and deliberately nothing else — no uptime, version or dependency state. |
+| `POST /api/auth/login` | The endpoint that issues a session.                                   |
+| `GET /api/auth/session` | Lets the dashboard ask whether it is logged in. Answers `200` either way, so a cold start is not a 401 storm. |
+
+`OPTIONS` (CORS preflight) is also answered without a session, because a
+preflight carries no credentials by definition.
+
+`POST /api/auth/logout` is **not** on the list: logging out acts on a session,
+so it needs one.
+
+The static dashboard bundle and the single-page app shell stay public as well.
+That is deliberate — the login page is part of that bundle, so gating it would
+leave a browser with nothing to log in with. The bundle contains no operational
+data: every value the dashboard displays comes from the API, which is closed.
+
+### Sessions
+
+`POST /api/auth/login` with `{"username": "...", "password": "..."}` answers
+`200` and sets two cookies:
+
+- `tas.sid` — an opaque, signed, `HttpOnly`, `SameSite=Lax` session identifier.
+  The session itself lives server-side, which is what makes it revocable.
+- `tas.csrf` — the CSRF token for that session. Readable by script on purpose
+  (see below).
+
+Sessions expire two ways. `SESSION_TTL_MS` (default 1 hour) is an *idle*
+timeout that slides forward on every request, so working in the dashboard never
+logs you out mid-task; `SESSION_ABSOLUTE_TTL_MS` (default 12 hours) is a hard
+cap that does not slide. `POST /api/auth/logout` invalidates a session
+immediately, and replaying its cookie afterwards answers `401`. Sessions are
+held in the process, so a restart ends all of them.
+
+### Cross-site request forgery
+
+Every state-changing request (`POST`, `DELETE`) must carry the session's token
+in an `X-CSRF-Token` header:
+
+```
+curl -X POST http://127.0.0.1:3004/api/models \
+  -H 'Content-Type: application/json' \
+  -H "X-CSRF-Token: $(...value of the tas.csrf cookie...)" \
+  -b cookies.txt -d '{"model": {"name": "demo", "devices": []}}'
+```
+
+A browser attaches the session cookie to any request that reaches this origin,
+including one an unrelated page caused, so the cookie alone cannot be what
+authorises a write. A cross-site page can cause the cookie to be *sent* but the
+same-origin policy stops it from *reading* it, so it can never produce the
+header. `POST /api/auth/login` is exempt, because it is what issues the token.
+
+`GET` never requires the header.
+
+### Delegating identity to a reverse proxy
+
+A deployment already behind an authenticating proxy can let the proxy assert who
+the caller is. Two settings must agree, because a header on its own is forgeable
+by anyone who can reach the port:
+
+```
+AUTH_TRUST_PROXY_HEADER=true
+AUTH_TRUSTED_PROXIES=10.0.0.7        # the proxy's address, as TaS sees it
+AUTH_PROXY_USER_HEADER=x-forwarded-user   # optional; this is the default
+```
+
+The header is honoured **only** when the connection comes from an address on
+`AUTH_TRUSTED_PROXIES`. With the flag on and the list empty the feature stays
+disabled and the server warns at startup. With the flag off — the default — the
+header is completely inert.
+
+The proxy must strip the identity header from incoming requests, or a client can
+set it itself. For example, with nginx:
+
+```
+location / {
+  auth_request /oauth2/auth;
+  proxy_set_header X-Forwarded-User $upstream_http_x_auth_request_user;  # set, never pass through
+  proxy_pass http://127.0.0.1:3004;
+}
+```
+
+### Login rate limit
+
+Failed logins are limited to `AUTH_LOGIN_RATE_LIMIT_MAX` (default 10) per
+`AUTH_LOGIN_RATE_LIMIT_WINDOW_MS` (default 15 minutes) per client, after which
+the endpoint answers `429`. Successful logins do not count towards it, so a
+working dashboard is never locked out by its own traffic. Every attempt, failed
+or successful, is written to the server log with the attempted username, the
+client address, the user agent and a running count of consecutive failures — the
+password never is.
 
 ## Deployment baseline
 
-Treat the service as **untrusted**. The safe baseline is to never expose it to
-an untrusted or public network:
+The API is authenticated, but the safe baseline is still defence in depth:
 
-- Bind published ports to loopback only (`127.0.0.1`), or to a private network
-  interface whose network is trusted.
-- Do not publish the ports to `0.0.0.0` or forward them from a public host or
-  load balancer.
-- If the service must be reachable from an untrusted network, put an
-  authenticated reverse proxy (with TLS) in front of it today; real
-  authentication scoped to TaS itself is planned and, once available, will let
-  you retire that workaround.
+- Terminate TLS in front of TaS. Set `SESSION_COOKIE_SECURE=true` whenever TLS
+  reaches the application itself; the default is `false` because the shipped
+  `docker run` speaks plain HTTP on loopback, where a `Secure` cookie would
+  never be sent at all and nobody could log in.
+- Set `SESSION_SECRET` to a long random value. Without it the server generates
+  an ephemeral one per process, which means every session ends at a restart.
+- Bind published ports to loopback (`127.0.0.1`) or to a trusted private
+  network interface rather than to `0.0.0.0`, unless the service is genuinely
+  meant to be reachable from elsewhere.
+- The MQTT broker and Node-RED are **not** covered by any of this. They have no
+  credentials of their own, so anything that can reach their ports can still
+  publish, subscribe and edit flows — keep those ports off untrusted networks.
 
-The quick-start `docker run` on this page already reflects this baseline by
-binding to loopback.
+The quick-start `docker run` on this page already binds to loopback.
 
 ## Security-related configuration
 
@@ -203,6 +325,18 @@ tighten a limit.
 | `RATE_LIMIT_MAX`       | `1000`            | Requests allowed per window per client. Going over returns `429`.                                                                                                                |
 | `CSP_REPORT_ONLY`      | `true`            | Ship the Content Security Policy as `Content-Security-Policy-Report-Only`, so browsers report violations without blocking. Set to `false` to enforce the policy.                 |
 | `CSP_REPORT_URI`       | _(empty)_         | Endpoint browsers should POST policy violation reports to. Empty means violations are only visible in the browser console. Must be a single URL: `;`, `,`, whitespace and control characters are refused at startup.                                                        |
+| `AUTH_ADMIN_USERNAME`  | `admin`           | The single administrator account name.                                                                                                                                                                                                                                     |
+| `AUTH_ADMIN_PASSWORD`  | _(empty)_         | Plaintext bootstrap password. Hashed once at startup and then discarded. Empty means no credential is configured, and every API request is refused.                                                                                                                        |
+| `AUTH_ADMIN_PASSWORD_HASH` | _(empty)_     | Preferred: a `scrypt$...` value produced by `hashPassword` (see above). Takes precedence over `AUTH_ADMIN_PASSWORD`.                                                                                                                                                       |
+| `SESSION_SECRET`       | _(none)_          | Secret the session cookie is signed with. There is deliberately no default: when unset, an ephemeral secret is generated per process and a warning is logged, so sessions do not survive a restart. Set it in production.                                                   |
+| `SESSION_TTL_MS`       | `3600000` (1 h)   | Idle timeout. Slides forward on every request, so an in-use session is never logged out.                                                                                                                                                                                   |
+| `SESSION_ABSOLUTE_TTL_MS` | `43200000` (12 h) | Hard lifetime. Does not slide: no session outlives it, however busy it is.                                                                                                                                                                                              |
+| `SESSION_COOKIE_SECURE` | `false`          | Mark the session cookies `Secure`. Set to `true` whenever TLS reaches the application; the default suits the documented plain-HTTP-on-loopback baseline, where a `Secure` cookie would never be sent.                                                                       |
+| `AUTH_TRUST_PROXY_HEADER` | `false`        | Believe an identity header from an authenticating reverse proxy. Ignored unless `AUTH_TRUSTED_PROXIES` is non-empty.                                                                                                                                                        |
+| `AUTH_PROXY_USER_HEADER` | `x-forwarded-user` | Name of that identity header.                                                                                                                                                                                                                                          |
+| `AUTH_TRUSTED_PROXIES` | _(empty)_         | Comma- or whitespace-separated peer addresses whose identity header is honoured. Empty means delegation stays disabled whatever the flag says.                                                                                                                              |
+| `AUTH_LOGIN_RATE_LIMIT_WINDOW_MS` | `900000` (15 min) | Window for the login-specific rate limit.                                                                                                                                                                                                             |
+| `AUTH_LOGIN_RATE_LIMIT_MAX` | `10`         | Failed logins allowed per window per client. Successful logins do not count.                                                                                                                                                                                               |
 
 Values are read from the process environment first, then from `.env`, then from
 these defaults — so a container or a CI job can override a setting without

--- a/README.md
+++ b/README.md
@@ -187,9 +187,10 @@ AUTH_ADMIN_PASSWORD_HASH=scrypt$16384$8$1$...
 ```
 
 For a first start, `AUTH_ADMIN_PASSWORD` accepts a plaintext instead. It is
-hashed once at startup and the plaintext is discarded immediately — it is never
-stored, never logged and never returned — but it does sit in the environment of
-the running process, which is why the hashed form is preferred.
+hashed once at startup and the plaintext is discarded immediately — it is erased
+from the configuration object as it is hashed, so it is never stored, never
+logged and never returned — but it does sit in the environment of the running
+process, which is why the hashed form is preferred.
 
 With neither set the server still starts, says so loudly on stderr, and refuses
 every API request: an appliance that cannot be configured is safer than one that
@@ -206,8 +207,12 @@ and holds exactly three endpoints:
 | `POST /api/auth/login` | The endpoint that issues a session.                                   |
 | `GET /api/auth/session` | Lets the dashboard ask whether it is logged in. Answers `200` either way, so a cold start is not a 401 storm. |
 
-`OPTIONS` (CORS preflight) is also answered without a session, because a
-preflight carries no credentials by definition.
+A genuine CORS **preflight** — an `OPTIONS` request carrying both an `Origin`
+and an `Access-Control-Request-Method` header — is also answered without a
+session, because a preflight carries no credentials by definition. A *bare*
+`OPTIONS` is not exempt: it is refused with `401` like anything else, so an
+anonymous caller cannot read an `Allow` header off every path and map which
+endpoints exist and which methods they accept.
 
 `POST /api/auth/logout` is **not** on the list: logging out acts on a session,
 so it needs one.
@@ -233,6 +238,12 @@ logs you out mid-task; `SESSION_ABSOLUTE_TTL_MS` (default 12 hours) is a hard
 cap that does not slide. `POST /api/auth/logout` invalidates a session
 immediately, and replaying its cookie afterwards answers `401`. Sessions are
 held in the process, so a restart ends all of them.
+
+The session table also has a hard size cap, `SESSION_MAX_RECORDS` (default
+1000): when it is full the least recently seen record is evicted. Expiry alone
+is not a bound — nothing stops records being minted faster than they age out —
+and a single-tenant appliance never has a thousand live operator sessions, so
+the cap only ever bites on runaway traffic.
 
 ### Cross-site request forgery
 
@@ -281,6 +292,31 @@ location / {
   proxy_pass http://127.0.0.1:3004;
 }
 ```
+
+A browser needs nothing more: the first request establishes a session and the
+cookies, and the dashboard boots straight into `GET /api/auth/session`, which
+reports the delegated identity.
+
+**CSRF still applies to a delegated request.** Delegation is deliberately not an
+exemption: the proxy attaches the identity header to whatever reaches it,
+cookies or no cookies, so a cross-site forged `POST` arrives in exactly the
+shape of a cookieless delegated request. A non-browser client behind the proxy
+must therefore fetch its token first and echo it back:
+
+```
+# 1. ask who the proxy says we are, and collect the token for that session
+TOKEN=$(curl -s http://127.0.0.1:3004/api/auth/session | sed 's/.*"csrfToken":"\([^"]*\)".*/\1/')
+
+# 2. now a write is accepted
+curl -X POST http://127.0.0.1:3004/api/models \
+  -H 'Content-Type: application/json' \
+  -H "X-CSRF-Token: $TOKEN" \
+  -d '{"model": {"name": "demo", "devices": []}}'
+```
+
+Every such cookieless client shares one session record per asserted identity —
+the record is reused rather than re-minted per request, so a monitoring probe
+behind the proxy cannot grow the session table.
 
 ### Login rate limit
 
@@ -331,6 +367,7 @@ tighten a limit.
 | `SESSION_SECRET`       | _(none)_          | Secret the session cookie is signed with. There is deliberately no default: when unset, an ephemeral secret is generated per process and a warning is logged, so sessions do not survive a restart. Set it in production.                                                   |
 | `SESSION_TTL_MS`       | `3600000` (1 h)   | Idle timeout. Slides forward on every request, so an in-use session is never logged out.                                                                                                                                                                                   |
 | `SESSION_ABSOLUTE_TTL_MS` | `43200000` (12 h) | Hard lifetime. Does not slide: no session outlives it, however busy it is.                                                                                                                                                                                              |
+| `SESSION_MAX_RECORDS`  | `1000`            | Hard cap on how many session records are held at once. When it is full the least recently seen record is evicted, so the table stays bounded whatever the traffic.                                                                                                          |
 | `SESSION_COOKIE_SECURE` | `false`          | Mark the session cookies `Secure`. Set to `true` whenever TLS reaches the application; the default suits the documented plain-HTTP-on-loopback baseline, where a `Secure` cookie would never be sent.                                                                       |
 | `AUTH_TRUST_PROXY_HEADER` | `false`        | Believe an identity header from an authenticating reverse proxy. Ignored unless `AUTH_TRUSTED_PROXIES` is non-empty.                                                                                                                                                        |
 | `AUTH_PROXY_USER_HEADER` | `x-forwarded-user` | Name of that identity header.                                                                                                                                                                                                                                          |

--- a/README.md
+++ b/README.md
@@ -263,6 +263,17 @@ authorises a write. A cross-site page can cause the cookie to be *sent* but the
 same-origin policy stops it from *reading* it, so it can never produce the
 header. `POST /api/auth/login` is exempt, because it is what issues the token.
 
+Four endpoints change state over `GET` and therefore need the header as well:
+
+- `GET /api/devops/start` and `GET /api/devops/stop`
+- `GET /api/simulation/stop/:fileName`
+- `GET /api/data-recorders/stop/:fileName`
+
+`SameSite=Lax` does not cover these on its own — it deliberately still attaches
+the cookie to a top-level `GET` navigation, so a link on any page an operator
+visits while logged in would otherwise start or stop a campaign. The dashboard
+sends the token on every request, so nothing in the UI has to know the list.
+
 `GET` never requires the header.
 
 ### Delegating identity to a reverse proxy

--- a/env.example
+++ b/env.example
@@ -11,3 +11,31 @@ DEV_DASHBOARD_PORT=8080
 #RATE_LIMIT_MAX=1000
 #CSP_REPORT_ONLY=true
 #CSP_REPORT_URI=
+
+# Authentication. The API is closed to anonymous callers, so a deployment needs
+# an administrator credential: set AUTH_ADMIN_PASSWORD_HASH (preferred - see the
+# README for the one-line command that generates it) or, for a first start,
+# AUTH_ADMIN_PASSWORD. NEVER commit a real value into this file.
+#AUTH_ADMIN_USERNAME=admin
+#AUTH_ADMIN_PASSWORD=
+#AUTH_ADMIN_PASSWORD_HASH=
+
+# Sessions. SESSION_SECRET signs the session cookie; when it is unset the server
+# generates an ephemeral one per process and says so loudly, which means every
+# session ends at a restart. Set it in production. Set SESSION_COOKIE_SECURE=true
+# whenever TLS reaches the application itself.
+#SESSION_SECRET=
+#SESSION_TTL_MS=3600000
+#SESSION_ABSOLUTE_TTL_MS=43200000
+#SESSION_COOKIE_SECURE=false
+
+# Delegating identity to an authenticating reverse proxy. Both must be set: the
+# identity header is only believed when the request comes from a listed peer.
+#AUTH_TRUST_PROXY_HEADER=false
+#AUTH_PROXY_USER_HEADER=x-forwarded-user
+#AUTH_TRUSTED_PROXIES=
+
+# Failed logins per window per client before the login endpoint starts refusing.
+# Successful logins do not count towards it.
+#AUTH_LOGIN_RATE_LIMIT_WINDOW_MS=900000
+#AUTH_LOGIN_RATE_LIMIT_MAX=10

--- a/env.example
+++ b/env.example
@@ -28,9 +28,14 @@ DEV_DASHBOARD_PORT=8080
 #SESSION_TTL_MS=3600000
 #SESSION_ABSOLUTE_TTL_MS=43200000
 #SESSION_COOKIE_SECURE=false
+# Hard cap on the session table. When it is full the least recently seen record
+# is evicted, so the table stays bounded whatever the traffic.
+#SESSION_MAX_RECORDS=1000
 
 # Delegating identity to an authenticating reverse proxy. Both must be set: the
 # identity header is only believed when the request comes from a listed peer.
+# Delegation is not a CSRF exemption: a non-browser client behind the proxy must
+# GET /api/auth/session for its token before it can POST or DELETE.
 #AUTH_TRUST_PROXY_HEADER=false
 #AUTH_PROXY_USER_HEADER=x-forwarded-user
 #AUTH_TRUSTED_PROXIES=

--- a/src/client/src/App.js
+++ b/src/client/src/App.js
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { Component } from "react";
 import "antd/dist/antd.css";
-import { Layout } from "antd";
+import { Layout, Spin } from "antd";
 import {
   BrowserRouter as Router,
   Switch,
@@ -9,7 +9,12 @@ import {
 } from "react-router-dom";
 
 import ErrorBoundary from "antd/lib/alert/ErrorBoundary";
+import { connect } from "react-redux";
+
+import { checkSession } from "./actions";
 import TSHeader from "./components/TSHeader";
+import SessionExpiredModal from "./components/SessionExpiredModal";
+import LoginPage from "./pages/LoginPage";
 import ModelPage from "./pages/ModelPage";
 import DataStoragePage from "./pages/DataStoragePage";
 import TestCampaignListPage from "./pages/TestCampaignListPage";
@@ -26,68 +31,117 @@ import LogsPage from "./pages/LogsPage";
 import ReportListPage from "./pages/ReportListPage";
 import ReportPage from "./pages/ReportPage";
 
-function App() {
-  return (
-    <Router>
-      <ErrorBoundary>
-        <Layout className="layout" style={{ height: "100%" }}>
-          <TSHeader />
-          <Switch>
-            <Route
-              exact
-              path="/"
-              render={() => <Redirect to="/test-campaigns" />}
-            />
-            <Route path="/test-campaigns/:testCampaignId">
-              <TestCampaignPage />
-            </Route>
-            <Route path="/logs/:tool">
-              <LogsPage message="This is the log file page" />
-            </Route>
-            <Route path="/test-campaigns">
-              <TestCampaignListPage />
-            </Route>
-            <Route path="/test-cases/:testCaseId">
-              <TestCasePage />
-            </Route>
-            <Route path="/test-cases">
-              <TestCaseListPage />
-            </Route>
-            <Route path="/data-sets/:datasetId">
-              <DatasetPage />
-            </Route>
-            <Route path="/data-sets">
-              <DatasetListPage />
-            </Route>
-            <Route path="/data-recorders/:dataRecorderId">
-              <DataRecorderPage />
-            </Route>
-            <Route path="/data-recorders">
-              <DataRecorderListPage />
-            </Route>
-            <Route path="/models/:modelId">
-              <ModelPage />
-            </Route>
-            <Route path="/models">
-              <ModelListPage />
-            </Route>
-            <Route path="/data-storage">
-              <DataStoragePage />
-            </Route>
-            <Route path="/simulation">
-              <SimulationPage />
-            </Route>
-            <Route path="/reports/:reportId">
-              <ReportPage />
-            </Route>
-            <Route path="/reports">
-              <ReportListPage />
-            </Route>
-          </Switch>
-        </Layout>
-      </ErrorBoundary>
-    </Router>
-  );
+/**
+ * The routed dashboard, or a sign-in prompt when there is no session.
+ *
+ * Three states, and the third is the one that matters. While the session is
+ * being resolved the app shows nothing but a spinner, because rendering either
+ * of the other two would be a guess. With no session at all it shows the login
+ * page. But when a session expires *underneath* a page that is already open,
+ * the routed content stays exactly where it is and a modal is laid over it
+ * (see `SessionExpiredModal`) - navigating away would silently discard whatever
+ * the operator had typed and not yet saved.
+ */
+class App extends Component {
+  componentDidMount() {
+    this.props.checkSession();
+  }
+
+  renderContent() {
+    const { checking, authenticated, sessionExpired } = this.props;
+    if (checking) {
+      return (
+        <div style={{ textAlign: "center", marginTop: 60 }}>
+          <Spin tip="Loading..." />
+        </div>
+      );
+    }
+    if (!authenticated && !sessionExpired) {
+      return <LoginPage />;
+    }
+    return this.renderRoutes();
+  }
+
+  renderRoutes() {
+    return (
+      <Switch>
+        <Route
+          exact
+          path="/"
+          render={() => <Redirect to="/test-campaigns" />}
+        />
+        <Route path="/test-campaigns/:testCampaignId">
+          <TestCampaignPage />
+        </Route>
+        <Route path="/logs/:tool">
+          <LogsPage message="This is the log file page" />
+        </Route>
+        <Route path="/test-campaigns">
+          <TestCampaignListPage />
+        </Route>
+        <Route path="/test-cases/:testCaseId">
+          <TestCasePage />
+        </Route>
+        <Route path="/test-cases">
+          <TestCaseListPage />
+        </Route>
+        <Route path="/data-sets/:datasetId">
+          <DatasetPage />
+        </Route>
+        <Route path="/data-sets">
+          <DatasetListPage />
+        </Route>
+        <Route path="/data-recorders/:dataRecorderId">
+          <DataRecorderPage />
+        </Route>
+        <Route path="/data-recorders">
+          <DataRecorderListPage />
+        </Route>
+        <Route path="/models/:modelId">
+          <ModelPage />
+        </Route>
+        <Route path="/models">
+          <ModelListPage />
+        </Route>
+        <Route path="/data-storage">
+          <DataStoragePage />
+        </Route>
+        <Route path="/simulation">
+          <SimulationPage />
+        </Route>
+        <Route path="/reports/:reportId">
+          <ReportPage />
+        </Route>
+        <Route path="/reports">
+          <ReportListPage />
+        </Route>
+      </Switch>
+    );
+  }
+
+  render() {
+    return (
+      <Router>
+        <ErrorBoundary>
+          <Layout className="layout" style={{ height: "100%" }}>
+            <TSHeader />
+            {this.renderContent()}
+            <SessionExpiredModal />
+          </Layout>
+        </ErrorBoundary>
+      </Router>
+    );
+  }
 }
 
-export default App;
+const mapPropsToStates = ({ auth }) => ({
+  authenticated: auth.authenticated,
+  checking: auth.checking,
+  sessionExpired: auth.sessionExpired,
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  checkSession: () => dispatch(checkSession()),
+});
+
+export default connect(mapPropsToStates, mapDispatchToProps)(App);

--- a/src/client/src/actions/index.js
+++ b/src/client/src/actions/index.js
@@ -166,3 +166,11 @@ export const requestOriginalEvents = createAction('REQUEST_ORIGINAL_EVENTS');
 export const setOriginalEvents = createAction('SET_ORIGINAL_EVENTS');
 export const requestNewEvents = createAction('REQUEST_NEW_EVENTS');
 export const setNewEvents = createAction('SET_NEW_EVENTS');
+
+// Authentication
+export const checkSession = createAction('CHECK_SESSION');
+export const setSession = createAction('SET_SESSION');
+export const login = createAction('LOGIN');
+export const setLoginError = createAction('SET_LOGIN_ERROR');
+export const logout = createAction('LOGOUT');
+export const sessionExpired = createAction('SESSION_EXPIRED');

--- a/src/client/src/api/index.js
+++ b/src/client/src/api/index.js
@@ -15,9 +15,6 @@ const CSRF_COOKIE = "tas.csrf";
 /** The header the server expects the session's CSRF token in. */
 const CSRF_HEADER = "X-CSRF-Token";
 
-/** Methods that change nothing, and therefore carry no token. */
-const SAFE_METHODS = ["GET", "HEAD", "OPTIONS"];
-
 /**
  * The message a request that fell outside a live session is reported with.
  *
@@ -100,11 +97,14 @@ const notifySessionExpired = () => {
  * @returns {Promise<Response>}
  */
 const apiFetch = (url, options = {}) => {
-  const method = String(options.method || "GET").toUpperCase();
   const headers = { ...(options.headers || {}) };
-  if (SAFE_METHODS.indexOf(method) === -1) {
-    headers[CSRF_HEADER] = readCsrfToken();
-  }
+  // Sent on every call, not only the unsafe methods: a handful of endpoints
+  // (starting and stopping a campaign, a simulation or a recorder) mutate over
+  // `GET`, and the server requires the token on those too — see
+  // `MUTATING_SAFE_METHOD_PATHS` in `src/server/middleware/csrf.js`. Attaching
+  // it unconditionally is also what keeps a route moved between methods later
+  // from silently losing its protection.
+  headers[CSRF_HEADER] = readCsrfToken();
   return fetch(url, {
     ...options,
     credentials: "same-origin",

--- a/src/client/src/api/index.js
+++ b/src/client/src/api/index.js
@@ -3,6 +3,116 @@
 export const URL = "";
 
 /**
+ * Name of the cookie the server puts the session's CSRF token in.
+ *
+ * Deliberately readable by JavaScript (see `src/server/middleware/auth.js`):
+ * reading it here and echoing it back in a header is the entire mechanism that
+ * tells the server this request came from the dashboard and not from a page on
+ * somebody else's site.
+ */
+const CSRF_COOKIE = "tas.csrf";
+
+/** The header the server expects the session's CSRF token in. */
+const CSRF_HEADER = "X-CSRF-Token";
+
+/** Methods that change nothing, and therefore carry no token. */
+const SAFE_METHODS = ["GET", "HEAD", "OPTIONS"];
+
+/**
+ * The message a request that fell outside a live session is reported with.
+ *
+ * Exported so the login view can recognise it and phrase the prompt in the
+ * same words the notification used.
+ */
+export const SESSION_EXPIRED_MESSAGE =
+  "Your session has expired. Please sign in again.";
+
+/**
+ * Read the session's CSRF token out of `document.cookie`.
+ *
+ * Tolerant of every way the cookie can be missing - no document at all (a
+ * test renderer), no cookie yet (not logged in), a value that is not valid
+ * percent-encoding - because the caller's only sensible reaction to any of
+ * them is the same: send an empty token and let the server refuse it.
+ *
+ * @returns {String} The token, or "" when there is none
+ */
+export const readCsrfToken = () => {
+  if (typeof document === "undefined" || typeof document.cookie !== "string") {
+    return "";
+  }
+  const prefix = `${CSRF_COOKIE}=`;
+  const entries = document.cookie.split(";");
+  for (let index = 0; index < entries.length; index++) {
+    const entry = entries[index].trim();
+    if (entry.indexOf(prefix) === 0) {
+      const raw = entry.slice(prefix.length);
+      try {
+        return decodeURIComponent(raw);
+      } catch (e) {
+        return raw;
+      }
+    }
+  }
+  return "";
+};
+
+/**
+ * The one subscriber notified when the API says the caller has no session.
+ *
+ * A module-level slot rather than a list: there is exactly one thing in the
+ * app that reacts to this (the auth saga), and a list would quietly accumulate
+ * stale handlers across hot reloads.
+ */
+let sessionExpiredHandler = null;
+
+/**
+ * Register the handler called when a request comes back 401.
+ *
+ * @param {Function|null} handler The handler, or null to unregister
+ */
+export const onSessionExpired = (handler) => {
+  sessionExpiredHandler = typeof handler === "function" ? handler : null;
+};
+
+/** Tell the subscriber, if there is one, that the session is gone. */
+const notifySessionExpired = () => {
+  if (!sessionExpiredHandler) return;
+  try {
+    sessionExpiredHandler();
+  } catch (e) {
+    // A broken subscriber must not swallow the error the caller is about to
+    // be thrown; there is nothing useful to do with it here.
+  }
+};
+
+/**
+ * `fetch`, with the two things every API call in this file needs.
+ *
+ * The session cookie has to be sent (`credentials`), and every state-changing
+ * request has to echo the session's CSRF token or the server answers 403 (see
+ * `src/server/middleware/csrf.js`). Attaching the token here rather than at
+ * each of the ~50 call sites is what keeps a route added later from being the
+ * one that forgets it.
+ *
+ * @param {String} url The absolute URL, already built from `URL`
+ * @param {Object} [options] The usual `fetch` options
+ * @returns {Promise<Response>}
+ */
+const apiFetch = (url, options = {}) => {
+  const method = String(options.method || "GET").toUpperCase();
+  const headers = { ...(options.headers || {}) };
+  if (SAFE_METHODS.indexOf(method) === -1) {
+    headers[CSRF_HEADER] = readCsrfToken();
+  }
+  return fetch(url, {
+    ...options,
+    credentials: "same-origin",
+    headers,
+  });
+};
+
+/**
  * Build the message shown to the user from an error response.
  *
  * The API answers every failure with `{ error, details? }` (see
@@ -46,10 +156,20 @@ const errorMessage = (data, response) => {
  * Failures are still thrown, and still thrown as a plain string, because that
  * is what every saga's `catch` puts straight into a notification.
  *
+ * A 401 is the one status with a second consequence: it means the session the
+ * request was made under is gone, which the rest of the app has to know about
+ * even though the caller only sees a thrown string. The registered subscriber
+ * is told before the throw, so the dashboard can offer a sign-in without any
+ * saga having to learn a new failure shape. `authRequest` opts the three
+ * authentication calls out of that: a refused *login* is not an expired
+ * session, and reporting it as one would replace "Invalid credentials" with a
+ * message about a session the user never had.
+ *
  * @param {Response} response The fetch response
+ * @param {Object} [options] `{ authRequest }` for calls under `/api/auth`
  * @returns {Promise<Object>} The parsed body of a successful response
  */
-const parseResponse = async (response) => {
+const parseResponse = async (response, options = {}) => {
   let body = null;
   try {
     body = await response.json();
@@ -57,6 +177,10 @@ const parseResponse = async (response) => {
     // A non-JSON body (an error page from a proxy, an empty response) must not
     // surface as a raw SyntaxError.
     body = null;
+  }
+  if (response.status === 401 && options.authRequest !== true) {
+    notifySessionExpired();
+    throw SESSION_EXPIRED_MESSAGE;
   }
   if (!response.ok || (body && body.error)) {
     throw errorMessage(body, response);
@@ -67,14 +191,14 @@ const parseResponse = async (response) => {
 // MODELS
 export const requestAllModels = async () => {
   const url = `${URL}/api/models`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await parseResponse(response);
   return data.models;
 };
 
 export const requestDeleteModel = async (modelFileName) => {
   const url = `${URL}/api/models/${modelFileName}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "DELETE",
   });
   const data = await parseResponse(response);
@@ -83,7 +207,7 @@ export const requestDeleteModel = async (modelFileName) => {
 
 export const requestDuplicateModel = async (modelFileName) => {
   const url = `${URL}/api/models/${modelFileName}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -98,14 +222,14 @@ export const requestDuplicateModel = async (modelFileName) => {
 
 export const requestModel = async (modelFileName) => {
   const url = `${URL}/api/models/${modelFileName}`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await parseResponse(response);
   return data.model;
 };
 
 export const uploadModel = async (model) => {
   const url = `${URL}/api/models`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -118,7 +242,7 @@ export const uploadModel = async (model) => {
 
 export const updateModel = async (modelFileName, model) => {
   const url = `${URL}/api/models/${modelFileName}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -132,14 +256,14 @@ export const updateModel = async (modelFileName, model) => {
 // DATA RECORDERS
 export const requestAllDataRecorders = async () => {
   const url = `${URL}/api/data-recorders/models`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await parseResponse(response);
   return data.dataRecorders;
 };
 
 export const requestDeleteDataRecorder = async (dataRecorderFileName) => {
   const url = `${URL}/api/data-recorders/models/${dataRecorderFileName}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "DELETE",
   });
   const data = await parseResponse(response);
@@ -148,7 +272,7 @@ export const requestDeleteDataRecorder = async (dataRecorderFileName) => {
 
 export const requestDuplicateDataRecorder = async (dataRecorderFileName) => {
   const url = `${URL}/api/data-recorders/models/${dataRecorderFileName}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -163,14 +287,14 @@ export const requestDuplicateDataRecorder = async (dataRecorderFileName) => {
 
 export const requestDataRecorder = async (dataRecorderFileName) => {
   const url = `${URL}/api/data-recorders/models/${dataRecorderFileName}`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await parseResponse(response);
   return data.dataRecorder;
 };
 
 export const uploadDataRecorder = async (dataRecorder) => {
   const url = `${URL}/api/data-recorders/models`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -186,7 +310,7 @@ export const updateDataRecorder = async (
   dataRecorder
 ) => {
   const url = `${URL}/api/data-recorders/models/${dataRecorderFileName}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -199,7 +323,7 @@ export const updateDataRecorder = async (
 
 export const sendRequestStartDataRecorder = async (dataRecorderFileName) => {
   const url = `${URL}/api/data-recorders/start`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -212,14 +336,14 @@ export const sendRequestStartDataRecorder = async (dataRecorderFileName) => {
 
 export const sendRequestStopDataRecorder = async (fileName) => {
   const url = `${URL}/api/data-recorders/stop/${fileName}`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await parseResponse(response);
   return data.status;
 };
 
 export const sendRequestDataRecorderStatus = async () => {
   const url = `${URL}/api/data-recorders/status`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await parseResponse(response);
   return data.status;
 };
@@ -227,14 +351,14 @@ export const sendRequestDataRecorderStatus = async () => {
 // DATA STORAGE
 export const sendRequestDataStorage = async () => {
   const url = `${URL}/api/data-storage`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await parseResponse(response);
   return data.dataStorage;
 };
 
 export const sendRequestUpdateDataStorage = async (dataStorage) => {
   const url = `${URL}/api/data-storage`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -247,21 +371,21 @@ export const sendRequestUpdateDataStorage = async (dataStorage) => {
 
 export const sendRequestTestDataStorageConnection = async (dataStorage) => {
   const url = `${URL}/api/data-storage/test`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await parseResponse(response);
   return data.connectionStatus;
 };
 
 export const sendRequestLogFile = async (tool, logFile) => {
   const url = `${URL}/api/logs/${tool}/${logFile}`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await parseResponse(response);
   return data.content;
 };
 
 export const sendRequestDeleteLogFile = async (tool, logFile) => {
   const url = `${URL}/api/logs/${tool}/${logFile}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "DELETE",
   });
   const data = await parseResponse(response);
@@ -270,14 +394,14 @@ export const sendRequestDeleteLogFile = async (tool, logFile) => {
 
 export const sendRequestAllLogFiles = async (tool) => {
   const url = `${URL}/api/logs/${tool}`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await parseResponse(response);
   return data.files;
 };
 
 export const requestStartDeploy = async (tool, model) => {
   const url = `${URL}/api/${tool}/deploy`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -290,14 +414,14 @@ export const requestStartDeploy = async (tool, model) => {
 
 export const sendRequestStopSimulation = async (fileName) => {
   const url = `${URL}/api/simulation/stop/${fileName}`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await parseResponse(response);
   return data.simulationStatus;
 };
 
 export const sendRequestSimulationStatus = async () => {
   const url = `${URL}/api/simulation/status`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await parseResponse(response);
   return data.simulationStatus;
 };
@@ -305,14 +429,14 @@ export const sendRequestSimulationStatus = async () => {
 // Test campaigns
 export const sendRequestTestCampaign = async (tcId) => {
   const url = `${URL}/api/test-campaigns/${tcId}`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await parseResponse(response);
   return data.testCampaign;
 };
 
 export const sendRequestUpdateTestCampaign = async (id, testCampaign) => {
   const url = `${URL}/api/test-campaigns/${id}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -325,14 +449,14 @@ export const sendRequestUpdateTestCampaign = async (id, testCampaign) => {
 
 export const sendRequestAllTestCampaigns = async () => {
   const url = `${URL}/api/test-campaigns`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await parseResponse(response);
   return data.testCampaigns;
 };
 
 export const sendRequestAddNewTestCampaign = async (testCampaign) => {
   const url = `${URL}/api/test-campaigns`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -345,7 +469,7 @@ export const sendRequestAddNewTestCampaign = async (testCampaign) => {
 
 export const sendRequestDeleteTestCampaign = async (testCampaignId) => {
   const url = `${URL}/api/test-campaigns/${testCampaignId}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "DELETE",
   });
   const data = await parseResponse(response);
@@ -355,14 +479,14 @@ export const sendRequestDeleteTestCampaign = async (testCampaignId) => {
 // Devops
 export const sendRequestDevops = async () => {
   const url = `${URL}/api/devops`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await parseResponse(response);
   return data.devops;
 };
 
 export const sendRequestUpdateDevops = async (devops) => {
   const url = `${URL}/api/devops`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -376,14 +500,14 @@ export const sendRequestUpdateDevops = async (devops) => {
 // Test cases
 export const sendRequestTestCase = async (tcId) => {
   const url = `${URL}/api/test-cases/${tcId}`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const status = await parseResponse(response);
   return status.testCase;
 };
 
 export const sendRequestUpdateTestCase = async (id, testCase) => {
   const url = `${URL}/api/test-cases/${id}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -396,14 +520,14 @@ export const sendRequestUpdateTestCase = async (id, testCase) => {
 
 export const sendRequestAllTestCases = async () => {
   const url = `${URL}/api/test-cases`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await parseResponse(response);
   return data.testCases;
 };
 
 export const sendRequestAddNewTestCase = async (testCase) => {
   const url = `${URL}/api/test-cases`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -416,7 +540,7 @@ export const sendRequestAddNewTestCase = async (testCase) => {
 
 export const sendRequestDeleteTestCase = async (testCaseId) => {
   const url = `${URL}/api/test-cases/${testCaseId}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "DELETE",
   });
   const data = await parseResponse(response);
@@ -426,14 +550,14 @@ export const sendRequestDeleteTestCase = async (testCaseId) => {
 // Dataset
 export const sendRequestDataset = async (tcId) => {
   const url = `${URL}/api/data-sets/${tcId}`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const status = await parseResponse(response);
   return status.dataset;
 };
 
 export const sendRequestUpdateDataset = async (id, dataset) => {
   const url = `${URL}/api/data-sets/${id}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -446,14 +570,14 @@ export const sendRequestUpdateDataset = async (id, dataset) => {
 
 export const sendRequestAllDatasets = async () => {
   const url = `${URL}/api/data-sets`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await parseResponse(response);
   return data.datasets;
 };
 
 export const sendRequestAddNewDataset = async (dataset) => {
   const url = `${URL}/api/data-sets`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -466,7 +590,7 @@ export const sendRequestAddNewDataset = async (dataset) => {
 
 export const sendRequestDeleteDataset = async (datasetId) => {
   const url = `${URL}/api/data-sets/${datasetId}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "DELETE",
   });
   const data = await parseResponse(response);
@@ -476,7 +600,7 @@ export const sendRequestDeleteDataset = async (datasetId) => {
 // Reports
 export const sendRequestReport = async (rpId) => {
   const url = `${URL}/api/reports/${rpId}`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const status = await parseResponse(response);
   return status;
 };
@@ -496,14 +620,14 @@ export const sendRequestAllReports = async (options) => {
   }
 
   const url = `${URL}/api/reports${query}`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const status = await parseResponse(response);
   return status.reports;
 };
 
 export const sendRequestDeleteReport = async (reportId) => {
   const url = `${URL}/api/reports/${reportId}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "DELETE",
   });
   const data = await parseResponse(response);
@@ -513,7 +637,7 @@ export const sendRequestDeleteReport = async (reportId) => {
 export const sendRequestUpdateReport = async (id, report, newScore) => {
   console.log('Update report: ', id, report, newScore);
   const url = `${URL}/api/reports/${id}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -527,14 +651,14 @@ export const sendRequestUpdateReport = async (id, report, newScore) => {
 // Event
 export const sendRequestEvent = async (tcId) => {
   const url = `${URL}/api/events/${tcId}`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const status = await parseResponse(response);
   return status.event;
 };
 
 export const sendRequestUpdateEvent = async (id, event) => {
   const url = `${URL}/api/events/${id}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -554,14 +678,14 @@ export const sendRequestEventsByDatasetId = async (
   const url = `${URL}/api/events?datasetId=${datasetId}&startTime=${
     startTime ? startTime : 0
   }&endTime=${endTime ? endTime : Date.now()}&page=${page}`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await parseResponse(response);
   return {totalNbEvents: data.totalNbEvents, events: data.events};
 };
 
 export const sendRequestAddNewEvent = async (event) => {
   const url = `${URL}/api/events`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -574,7 +698,7 @@ export const sendRequestAddNewEvent = async (event) => {
 
 export const sendRequestDeleteEvent = async (eventId) => {
   const url = `${URL}/api/events/${eventId}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "DELETE",
   });
   const data = await parseResponse(response);
@@ -587,7 +711,7 @@ export const sendRequestStartSimulation = async (
   newDataset
 ) => {
   const url = `${URL}/api/simulation/start`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -607,21 +731,57 @@ export const sendRequestStartSimulation = async (
 // Test campaign
 export const sendRequestLaunchTestCampaign = async () => {
   const url = `${URL}/api/devops/start`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const status = await parseResponse(response);
   return status.runningStatus;
 };
 
 export const sendRequestStopTestCampaign = async () => {
   const url = `${URL}/api/devops/stop`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const status = await parseResponse(response);
   return status.runningStatus;
 };
 
 export const sendRequestTestCampaignStatus = async () => {
   const url = `${URL}/api/devops/status`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const status = await parseResponse(response);
   return status.runningStatus;
+};
+
+// AUTHENTICATION
+export const requestLogin = async ({ username, password }) => {
+  const url = `${URL}/api/auth/login`;
+  const response = await apiFetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ username, password }),
+  });
+  // The whole body is the session: `{ authenticated, user, csrfToken }`.
+  const data = await parseResponse(response, { authRequest: true });
+  return data;
+};
+
+export const requestLogout = async () => {
+  const url = `${URL}/api/auth/logout`;
+  const response = await apiFetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+  const data = await parseResponse(response, { authRequest: true });
+  return data;
+};
+
+export const requestSession = async () => {
+  // Answers 200 either way, on purpose, so a cold start can ask "am I logged
+  // in?" without turning every anonymous load into a 401.
+  const url = `${URL}/api/auth/session`;
+  const response = await apiFetch(url);
+  const data = await parseResponse(response, { authRequest: true });
+  return data;
 };

--- a/src/client/src/components/LoginForm/LoginForm.js
+++ b/src/client/src/components/LoginForm/LoginForm.js
@@ -1,0 +1,85 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { Alert, Button, Form, Input } from "antd";
+import { LockOutlined, UserOutlined } from "@ant-design/icons";
+
+import { login } from "../../actions";
+
+/**
+ * Turn what the API threw into something worth reading.
+ *
+ * The api layer throws the server's own message, which is right for a wrong
+ * password ("Invalid credentials") but unhelpful for the two failures an
+ * operator can only fix outside the browser: a server with no credential
+ * configured at all, and a login attempt that tripped the rate limit. Both are
+ * recognised by the message the server sends (see `src/server/app.js` and
+ * `src/server/routes/auth.js`) and answered with what to do about it.
+ *
+ * @param {*} error The value thrown by the api layer, normally a string
+ * @returns {String|null} The message to show, or null when there is none
+ */
+const describeError = (error) => {
+  if (!error) return null;
+  const message = typeof error === "string" ? error : String(error);
+  if (message.indexOf("Authentication is not configured") !== -1) {
+    return "This server has no administrator credential configured, so nobody can sign in yet. Set AUTH_ADMIN_USERNAME and AUTH_ADMIN_PASSWORD_HASH (see the README) and restart it.";
+  }
+  if (message.indexOf("Too many login attempts") !== -1) {
+    return "Too many failed sign-in attempts from this address. Wait a few minutes and try again.";
+  }
+  return message;
+};
+
+class LoginForm extends Component {
+  render() {
+    const { loggingIn, error, login } = this.props;
+    const description = describeError(error);
+    return (
+      <Form
+        layout="vertical"
+        onFinish={(values) =>
+          login({ username: values.username, password: values.password })
+        }
+      >
+        {description && (
+          <Form.Item>
+            <Alert type="error" message={description} showIcon />
+          </Form.Item>
+        )}
+        <Form.Item
+          label="Username"
+          name="username"
+          rules={[{ required: true, message: "Please enter your username" }]}
+        >
+          <Input prefix={<UserOutlined />} autoComplete="username" />
+        </Form.Item>
+        <Form.Item
+          label="Password"
+          name="password"
+          rules={[{ required: true, message: "Please enter your password" }]}
+        >
+          <Input.Password
+            prefix={<LockOutlined />}
+            autoComplete="current-password"
+          />
+        </Form.Item>
+        <Form.Item style={{ marginBottom: 0 }}>
+          <Button type="primary" htmlType="submit" loading={loggingIn} block>
+            Sign in
+          </Button>
+        </Form.Item>
+      </Form>
+    );
+  }
+}
+
+const mapPropsToStates = ({ auth }) => ({
+  loggingIn: auth.loggingIn,
+  error: auth.error,
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  login: ({ username, password }) => dispatch(login({ username, password })),
+});
+
+export default connect(mapPropsToStates, mapDispatchToProps)(LoginForm);

--- a/src/client/src/components/LoginForm/index.js
+++ b/src/client/src/components/LoginForm/index.js
@@ -1,0 +1,3 @@
+import LoginForm from './LoginForm';
+
+export default LoginForm;

--- a/src/client/src/components/SessionExpiredModal/SessionExpiredModal.js
+++ b/src/client/src/components/SessionExpiredModal/SessionExpiredModal.js
@@ -1,0 +1,46 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { Modal, Typography } from "antd";
+
+import LoginForm from "../LoginForm";
+
+const { Paragraph } = Typography;
+
+/**
+ * Sign in again without leaving the page.
+ *
+ * When a session runs out in the middle of a workflow the obvious reaction -
+ * send the browser to a login screen - throws away whatever the operator had
+ * typed and not yet saved. So this is a modal laid over the current page
+ * instead: the view underneath stays mounted, with its form state intact, and
+ * comes back exactly as it was once the new session is established.
+ */
+class SessionExpiredModal extends Component {
+  render() {
+    const { authenticated, sessionExpired } = this.props;
+    return (
+      <Modal
+        title="Your session has expired"
+        visible={sessionExpired && !authenticated}
+        footer={null}
+        closable={false}
+        maskClosable={false}
+        keyboard={false}
+        destroyOnClose
+      >
+        <Paragraph>
+          Sign in again to carry on. Nothing on the page behind this window has
+          been lost - anything you were editing is still there.
+        </Paragraph>
+        <LoginForm />
+      </Modal>
+    );
+  }
+}
+
+const mapPropsToStates = ({ auth }) => ({
+  authenticated: auth.authenticated,
+  sessionExpired: auth.sessionExpired,
+});
+
+export default connect(mapPropsToStates)(SessionExpiredModal);

--- a/src/client/src/components/SessionExpiredModal/index.js
+++ b/src/client/src/components/SessionExpiredModal/index.js
@@ -1,0 +1,3 @@
+import SessionExpiredModal from './SessionExpiredModal';
+
+export default SessionExpiredModal;

--- a/src/client/src/components/TSHeader/TSHeader.js
+++ b/src/client/src/components/TSHeader/TSHeader.js
@@ -2,11 +2,12 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { Layout, Menu, Row, Col } from "antd";
 import {
-  ClusterOutlined, DatabaseOutlined, DeploymentUnitOutlined, InteractionOutlined, FileTextOutlined, FolderOpenOutlined, EyeOutlined,
+  ClusterOutlined, DatabaseOutlined, DeploymentUnitOutlined, InteractionOutlined, FileTextOutlined, FolderOpenOutlined, EyeOutlined, LogoutOutlined,
 } from "@ant-design/icons";
 
 import {
   setNotification,
+  logout,
 } from "../../actions";
 import "./styles.css";
 
@@ -14,6 +15,7 @@ const { Header } = Layout;
 
 class TSHeader extends Component {
   render() {
+    const { authenticated, user, logout } = this.props;
     const menuLinks = [
       '/test-campaigns',
       '/test-cases',
@@ -99,6 +101,12 @@ class TSHeader extends Component {
                   Report
                 </a>
               </Menu.Item>
+              {authenticated ? (
+                <Menu.Item key="logout" onClick={() => logout()}>
+                  <LogoutOutlined />
+                  {user ? `Sign out (${user})` : "Sign out"}
+                </Menu.Item>
+              ) : null}
             </Menu>
           </Col>
         </Row>
@@ -108,13 +116,16 @@ class TSHeader extends Component {
   }
 }
 
-const mapPropsToStates = ({ requesting }) => ({
+const mapPropsToStates = ({ requesting, auth }) => ({
   requesting,
+  authenticated: auth.authenticated,
+  user: auth.user,
 });
 
 const mapDispatchToProps = (dispatch) => ({
   setNotification: ({ type, message }) =>
     dispatch(setNotification({ type, message })),
+  logout: () => dispatch(logout()),
 });
 
 export default connect(mapPropsToStates, mapDispatchToProps)(TSHeader);

--- a/src/client/src/pages/LoginPage.js
+++ b/src/client/src/pages/LoginPage.js
@@ -1,0 +1,44 @@
+import React, { Component } from "react";
+import { Card, Layout, Typography } from "antd";
+
+import LoginForm from "../components/LoginForm";
+import "./styles.css";
+
+const { Content } = Layout;
+const { Title, Text } = Typography;
+
+/**
+ * The whole page when there is no session.
+ *
+ * Shown instead of the routed content, not on a route of its own: the address
+ * the operator asked for is worth keeping, so that signing in leaves them on
+ * the page they were trying to reach rather than on the dashboard's front page.
+ */
+class LoginPage extends Component {
+  render() {
+    return (
+      <Layout style={{ backgroundColor: "white" }}>
+        <Content
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            padding: "60px 20px",
+          }}
+        >
+          <Card style={{ width: "100%", maxWidth: "420px" }}>
+            <Title level={3}>Sign in</Title>
+            <Text type="secondary">
+              The Testing as a Service API is only served to a signed-in
+              operator.
+            </Text>
+            <div style={{ paddingTop: "24px" }}>
+              <LoginForm />
+            </div>
+          </Card>
+        </Content>
+      </Layout>
+    );
+  }
+}
+
+export default LoginPage;

--- a/src/client/src/reducers/authReducer.js
+++ b/src/client/src/reducers/authReducer.js
@@ -1,0 +1,64 @@
+import {
+  createReducer
+} from "redux-act";
+import produce from "immer";
+import {
+  checkSession,
+  setSession,
+  login,
+  setLoginError,
+  logout,
+  sessionExpired
+} from "../actions";
+
+// `checking` starts true: the app asks the server who it is on mount, and
+// rendering the login form during that round trip would flash a sign-in
+// prompt at somebody who is already signed in.
+const initState = {
+  authenticated: false,
+  user: null,
+  checking: true,
+  loggingIn: false,
+  error: null,
+  sessionExpired: false
+};
+
+export default createReducer({
+    [checkSession]: produce((draft) => {
+      draft.checking = true;
+    }),
+    [setSession]: produce((draft, session) => {
+      const authenticated = !!(session && session.authenticated);
+      draft.authenticated = authenticated;
+      draft.user = authenticated ? session.user : null;
+      draft.checking = false;
+      draft.loggingIn = false;
+      draft.error = null;
+      // A session that has just been established is by definition not the
+      // expired one, so this is what dismisses the re-authentication modal.
+      draft.sessionExpired = false;
+    }),
+    [login]: produce((draft) => {
+      draft.loggingIn = true;
+      draft.error = null;
+    }),
+    [setLoginError]: produce((draft, error) => {
+      draft.loggingIn = false;
+      draft.error = typeof error === "string" && error ? error : "Sign in failed";
+    }),
+    [logout]: produce((draft) => {
+      draft.loggingIn = false;
+      draft.error = null;
+    }),
+    [sessionExpired]: produce((draft) => {
+      // Deliberately leaves the rest of the app mounted: the flag is what
+      // raises a sign-in modal over the current page, so an unsaved form is
+      // still there afterwards.
+      draft.authenticated = false;
+      draft.user = null;
+      draft.checking = false;
+      draft.sessionExpired = true;
+    }),
+  },
+  initState
+);

--- a/src/client/src/reducers/index.js
+++ b/src/client/src/reducers/index.js
@@ -19,6 +19,7 @@ import devopsReducer from './devopsReducer';
 import testCasesReducer from './testCasesReducer';
 import datasetsReducer from './datasetsReducer';
 import reportsReducer from './reportsReducer';
+import authReducer from './authReducer';
 
 const rootReducer = combineReducers({
   allDataRecorders: allDataRecordersReducer,
@@ -37,7 +38,8 @@ const rootReducer = combineReducers({
   devops: devopsReducer,
   testCases: testCasesReducer,
   datasets: datasetsReducer,
-  reports: reportsReducer
+  reports: reportsReducer,
+  auth: authReducer
 });
 
 export default rootReducer;

--- a/src/client/src/sagas/authSaga.js
+++ b/src/client/src/sagas/authSaga.js
@@ -1,0 +1,84 @@
+// watcher saga -> actions -> worker saga
+import {
+  call,
+  fork,
+  put,
+  take,
+  takeEvery,
+} from 'redux-saga/effects';
+import { eventChannel } from 'redux-saga';
+
+import {
+  requestLogin,
+  requestLogout,
+  requestSession,
+  onSessionExpired,
+} from '../api';
+import {
+  setNotification,
+  setSession,
+  setLoginError,
+  sessionExpired,
+} from '../actions';
+
+function* handleCheckSession() {
+  try {
+    const session = yield call(() => requestSession());
+    yield put(setSession(session));
+  } catch (error) {
+    // Asking who we are must never leave the app stuck on its loading state:
+    // an unreachable server is answered the same way as an anonymous one.
+    yield put(setSession({ authenticated: false }));
+    yield put(setNotification({type: 'error', message: error}));
+  }
+}
+
+function* handleLogin(action) {
+  try {
+    const session = yield call(() => requestLogin(action.payload));
+    yield put(setSession(session));
+  } catch (error) {
+    // The api layer throws a plain string, which is what the login form shows.
+    yield put(setLoginError(error));
+  }
+}
+
+function* handleLogout() {
+  try {
+    yield call(() => requestLogout());
+  } catch (error) {
+    yield put(setNotification({type: 'error', message: error}));
+  }
+  // Whether or not the server could be told, this browser is signed out.
+  yield put(setSession({ authenticated: false }));
+}
+
+/**
+ * Turn the api layer's session-expiry callback into a saga channel.
+ *
+ * The api layer cannot dispatch - it knows nothing about the store - so it
+ * exposes one subscriber slot instead, and this is the bridge to it.
+ */
+function createSessionExpiryChannel() {
+  return eventChannel((emitter) => {
+    onSessionExpired(() => emitter(true));
+    return () => onSessionExpired(null);
+  });
+}
+
+function* watchSessionExpiry() {
+  const channel = yield call(createSessionExpiryChannel);
+  while (true) {
+    yield take(channel);
+    yield put(sessionExpired());
+  }
+}
+
+function* watchAuth() {
+  yield fork(watchSessionExpiry);
+  yield takeEvery('CHECK_SESSION', handleCheckSession);
+  yield takeEvery('LOGIN', handleLogin);
+  yield takeEvery('LOGOUT', handleLogout);
+}
+
+export default watchAuth;

--- a/src/client/src/sagas/index.js
+++ b/src/client/src/sagas/index.js
@@ -12,6 +12,7 @@ import datasetsSaga from './datasetsSaga';
 import eventsSaga from './eventsSaga';
 import reportsSaga from './reportsSaga';
 import devopsSaga from './devopsSaga';
+import authSaga from './authSaga';
 
 function* rootSaga() {
   yield all([
@@ -26,7 +27,8 @@ function* rootSaga() {
     testCasesSaga(),
     datasetsSaga(),
     eventsSaga(),
-    reportsSaga()
+    reportsSaga(),
+    authSaga()
   ]);
 }
 

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -35,11 +35,17 @@ const createAuthRouter = require('./routes/auth');
  * Both are process-wide by design: there is one operator account, and the
  * session table is the thing that makes a session revocable (see
  * `auth/session-store.js`).
+ *
+ * `createCredential` hashes any plaintext bootstrap password and erases it from
+ * the configuration object as it goes, so what this module holds for the
+ * lifetime of the process — and hands to the middleware, the router and the
+ * cookie helpers — no longer carries the plaintext at all.
  */
 const credential = createCredential(config);
 const sessions = createSessionStore({
   idleTtlMs: config.sessionIdleTtlMs,
-  absoluteTtlMs: config.sessionAbsoluteTtlMs
+  absoluteTtlMs: config.sessionAbsoluteTtlMs,
+  maxSessions: config.sessionMaxRecords
 });
 
 if (!credential.configured) {

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -7,6 +7,10 @@ var rateLimit = require('express-rate-limit');
 var { loadConfig } = require('./config');
 var { errorHandler, apiNotFound, forbidden, ApiError, sendError } = require('./middleware/errors');
 var { securityHeaders } = require('./middleware/security-headers');
+var { createAuthMiddleware } = require('./middleware/auth');
+var { createCsrfMiddleware } = require('./middleware/csrf');
+var { createCredential } = require('./auth/credentials');
+var { createSessionStore } = require('./auth/session-store');
 
 // Read the environment configuration once at startup.
 const config = loadConfig();
@@ -22,6 +26,28 @@ const testCampaignRouter = require('./routes/test-campaigns');
 const dataSetRouter = require('./routes/data-sets');
 const eventRouter = require('./routes/events');
 const devopsRouter = require('./routes/devops');
+const healthRouter = require('./routes/health');
+const createAuthRouter = require('./routes/auth');
+
+/**
+ * The single administrator credential and the session table, built once.
+ *
+ * Both are process-wide by design: there is one operator account, and the
+ * session table is the thing that makes a session revocable (see
+ * `auth/session-store.js`).
+ */
+const credential = createCredential(config);
+const sessions = createSessionStore({
+  idleTtlMs: config.sessionIdleTtlMs,
+  absoluteTtlMs: config.sessionAbsoluteTtlMs
+});
+
+if (!credential.configured) {
+  console.error('[AUTH] No administrator credential configured — every API endpoint will reject requests. Set AUTH_ADMIN_PASSWORD or AUTH_ADMIN_PASSWORD_HASH.');
+}
+if (config.authTrustProxyHeader === true && config.authTrustedProxies.length === 0) {
+  console.error('[AUTH] AUTH_TRUST_PROXY_HEADER is enabled but AUTH_TRUSTED_PROXIES is empty — proxy identity delegation stays disabled.');
+}
 
 var app = express();
 
@@ -95,7 +121,10 @@ app.use(function corsControl(req, res, next) {
   res.setHeader('Vary', 'Origin');
   res.setHeader('Access-Control-Allow-Origin', origin);
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  // X-CSRF-Token is part of every state-changing request the dashboard makes,
+  // so a cross-origin dashboard configured through CORS_ALLOWED_ORIGINS cannot
+  // work without the browser being told the header is permitted.
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-CSRF-Token');
   res.setHeader('Access-Control-Allow-Credentials', 'true');
 
   if (req.method === 'OPTIONS') {
@@ -112,7 +141,10 @@ app.use(bodyParser.urlencoded({
   limit: config.bodyLimit,
   extended: true
 }));
-app.use(cookieParser());
+// The secret is what makes `signed: true` cookies verifiable: a session cookie
+// that was edited or minted by anything but this process fails the signature
+// check and never reaches the session table.
+app.use(cookieParser(config.sessionSecret));
 app.use(express.static(path.join(__dirname, '../public')));
 
 // Per-client rate limiting on the unauthenticated API surface.
@@ -129,6 +161,40 @@ const apiLimiter = rateLimit({
 });
 
 app.use('/api', apiLimiter);
+
+/**
+ * A second, much tighter limit on the login endpoint alone.
+ *
+ * `skipSuccessfulRequests` is what makes it usable: only *failed* logins count
+ * towards it, so an operator who mistypes a password a few times is unaffected
+ * while a credential-guessing run is cut off after a handful of attempts. The
+ * general API limit above is far too loose to be that ceiling.
+ */
+const loginLimiter = rateLimit({
+  windowMs: config.authLoginRateLimitWindowMs,
+  max: config.authLoginRateLimitMax,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skipSuccessfulRequests: true,
+  handler: function (req, res, next) {
+    next(new ApiError(429, 'Too many login attempts, please try again later.'));
+  }
+});
+
+app.use('/api/auth/login', loginLimiter);
+
+/**
+ * Everything under /api requires a session, bar the short allowlist declared in
+ * `middleware/auth.js`; every state-changing request additionally has to echo
+ * the token bound to that session (`middleware/csrf.js`). Both are mounted here,
+ * ahead of every router, so a route added later is closed by default rather
+ * than open until somebody remembers to guard it.
+ */
+app.use('/api', createAuthMiddleware({ credential: credential, sessions: sessions, config: config }));
+app.use('/api', createCsrfMiddleware());
+
+app.use('/api/health', healthRouter);
+app.use('/api/auth', createAuthRouter({ credential: credential, sessions: sessions, config: config }));
 
 app.use('/api/models', modelRouter);
 app.use('/api/data-recorders', dataRecorderRouter);

--- a/src/server/auth/credentials.js
+++ b/src/server/auth/credentials.js
@@ -12,6 +12,14 @@
  * once here and the plaintext is dropped on the floor immediately, so it is
  * never stored on the returned object, never logged and never comparable by a
  * later bug.
+ *
+ * "Dropped on the floor" is meant literally, and it extends to the caller's
+ * configuration object: that object is held for the lifetime of the process and
+ * passed to the middleware, the router and the cookie helpers, so a plaintext
+ * left on it would be reachable from a heap dump, a debugger or a careless
+ * `console.error(config)` long after it was needed. This function therefore
+ * blanks the plaintext fields on the object it is handed, once it has hashed
+ * them. It is the only consumer of those fields.
  */
 const { hashPassword, verifyPassword, timingSafeCompare } = require("./passwords");
 
@@ -24,6 +32,24 @@ const { hashPassword, verifyPassword, timingSafeCompare } = require("./passwords
  * set at all.
  */
 const UNCONFIGURED_HASH = hashPassword(require("crypto").randomBytes(32).toString("hex"));
+
+/**
+ * Blank a secret field on a configuration object, tolerating a frozen or
+ * read-only object rather than failing startup over a defence-in-depth measure.
+ *
+ * @param {Object} target The object to scrub
+ * @param {String} key The field to blank
+ * @returns {void}
+ */
+function eraseSecret(target, key) {
+  if (typeof target[key] !== "string" || target[key] === "") return;
+  try {
+    target[key] = "";
+  } catch (_) {
+    // Non-writable property: the value stays, and the hash is still what the
+    // login route compares against.
+  }
+}
 
 /**
  * Build the credential the login route verifies against.
@@ -46,6 +72,12 @@ function createCredential(config) {
     hash = hashPassword(settings.authAdminPassword);
     source = "password";
   }
+
+  // Erase the plaintext from the caller's object now that it has been hashed.
+  // Deliberately unconditional: whether the hash form won, the plaintext form
+  // did, or neither was set, nothing downstream has any use for the plaintext.
+  eraseSecret(settings, "authAdminPassword");
+  eraseSecret(settings, "AUTH_ADMIN_PASSWORD");
 
   const configured = hash !== null;
   const stored = configured ? hash : UNCONFIGURED_HASH;

--- a/src/server/auth/credentials.js
+++ b/src/server/auth/credentials.js
@@ -1,0 +1,73 @@
+/**
+ * The single administrator credential, provisioned from configuration.
+ *
+ * TaS is a single-tenant appliance: there is one operator account, and it is
+ * bootstrapped from the environment rather than from a committed file, so a
+ * checkout of this repository never carries a working credential and two
+ * deployments never share one.
+ *
+ * Two forms are accepted. `AUTH_ADMIN_PASSWORD_HASH` is the preferred one — the
+ * plaintext then only ever exists on the machine where the hash was generated.
+ * `AUTH_ADMIN_PASSWORD` is the convenience form for a first start; it is hashed
+ * once here and the plaintext is dropped on the floor immediately, so it is
+ * never stored on the returned object, never logged and never comparable by a
+ * later bug.
+ */
+const { hashPassword, verifyPassword, timingSafeCompare } = require("./passwords");
+
+/**
+ * A hash of a value nobody knows, used when no credential is configured.
+ *
+ * Verification still runs against it so an unconfigured deployment answers a
+ * login attempt in the same time as a configured one — otherwise the response
+ * time alone would tell an anonymous caller whether the server has a password
+ * set at all.
+ */
+const UNCONFIGURED_HASH = hashPassword(require("crypto").randomBytes(32).toString("hex"));
+
+/**
+ * Build the credential the login route verifies against.
+ *
+ * @param {Object} config The loaded server configuration
+ * @returns {{configured: Boolean, username: String, source: String|null, verify: Function}}
+ */
+function createCredential(config) {
+  const settings = config || {};
+  const username = String(settings.authAdminUsername || "admin");
+
+  let hash = null;
+  let source = null;
+
+  if (typeof settings.authAdminPasswordHash === "string" && settings.authAdminPasswordHash.trim() !== "") {
+    hash = settings.authAdminPasswordHash.trim();
+    source = "hash";
+  } else if (typeof settings.authAdminPassword === "string" && settings.authAdminPassword !== "") {
+    // Hashed once, here, and the plaintext goes out of scope with this branch.
+    hash = hashPassword(settings.authAdminPassword);
+    source = "password";
+  }
+
+  const configured = hash !== null;
+  const stored = configured ? hash : UNCONFIGURED_HASH;
+
+  return {
+    configured: configured,
+    username: username,
+    source: source,
+    /**
+     * @param {String} offeredUsername Username from the login request
+     * @param {String} offeredPassword Password from the login request
+     * @returns {Boolean} True only when both match the configured credential
+     */
+    verify: function (offeredUsername, offeredPassword) {
+      const nameMatches = timingSafeCompare(offeredUsername, username);
+      // Deliberately unconditional: short-circuiting on the username would make
+      // a wrong username measurably faster to reject than a wrong password,
+      // which is a user-enumeration oracle even for a single-account system.
+      const passwordMatches = verifyPassword(offeredPassword, stored);
+      return configured && nameMatches && passwordMatches;
+    },
+  };
+}
+
+module.exports = { createCredential };

--- a/src/server/auth/passwords.js
+++ b/src/server/auth/passwords.js
@@ -1,0 +1,121 @@
+/**
+ * Password hashing and constant-time comparison.
+ *
+ * The administrator credential is the only secret the server verifies, so it is
+ * stored the way a password store must be: never in plaintext, salted per
+ * credential, and behind a deliberately slow key derivation. `scrypt` is used
+ * because it ships in Node's own `crypto` module — a native add-on such as
+ * bcrypt would have to be compiled inside the alpine image the Dockerfile
+ * builds, which turns a hardening change into a build-system change.
+ *
+ * Every comparison in this file runs in constant time. A verifier that returns
+ * as soon as two bytes differ leaks, through its response time, how much of a
+ * guess was right, which is enough to reconstruct a secret one byte at a time.
+ * `crypto.timingSafeEqual` refuses buffers of different lengths, so each caller
+ * checks the length first and reports the mismatch as a plain "no" rather than
+ * letting an exception escape into the request path.
+ */
+const crypto = require("crypto");
+
+/** Serialised-form marker: this file only ever produces and reads scrypt hashes. */
+const ALGORITHM = "scrypt";
+
+/**
+ * scrypt cost parameters. N=16384/r=8/p=1 is the interactive-login preset: it
+ * costs a few tens of milliseconds per verification here and many machine-years
+ * to brute-force a strong password offline. `maxmem` is raised above Node's
+ * 32 MiB default because N*r*128 plus scrypt's own overhead sits just over it.
+ */
+const COST = { N: 16384, r: 8, p: 1, maxmem: 64 * 1024 * 1024 };
+
+/** Length of the random salt, in bytes. */
+const SALT_BYTES = 16;
+
+/** Length of the derived key, in bytes. */
+const KEY_BYTES = 64;
+
+/**
+ * Compare two strings without revealing, through timing, where they differ.
+ *
+ * @param {String} a First value
+ * @param {String} b Second value
+ * @returns {Boolean} True when the two values are byte-for-byte identical
+ */
+function timingSafeCompare(a, b) {
+  const left = Buffer.from(String(a === undefined || a === null ? "" : a), "utf8");
+  const right = Buffer.from(String(b === undefined || b === null ? "" : b), "utf8");
+  if (left.length !== right.length) {
+    // Still do a comparison of equal-length buffers so a length mismatch is not
+    // measurably cheaper than a content mismatch.
+    crypto.timingSafeEqual(left, left);
+    return false;
+  }
+  return crypto.timingSafeEqual(left, right);
+}
+
+/**
+ * Hash a plaintext password into the serialised form this module verifies.
+ *
+ * The returned string carries the algorithm and the cost parameters alongside
+ * the salt and the derived key, so a stored hash stays verifiable after the
+ * defaults here are raised.
+ *
+ * @param {String} plain The plaintext password
+ * @returns {String} `scrypt$N$r$p$<saltBase64>$<hashBase64>`
+ */
+function hashPassword(plain) {
+  const salt = crypto.randomBytes(SALT_BYTES);
+  const derived = crypto.scryptSync(String(plain), salt, KEY_BYTES, COST);
+  return [
+    ALGORITHM,
+    COST.N,
+    COST.r,
+    COST.p,
+    salt.toString("base64"),
+    derived.toString("base64"),
+  ].join("$");
+}
+
+/**
+ * Verify a plaintext password against a serialised hash.
+ *
+ * Never throws: a malformed or truncated stored value is a configuration
+ * mistake, and turning it into an exception inside the login path would answer
+ * a wrong password with a 500 carrying a stack trace.
+ *
+ * @param {String} plain The plaintext password offered by the caller
+ * @param {String} serialized The stored `scrypt$...` value
+ * @returns {Boolean} True only when the password reproduces the stored key
+ */
+function verifyPassword(plain, serialized) {
+  try {
+    const parts = String(serialized || "").split("$");
+    if (parts.length !== 6 || parts[0] !== ALGORITHM) return false;
+    const N = Number(parts[1]);
+    const r = Number(parts[2]);
+    const p = Number(parts[3]);
+    if (!Number.isInteger(N) || !Number.isInteger(r) || !Number.isInteger(p)) return false;
+    if (N < 2 || r < 1 || p < 1) return false;
+    const salt = Buffer.from(parts[4], "base64");
+    const expected = Buffer.from(parts[5], "base64");
+    if (salt.length === 0 || expected.length === 0) return false;
+    const derived = crypto.scryptSync(String(plain), salt, expected.length, {
+      N: N,
+      r: r,
+      p: p,
+      maxmem: COST.maxmem,
+    });
+    if (derived.length !== expected.length) return false;
+    return crypto.timingSafeEqual(derived, expected);
+  } catch (_) {
+    // A bad base64 payload, an unsupported cost, an out-of-memory scrypt: all
+    // of them mean "this value does not verify", not "the server broke".
+    return false;
+  }
+}
+
+module.exports = {
+  hashPassword,
+  verifyPassword,
+  timingSafeCompare,
+};

--- a/src/server/auth/session-store.js
+++ b/src/server/auth/session-store.js
@@ -15,6 +15,12 @@
  * Expired records are removed lazily, from `get` and `create`, rather than by a
  * timer: a `setInterval` would hold the event loop open and stop the process
  * (and every test suite that starts one) from exiting on its own.
+ *
+ * Lazy expiry alone is not a bound, though: nothing stops a caller from minting
+ * records faster than they age out. So the table also carries a hard size cap
+ * and evicts the least recently seen record when it is full, exactly as the
+ * login failure tracker is bounded in `routes/auth.js`. The map is kept in
+ * recency order (`touch` re-inserts) so "least recently seen" is its first key.
  */
 const crypto = require("crypto");
 
@@ -23,6 +29,9 @@ const DEFAULT_IDLE_TTL_MS = 60 * 60 * 1000;
 
 /** Default hard cap: no session outlives half a day, however busy it is. */
 const DEFAULT_ABSOLUTE_TTL_MS = 12 * 60 * 60 * 1000;
+
+/** Most records held at once before the least recently seen one is evicted. */
+const DEFAULT_MAX_SESSIONS = 1000;
 
 /** Opaque, unguessable identifier — 256 bits from the system CSPRNG. */
 const newId = () => crypto.randomBytes(32).toString("base64url");
@@ -33,6 +42,7 @@ const newId = () => crypto.randomBytes(32).toString("base64url");
  * @param {Object} [options]
  * @param {Number} [options.idleTtlMs] Sliding inactivity window
  * @param {Number} [options.absoluteTtlMs] Hard lifetime, measured from creation
+ * @param {Number} [options.maxSessions] Hard cap on how many records are held
  * @returns {Object} The store
  */
 function createSessionStore(options) {
@@ -40,6 +50,8 @@ function createSessionStore(options) {
   const idleTtlMs = Number(opts.idleTtlMs) > 0 ? Number(opts.idleTtlMs) : DEFAULT_IDLE_TTL_MS;
   const absoluteTtlMs =
     Number(opts.absoluteTtlMs) > 0 ? Number(opts.absoluteTtlMs) : DEFAULT_ABSOLUTE_TTL_MS;
+  const maxSessions =
+    Number(opts.maxSessions) > 0 ? Math.floor(Number(opts.maxSessions)) : DEFAULT_MAX_SESSIONS;
 
   const sessions = new Map();
 
@@ -75,6 +87,15 @@ function createSessionStore(options) {
      */
     create: function (user) {
       sweep();
+      // Sweeping only reclaims records that have aged out. Under a load that
+      // mints faster than the idle window expires them, the cap is what keeps
+      // the table bounded; the oldest key is the least recently seen one
+      // because `touch` re-inserts.
+      while (sessions.size >= maxSessions) {
+        const oldest = sessions.keys().next();
+        if (oldest.done) break;
+        sessions.delete(oldest.value);
+      }
       const now = Date.now();
       const session = {
         id: newId(),
@@ -112,6 +133,10 @@ function createSessionStore(options) {
       const session = this.get(id);
       if (!session) return null;
       session.lastSeenAt = Date.now();
+      // Re-insert so the map stays ordered by recency and eviction can take the
+      // first key without scanning.
+      sessions.delete(session.id);
+      sessions.set(session.id, session);
       return session;
     },
 
@@ -135,7 +160,17 @@ function createSessionStore(options) {
     size: function () {
       return sessions.size;
     },
+
+    /** @returns {Number} The hard cap this store evicts at. */
+    maxSessions: function () {
+      return maxSessions;
+    },
   };
 }
 
-module.exports = { createSessionStore, DEFAULT_IDLE_TTL_MS, DEFAULT_ABSOLUTE_TTL_MS };
+module.exports = {
+  createSessionStore,
+  DEFAULT_IDLE_TTL_MS,
+  DEFAULT_ABSOLUTE_TTL_MS,
+  DEFAULT_MAX_SESSIONS,
+};

--- a/src/server/auth/session-store.js
+++ b/src/server/auth/session-store.js
@@ -1,0 +1,141 @@
+/**
+ * The server-side session table.
+ *
+ * Sessions are held here, in the process, and the browser only ever carries an
+ * opaque identifier. That is what makes a session revocable: a self-contained
+ * token (a JWT, say) cannot be invalidated before it expires without a denylist,
+ * which is this table under another name — and this deployment is a single
+ * process, so the table is both tiny and authoritative.
+ *
+ * Expiry is two-sided on purpose. The idle timeout slides forward on every
+ * request, so an operator working in the dashboard is never logged out mid-task
+ * (that is the "no spurious logouts" requirement); the absolute timeout does not
+ * slide, so a session cannot be kept alive indefinitely by traffic alone.
+ *
+ * Expired records are removed lazily, from `get` and `create`, rather than by a
+ * timer: a `setInterval` would hold the event loop open and stop the process
+ * (and every test suite that starts one) from exiting on its own.
+ */
+const crypto = require("crypto");
+
+/** Default idle window: an operator session that goes quiet for an hour ends. */
+const DEFAULT_IDLE_TTL_MS = 60 * 60 * 1000;
+
+/** Default hard cap: no session outlives half a day, however busy it is. */
+const DEFAULT_ABSOLUTE_TTL_MS = 12 * 60 * 60 * 1000;
+
+/** Opaque, unguessable identifier — 256 bits from the system CSPRNG. */
+const newId = () => crypto.randomBytes(32).toString("base64url");
+
+/**
+ * Create an in-process session store.
+ *
+ * @param {Object} [options]
+ * @param {Number} [options.idleTtlMs] Sliding inactivity window
+ * @param {Number} [options.absoluteTtlMs] Hard lifetime, measured from creation
+ * @returns {Object} The store
+ */
+function createSessionStore(options) {
+  const opts = options || {};
+  const idleTtlMs = Number(opts.idleTtlMs) > 0 ? Number(opts.idleTtlMs) : DEFAULT_IDLE_TTL_MS;
+  const absoluteTtlMs =
+    Number(opts.absoluteTtlMs) > 0 ? Number(opts.absoluteTtlMs) : DEFAULT_ABSOLUTE_TTL_MS;
+
+  const sessions = new Map();
+
+  /**
+   * @param {Object} session The stored record
+   * @param {Number} now Current epoch milliseconds
+   * @returns {Boolean} True when the record may no longer be used
+   */
+  const isExpired = (session, now) =>
+    now - session.lastSeenAt > idleTtlMs || now - session.createdAt > absoluteTtlMs;
+
+  /**
+   * Drop every expired record. Cheap: the table holds one entry per live
+   * operator session, which for a single-tenant appliance is a handful.
+   * @returns {Number} How many records were removed
+   */
+  function sweep() {
+    const now = Date.now();
+    let removed = 0;
+    for (const [id, session] of sessions) {
+      if (isExpired(session, now)) {
+        sessions.delete(id);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  return {
+    /**
+     * @param {String} user The authenticated identity
+     * @returns {Object} The new session record
+     */
+    create: function (user) {
+      sweep();
+      const now = Date.now();
+      const session = {
+        id: newId(),
+        user: String(user),
+        csrfToken: crypto.randomBytes(32).toString("base64url"),
+        createdAt: now,
+        lastSeenAt: now,
+        expiresAt: now + absoluteTtlMs,
+      };
+      sessions.set(session.id, session);
+      return session;
+    },
+
+    /**
+     * @param {String} id Session identifier from the cookie
+     * @returns {Object|null} The live record, or null when absent or expired
+     */
+    get: function (id) {
+      if (typeof id !== "string" || id === "") return null;
+      const session = sessions.get(id);
+      if (!session) return null;
+      if (isExpired(session, Date.now())) {
+        sessions.delete(id);
+        return null;
+      }
+      return session;
+    },
+
+    /**
+     * Slide the inactivity window forward.
+     * @param {String} id Session identifier
+     * @returns {Object|null} The refreshed record, or null when it is gone
+     */
+    touch: function (id) {
+      const session = this.get(id);
+      if (!session) return null;
+      session.lastSeenAt = Date.now();
+      return session;
+    },
+
+    /**
+     * @param {String} id Session identifier
+     * @returns {Boolean} True when a record was removed
+     */
+    destroy: function (id) {
+      if (typeof id !== "string") return false;
+      return sessions.delete(id);
+    },
+
+    /** Invalidate every session at once. */
+    destroyAll: function () {
+      sessions.clear();
+    },
+
+    sweep: sweep,
+
+    /** @returns {Number} How many records are held (expired ones included). */
+    size: function () {
+      return sessions.size;
+    },
+  };
+}
+
+module.exports = { createSessionStore, DEFAULT_IDLE_TTL_MS, DEFAULT_ABSOLUTE_TTL_MS };

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -26,10 +26,11 @@ var SECURITY_DEFAULTS = {
   cspReportOnly: true, // report violations, do not block, until observed clean
   cspReportUri: '', // empty = browsers report to the console only
   authAdminUsername: 'admin', // the single operator account
-  authAdminPassword: '', // plaintext bootstrap; hashed at startup, never kept
+  authAdminPassword: '', // plaintext bootstrap; hashed and erased by createCredential
   authAdminPasswordHash: '', // preferred: a `scrypt$...` value from hashPassword
   sessionIdleTtlMs: 60 * 60 * 1000, // 1 hour of inactivity ends a session
   sessionAbsoluteTtlMs: 12 * 60 * 60 * 1000, // no session outlives 12 hours
+  sessionMaxRecords: 1000, // hard cap on the session table; oldest is evicted
   // Plain HTTP on loopback behind a TLS-terminating reverse proxy is the
   // documented deployment baseline, and a `Secure` cookie is simply never sent
   // over such a connection - hard-coding it on would make the shipped
@@ -215,6 +216,8 @@ function loadConfig(options) {
     sessionIdleTtlMs: Number(value('SESSION_TTL_MS')) || SECURITY_DEFAULTS.sessionIdleTtlMs,
     sessionAbsoluteTtlMs:
       Number(value('SESSION_ABSOLUTE_TTL_MS')) || SECURITY_DEFAULTS.sessionAbsoluteTtlMs,
+    sessionMaxRecords:
+      Number(value('SESSION_MAX_RECORDS')) || SECURITY_DEFAULTS.sessionMaxRecords,
     sessionCookieSecure: parseBoolean(
       value('SESSION_COOKIE_SECURE'),
       SECURITY_DEFAULTS.sessionCookieSecure

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -1,3 +1,4 @@
+var crypto = require('crypto');
 var dotenv = require('dotenv');
 var fs = require('fs');
 var path = require('path');
@@ -23,8 +24,75 @@ var SECURITY_DEFAULTS = {
   rateLimitMax: 1000, // requests per window per client
   corsAllowedOrigins: [], // empty = same-origin only
   cspReportOnly: true, // report violations, do not block, until observed clean
-  cspReportUri: '' // empty = browsers report to the console only
+  cspReportUri: '', // empty = browsers report to the console only
+  authAdminUsername: 'admin', // the single operator account
+  authAdminPassword: '', // plaintext bootstrap; hashed at startup, never kept
+  authAdminPasswordHash: '', // preferred: a `scrypt$...` value from hashPassword
+  sessionIdleTtlMs: 60 * 60 * 1000, // 1 hour of inactivity ends a session
+  sessionAbsoluteTtlMs: 12 * 60 * 60 * 1000, // no session outlives 12 hours
+  // Plain HTTP on loopback behind a TLS-terminating reverse proxy is the
+  // documented deployment baseline, and a `Secure` cookie is simply never sent
+  // over such a connection - hard-coding it on would make the shipped
+  // `docker run` unable to log in at all. Operators whose TLS reaches the
+  // application itself must set SESSION_COOKIE_SECURE=true; the README says so.
+  sessionCookieSecure: false,
+  authTrustProxyHeader: false, // identity delegation is opt-in, and off by default
+  authProxyUserHeader: 'x-forwarded-user',
+  authTrustedProxies: [], // empty = delegation stays off, whatever the flag says
+  authLoginRateLimitWindowMs: 15 * 60 * 1000,
+  authLoginRateLimitMax: 10 // failed logins per window per client
 };
+
+/**
+ * Emitted once per process, so a restart loop does not bury the rest of the log.
+ */
+var warnedAboutSessionSecret = false;
+
+/**
+ * Read the secret the session cookie is signed with.
+ *
+ * There is deliberately no default value. A hardcoded fallback would ship in
+ * the image, be identical in every deployment, and be readable by anyone with
+ * the source - which is to say it would let anyone mint a valid session cookie.
+ *
+ * Refusing to start instead would turn a missing hardening knob into an outage
+ * for every existing deployment, container healthcheck and smoke test that has
+ * never heard of this setting. An ephemeral per-process secret is the fail-safe
+ * middle: it cannot be guessed, it is never shared, it degrades only in that
+ * sessions do not survive a restart - and it says so, loudly, at startup. The
+ * value itself is never logged.
+ *
+ * @param {String} configured Raw configuration value
+ * @returns {String} The secret to sign session cookies with
+ */
+function resolveSessionSecret(configured) {
+  var secret = String(configured || '').trim();
+  if (secret !== '') {
+    return secret;
+  }
+  if (!warnedAboutSessionSecret) {
+    warnedAboutSessionSecret = true;
+    console.error('[AUTH] SESSION_SECRET is not set — generated an ephemeral secret; all sessions will be invalidated when this process restarts. Set SESSION_SECRET in production.');
+  }
+  return crypto.randomBytes(32).toString('hex');
+}
+
+/**
+ * Split a comma/whitespace separated list into trimmed, non-empty entries.
+ * @param {String} value Raw configuration value
+ * @returns {String[]} The entries
+ */
+function normalizeList(value) {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(/[,\s]+/)
+    .map(function (entry) {
+      return entry.trim();
+    })
+    .filter(Boolean);
+}
 
 /**
  * Split a comma/whitespace separated origin list into normalised origins.
@@ -138,7 +206,31 @@ function loadConfig(options) {
     rateLimitMax: Number(value('RATE_LIMIT_MAX')) || SECURITY_DEFAULTS.rateLimitMax,
     corsAllowedOrigins: normalizeOrigins(value('CORS_ALLOWED_ORIGINS')),
     cspReportOnly: parseBoolean(value('CSP_REPORT_ONLY'), SECURITY_DEFAULTS.cspReportOnly),
-    cspReportUri: parseReportUri(value('CSP_REPORT_URI') || SECURITY_DEFAULTS.cspReportUri)
+    cspReportUri: parseReportUri(value('CSP_REPORT_URI') || SECURITY_DEFAULTS.cspReportUri),
+    authAdminUsername: value('AUTH_ADMIN_USERNAME') || SECURITY_DEFAULTS.authAdminUsername,
+    authAdminPassword: value('AUTH_ADMIN_PASSWORD') || SECURITY_DEFAULTS.authAdminPassword,
+    authAdminPasswordHash:
+      value('AUTH_ADMIN_PASSWORD_HASH') || SECURITY_DEFAULTS.authAdminPasswordHash,
+    sessionSecret: resolveSessionSecret(value('SESSION_SECRET')),
+    sessionIdleTtlMs: Number(value('SESSION_TTL_MS')) || SECURITY_DEFAULTS.sessionIdleTtlMs,
+    sessionAbsoluteTtlMs:
+      Number(value('SESSION_ABSOLUTE_TTL_MS')) || SECURITY_DEFAULTS.sessionAbsoluteTtlMs,
+    sessionCookieSecure: parseBoolean(
+      value('SESSION_COOKIE_SECURE'),
+      SECURITY_DEFAULTS.sessionCookieSecure
+    ),
+    authTrustProxyHeader: parseBoolean(
+      value('AUTH_TRUST_PROXY_HEADER'),
+      SECURITY_DEFAULTS.authTrustProxyHeader
+    ),
+    authProxyUserHeader:
+      value('AUTH_PROXY_USER_HEADER') || SECURITY_DEFAULTS.authProxyUserHeader,
+    authTrustedProxies: normalizeList(value('AUTH_TRUSTED_PROXIES')),
+    authLoginRateLimitWindowMs:
+      Number(value('AUTH_LOGIN_RATE_LIMIT_WINDOW_MS')) ||
+      SECURITY_DEFAULTS.authLoginRateLimitWindowMs,
+    authLoginRateLimitMax:
+      Number(value('AUTH_LOGIN_RATE_LIMIT_MAX')) || SECURITY_DEFAULTS.authLoginRateLimitMax
   });
 }
 

--- a/src/server/middleware/auth.js
+++ b/src/server/middleware/auth.js
@@ -309,6 +309,16 @@ function createAuthMiddleware({ credential, sessions, config }) {
     // access. A non-browser client behind the proxy fetches
     // `GET /api/auth/session` first and echoes the token back, which is what
     // the README documents.
+    // A genuine preflight is answered here rather than passed on. Handing it to
+    // the router means Express's built-in OPTIONS responder answers an
+    // anonymous caller with an `Allow` header assembled from the registered
+    // handlers, while an unrouted path 404s — the endpoint-and-method map that
+    // the deliberate 401 on a bare OPTIONS exists to deny. The two headers that
+    // define a preflight are trivially forged by a non-browser client, so the
+    // exemption has to stop at "answer it", not "let it through".
+    if (isCorsPreflight(req)) {
+      return res.sendStatus(204);
+    }
     if (isPublicRoute(req)) {
       return next();
     }

--- a/src/server/middleware/auth.js
+++ b/src/server/middleware/auth.js
@@ -1,0 +1,244 @@
+/**
+ * The gate in front of the API.
+ *
+ * Everything under `/api` requires an authenticated session. The exception is
+ * an explicit, short allowlist declared here — not scattered across the routers
+ * — because an allowlist that is written down in one place is one an operator
+ * (and a reviewer) can actually read. It holds exactly what has to answer to an
+ * anonymous caller: the liveness probe, the login endpoint, and the endpoint
+ * the dashboard asks "am I logged in?" before it decides which screen to draw.
+ * `POST /api/auth/logout` is deliberately *not* on it: logging out is an act on
+ * a session, so it needs one.
+ *
+ * The static dashboard bundle is served before this middleware and stays public
+ * on purpose — the login page is part of that bundle, so gating it would leave
+ * a browser with nothing to log in *with*. No operational data is served from
+ * there; every value the dashboard renders comes from the API, which is closed.
+ *
+ * The browser holds nothing but an opaque, signed session identifier. Signing
+ * (via `cookie-parser`'s secret) means a forged or edited identifier is
+ * rejected before the session table is even consulted, and the identifier
+ * itself carries no claims that could be tampered with in the first place.
+ *
+ * Identity may instead be delegated to a reverse proxy that has already
+ * authenticated the caller, but only when two independent settings agree: the
+ * feature is switched on *and* the peer address is on the trusted-proxy list.
+ * A header alone is not evidence of anything — anyone who can reach the port
+ * can send `X-Forwarded-User: admin` — so trusting the header without pinning
+ * the peer would make the feature the bypass it exists to avoid.
+ */
+const { unauthorized } = require("./errors");
+const { timingSafeCompare } = require("../auth/passwords");
+
+/** Name of the signed cookie carrying the opaque session identifier. */
+const SESSION_COOKIE = "tas.sid";
+
+/**
+ * Name of the readable cookie carrying the CSRF token. Deliberately NOT
+ * httpOnly: the dashboard has to read it to echo it back in a request header,
+ * which is the whole mechanism (see `middleware/csrf.js`).
+ */
+const CSRF_COOKIE = "tas.csrf";
+
+/**
+ * The endpoints that answer without a session, relative to the `/api` mount.
+ * Documented in the README; changing this list changes the attack surface.
+ */
+const PUBLIC_API_ROUTES = [
+  { method: "GET", path: "/health" },
+  { method: "POST", path: "/auth/login" },
+  { method: "GET", path: "/auth/session" },
+];
+
+/**
+ * Normalise a request path for allowlist comparison: a trailing slash is the
+ * same resource, and nothing else about the path is negotiable.
+ * @param {String} value Raw `req.path`
+ * @returns {String} Path without a trailing slash (except the root)
+ */
+const normalizePath = (value) => {
+  const path = String(value || "/");
+  const trimmed = path.replace(/\/+$/, "");
+  return trimmed === "" ? "/" : trimmed;
+};
+
+/**
+ * @param {String} method HTTP method
+ * @param {String} path Path relative to the `/api` mount
+ * @returns {Boolean} True when the request may proceed without a session
+ */
+const isPublicRoute = (method, path) => {
+  // A CORS preflight carries no credentials by definition; rejecting it with a
+  // 401 would make the browser report a CORS failure for a request that would
+  // in fact have been authorised.
+  if (method === "OPTIONS") return true;
+  const wanted = normalizePath(path);
+  return PUBLIC_API_ROUTES.some(
+    (route) => route.method === method && route.path === wanted
+  );
+};
+
+/**
+ * Cookie attributes shared by both session cookies.
+ * @param {Object} config The loaded configuration
+ * @returns {Object} Options for `res.cookie`
+ */
+const baseCookieOptions = (config) => ({
+  sameSite: "lax",
+  path: "/",
+  secure: config.sessionCookieSecure === true,
+  maxAge: config.sessionIdleTtlMs,
+});
+
+/**
+ * Issue (or refresh) the pair of cookies a browser session is made of.
+ *
+ * Re-issued on every authenticated request so the cookie's own lifetime tracks
+ * the sliding server-side session rather than expiring underneath it.
+ *
+ * @param {Object} res Express response
+ * @param {Object} session The session record
+ * @param {Object} config The loaded configuration
+ */
+function setSessionCookies(res, session, config) {
+  res.cookie(SESSION_COOKIE, session.id, {
+    ...baseCookieOptions(config),
+    httpOnly: true,
+    signed: true,
+  });
+  res.cookie(CSRF_COOKIE, session.csrfToken, {
+    ...baseCookieOptions(config),
+    httpOnly: false,
+    signed: false,
+  });
+}
+
+/**
+ * Remove both cookies. The attributes must match the ones they were set with,
+ * or the browser keeps the original cookie alongside the expired one.
+ * @param {Object} res Express response
+ * @param {Object} config The loaded configuration
+ */
+function clearSessionCookies(res, config) {
+  const options = {
+    sameSite: "lax",
+    path: "/",
+    secure: config.sessionCookieSecure === true,
+  };
+  // Not signed: an expiring cookie carries no value worth signing, and signing
+  // an empty string produces a `s:.<mac>` value that reads like a live session.
+  res.clearCookie(SESSION_COOKIE, { ...options, httpOnly: true });
+  res.clearCookie(CSRF_COOKIE, { ...options, httpOnly: false });
+}
+
+/**
+ * Resolve the live session a request carries, refreshing its idle window.
+ *
+ * Shared by the gate and by `GET /api/auth/session`, which has to answer the
+ * same question from outside the gate.
+ *
+ * @param {Object} req Express request
+ * @param {Object} sessions The session store
+ * @returns {Object|null} The live session, or null
+ */
+function resolveSession(req, sessions) {
+  const signed = req.signedCookies || {};
+  const id = signed[SESSION_COOKIE];
+  if (typeof id !== "string" || id === "") return null;
+  return sessions.touch(id);
+}
+
+/**
+ * Reduce a socket address to the form the trusted-proxy list is written in.
+ *
+ * IPv4 peers reaching a dual-stack listener arrive as `::ffff:127.0.0.1`; that
+ * prefix is stripped so an operator can write `127.0.0.1`. Nothing else is
+ * folded together — `::1` and `127.0.0.1` are different addresses and treating
+ * them as one would silently widen a configured list.
+ *
+ * @param {String} address Raw remote address
+ * @returns {String} Normalised address
+ */
+const normalizeAddress = (address) =>
+  String(address || "").replace(/^::ffff:/i, "");
+
+/**
+ * Build the `/api` authentication gate.
+ *
+ * @param {Object} deps
+ * @param {Object} deps.credential The configured administrator credential
+ * @param {Object} deps.sessions The session store
+ * @param {Object} deps.config The loaded configuration
+ * @returns {Function} Express middleware
+ */
+function createAuthMiddleware({ credential, sessions, config }) {
+  const trustedProxies = Array.isArray(config.authTrustedProxies)
+    ? config.authTrustedProxies.map(normalizeAddress)
+    : [];
+  // Both conditions, deliberately: an operator who sets the flag but forgets
+  // the list gets the feature switched off (and a startup warning), not a
+  // server that believes whatever header it is handed.
+  const proxyDelegationActive =
+    config.authTrustProxyHeader === true && trustedProxies.length > 0;
+  const proxyUserHeader = String(config.authProxyUserHeader || "x-forwarded-user").toLowerCase();
+
+  /**
+   * @param {Object} req Express request
+   * @returns {String|null} The identity the proxy asserts, when it may be believed
+   */
+  function proxyIdentity(req) {
+    if (!proxyDelegationActive) return null;
+    const peer = normalizeAddress(req.socket && req.socket.remoteAddress);
+    if (trustedProxies.indexOf(peer) === -1) return null;
+    const asserted = req.headers[proxyUserHeader];
+    if (typeof asserted !== "string") return null;
+    const user = asserted.trim();
+    return user === "" ? null : user;
+  }
+
+  return function requireAuth(req, res, next) {
+    if (isPublicRoute(req.method, req.path)) {
+      return next();
+    }
+
+    const session = resolveSession(req, sessions);
+    if (session) {
+      req.auth = {
+        user: session.user,
+        sessionId: session.id,
+        csrfToken: session.csrfToken,
+        via: "session",
+      };
+      setSessionCookies(res, session, config);
+      return next();
+    }
+
+    const delegated = proxyIdentity(req);
+    if (delegated) {
+      const created = sessions.create(delegated);
+      req.auth = {
+        user: created.user,
+        sessionId: created.id,
+        csrfToken: created.csrfToken,
+        via: "proxy",
+      };
+      setSessionCookies(res, created, config);
+      return next();
+    }
+
+    return next(unauthorized("Authentication required"));
+  };
+}
+
+module.exports = {
+  createAuthMiddleware,
+  setSessionCookies,
+  clearSessionCookies,
+  resolveSession,
+  isPublicRoute,
+  normalizeAddress,
+  timingSafeCompare,
+  PUBLIC_API_ROUTES,
+  SESSION_COOKIE,
+  CSRF_COOKIE,
+};

--- a/src/server/middleware/auth.js
+++ b/src/server/middleware/auth.js
@@ -26,9 +26,27 @@
  * A header alone is not evidence of anything — anyone who can reach the port
  * can send `X-Forwarded-User: admin` — so trusting the header without pinning
  * the peer would make the feature the bypass it exists to avoid.
+ *
+ * Identity is resolved *before* the allowlist is consulted, and the allowlist
+ * then only decides whether a request with no identity is refused. That order
+ * matters: `GET /api/auth/session` is public, and it is the first call the
+ * dashboard makes. Answering it before delegation had been considered would
+ * report `{"authenticated":false}` to a browser the proxy had already
+ * authenticated, and show it a password form for an account whose password a
+ * proxy deployment deliberately does not hand out.
  */
 const { unauthorized } = require("./errors");
 const { timingSafeCompare } = require("../auth/passwords");
+
+/**
+ * How many delegated identities the proxy session cache remembers.
+ *
+ * The key is asserted by the proxy, so it is outside data; bounding the map
+ * keeps a misbehaving (or compromised) proxy from turning the cache into a
+ * memory sink. Evicting the oldest entry only costs that identity a fresh
+ * session record on its next request.
+ */
+const DELEGATED_IDENTITY_LIMIT = 1000;
 
 /** Name of the signed cookie carrying the opaque session identifier. */
 const SESSION_COOKIE = "tas.sid";
@@ -63,18 +81,36 @@ const normalizePath = (value) => {
 };
 
 /**
- * @param {String} method HTTP method
- * @param {String} path Path relative to the `/api` mount
+ * Is this OPTIONS request a genuine CORS preflight?
+ *
+ * A preflight is defined by the two headers the browser always sends with it.
+ * Requiring both is what keeps the exemption to preflights: a *bare* OPTIONS
+ * carries neither, and exempting it would let Express's built-in OPTIONS
+ * responder answer an anonymous caller with an `Allow` header assembled from
+ * the registered handlers — an endpoint-and-method map of the whole API, while
+ * an unrouted path 404s, which is exactly the disclosure the deliberate 401 on
+ * unknown `/api` paths exists to prevent.
+ *
+ * @param {Object} req Express request
+ * @returns {Boolean} True for a CORS preflight
+ */
+const isCorsPreflight = (req) =>
+  req.method === "OPTIONS" &&
+  typeof req.headers["origin"] === "string" &&
+  typeof req.headers["access-control-request-method"] === "string";
+
+/**
+ * @param {Object} req Express request
  * @returns {Boolean} True when the request may proceed without a session
  */
-const isPublicRoute = (method, path) => {
+const isPublicRoute = (req) => {
   // A CORS preflight carries no credentials by definition; rejecting it with a
   // 401 would make the browser report a CORS failure for a request that would
   // in fact have been authorised.
-  if (method === "OPTIONS") return true;
-  const wanted = normalizePath(path);
+  if (isCorsPreflight(req)) return true;
+  const wanted = normalizePath(req.path);
   return PUBLIC_API_ROUTES.some(
-    (route) => route.method === method && route.path === wanted
+    (route) => route.method === req.method && route.path === wanted
   );
 };
 
@@ -196,37 +232,90 @@ function createAuthMiddleware({ credential, sessions, config }) {
     return user === "" ? null : user;
   }
 
+  /**
+   * The session already issued for each delegated identity.
+   *
+   * Without this, every cookieless request from behind the proxy — a curl call,
+   * a monitoring probe, a CI script — would mint a session record of its own,
+   * and `sweep()` only reclaims records that have *expired*, so at the default
+   * one-hour idle window the table would grow with traffic rather than with
+   * users. A browser establishes its session on the first GET and carries the
+   * cookie afterwards; a cookieless client reuses this one record.
+   *
+   * Bounded like the login failure tracker, and for the same reason: the key
+   * comes from outside, so an unbounded map is a memory sink.
+   */
+  const delegatedSessions = new Map();
+
+  /**
+   * Resolve (reusing where possible) the session that stands for a delegated
+   * identity.
+   *
+   * @param {String} user The identity the trusted proxy asserted
+   * @returns {Object} A live session record for that identity
+   */
+  function delegatedSession(user) {
+    const known = delegatedSessions.get(user);
+    if (typeof known === "string") {
+      const live = sessions.touch(known);
+      // A cached identifier can be stale: the session may have expired, or
+      // `POST /auth/logout` may have destroyed it. Either way, fall through and
+      // mint a fresh one rather than hand back nothing.
+      if (live && live.user === user) {
+        delegatedSessions.delete(user);
+        delegatedSessions.set(user, known);
+        return live;
+      }
+      delegatedSessions.delete(user);
+    }
+    const created = sessions.create(user);
+    delegatedSessions.set(user, created.id);
+    while (delegatedSessions.size > DELEGATED_IDENTITY_LIMIT) {
+      delegatedSessions.delete(delegatedSessions.keys().next().value);
+    }
+    return created;
+  }
+
   return function requireAuth(req, res, next) {
-    if (isPublicRoute(req.method, req.path)) {
-      return next();
+    // Identity first, allowlist second. See the note at the top of this file:
+    // a public route still has to know who the caller is, or the endpoint the
+    // dashboard boots with cannot report a proxy-delegated login.
+    let session = resolveSession(req, sessions);
+    let via = "session";
+
+    if (!session) {
+      const delegated = proxyIdentity(req);
+      if (delegated) {
+        session = delegatedSession(delegated);
+        via = "proxy";
+      }
     }
 
-    const session = resolveSession(req, sessions);
     if (session) {
       req.auth = {
         user: session.user,
         sessionId: session.id,
         csrfToken: session.csrfToken,
-        via: "session",
+        via: via,
       };
       setSessionCookies(res, session, config);
-      return next();
     }
 
-    const delegated = proxyIdentity(req);
-    if (delegated) {
-      const created = sessions.create(delegated);
-      req.auth = {
-        user: created.user,
-        sessionId: created.id,
-        csrfToken: created.csrfToken,
-        via: "proxy",
-      };
-      setSessionCookies(res, created, config);
+    // A proxy-delegated request is deliberately NOT exempted from the CSRF
+    // check downstream. The proxy attaches the identity header to whatever
+    // reaches it, cookies or no cookies — so a cross-site forged POST from
+    // evil.com arrives in exactly the shape of a cookieless delegated request.
+    // Exempting that shape would hand an attacker authenticated, state-changing
+    // access. A non-browser client behind the proxy fetches
+    // `GET /api/auth/session` first and echoes the token back, which is what
+    // the README documents.
+    if (isPublicRoute(req)) {
       return next();
     }
-
-    return next(unauthorized("Authentication required"));
+    if (!req.auth) {
+      return next(unauthorized("Authentication required"));
+    }
+    return next();
   };
 }
 
@@ -236,9 +325,11 @@ module.exports = {
   clearSessionCookies,
   resolveSession,
   isPublicRoute,
+  isCorsPreflight,
   normalizeAddress,
   timingSafeCompare,
   PUBLIC_API_ROUTES,
+  DELEGATED_IDENTITY_LIMIT,
   SESSION_COOKIE,
   CSRF_COOKIE,
 };

--- a/src/server/middleware/csrf.js
+++ b/src/server/middleware/csrf.js
@@ -30,6 +30,30 @@ const { timingSafeCompare } = require("../auth/passwords");
 const SAFE_METHODS = ["GET", "HEAD", "OPTIONS"];
 
 /**
+ * Routes that change state over a *safe* method, and therefore need the token
+ * anyway (paths relative to the `/api` mount, lower-cased).
+ *
+ * The method-based rule above is only sound while `GET` really is safe. Four
+ * endpoints in this application predate that rule and mutate: they start and
+ * stop a test campaign, a simulation and a data recorder. `SameSite=Lax` does
+ * *not* cover them — it deliberately still attaches the cookie to a top-level
+ * `GET` navigation, so a link, a `window.open` or a redirect from any page an
+ * operator visits while logged in would reach them with full authority. They
+ * are listed here rather than left to the method check, and the dashboard's
+ * request layer sends the token on every call so the listed ones keep working.
+ *
+ * Compared case-insensitively because Express's own routing is: `/DevOps/stop`
+ * reaches the same handler, and a case-sensitive list would be a way around it.
+ */
+const MUTATING_SAFE_METHOD_PATHS = ["/devops/start", "/devops/stop"];
+
+/**
+ * Prefixes of the same kind, for the routes that carry a parameter.
+ * A path matches when it is the prefix itself or a child of it.
+ */
+const MUTATING_SAFE_METHOD_PREFIXES = ["/simulation/stop", "/data-recorders/stop"];
+
+/**
  * Paths (relative to the `/api` mount) exempt from the check.
  *
  * Login is the one state-changing request that provably cannot carry a token:
@@ -57,9 +81,25 @@ const normalizePath = (value) => {
  *
  * @returns {Function} Express middleware
  */
+/**
+ * Does this path mutate despite arriving over a safe method?
+ * @param {String} path Normalised, `/api`-relative path
+ * @returns {Boolean} True when the token is required regardless of the method
+ */
+const isMutatingSafeMethodPath = (path) => {
+  const wanted = path.toLowerCase();
+  if (MUTATING_SAFE_METHOD_PATHS.indexOf(wanted) !== -1) return true;
+  return MUTATING_SAFE_METHOD_PREFIXES.some(
+    (prefix) => wanted === prefix || wanted.startsWith(prefix + "/")
+  );
+};
+
 function createCsrfMiddleware() {
   return function csrfProtection(req, res, next) {
-    if (SAFE_METHODS.indexOf(req.method) !== -1) {
+    if (
+      SAFE_METHODS.indexOf(req.method) !== -1 &&
+      !isMutatingSafeMethodPath(normalizePath(req.path))
+    ) {
       return next();
     }
     if (EXEMPT_PATHS.indexOf(normalizePath(req.path)) !== -1) {
@@ -82,4 +122,12 @@ function createCsrfMiddleware() {
   };
 }
 
-module.exports = { createCsrfMiddleware, CSRF_HEADER, SAFE_METHODS, EXEMPT_PATHS };
+module.exports = {
+  createCsrfMiddleware,
+  isMutatingSafeMethodPath,
+  CSRF_HEADER,
+  SAFE_METHODS,
+  EXEMPT_PATHS,
+  MUTATING_SAFE_METHOD_PATHS,
+  MUTATING_SAFE_METHOD_PREFIXES,
+};

--- a/src/server/middleware/csrf.js
+++ b/src/server/middleware/csrf.js
@@ -30,6 +30,17 @@ const { timingSafeCompare } = require("../auth/passwords");
 const SAFE_METHODS = ["GET", "HEAD", "OPTIONS"];
 
 /**
+ * The safe methods that can still reach a handler and therefore still mutate.
+ *
+ * `OPTIONS` is excluded deliberately: it never reaches a route handler in this
+ * application, so demanding a token on it would answer a preflight — or a plain
+ * capability probe — with a CSRF failure. Keeping it out means the guard is
+ * correct on its own rather than only because the gate ahead of it answers
+ * preflights first.
+ */
+const ROUTED_SAFE_METHODS = ["GET", "HEAD"];
+
+/**
  * Routes that change state over a *safe* method, and therefore need the token
  * anyway (paths relative to the `/api` mount, lower-cased).
  *
@@ -96,11 +107,11 @@ const isMutatingSafeMethodPath = (path) => {
 
 function createCsrfMiddleware() {
   return function csrfProtection(req, res, next) {
-    if (
-      SAFE_METHODS.indexOf(req.method) !== -1 &&
-      !isMutatingSafeMethodPath(normalizePath(req.path))
-    ) {
-      return next();
+    if (SAFE_METHODS.indexOf(req.method) !== -1) {
+      const routed = ROUTED_SAFE_METHODS.indexOf(req.method) !== -1;
+      if (!routed || !isMutatingSafeMethodPath(normalizePath(req.path))) {
+        return next();
+      }
     }
     if (EXEMPT_PATHS.indexOf(normalizePath(req.path)) !== -1) {
       return next();
@@ -127,6 +138,7 @@ module.exports = {
   isMutatingSafeMethodPath,
   CSRF_HEADER,
   SAFE_METHODS,
+  ROUTED_SAFE_METHODS,
   EXEMPT_PATHS,
   MUTATING_SAFE_METHOD_PATHS,
   MUTATING_SAFE_METHOD_PREFIXES,

--- a/src/server/middleware/csrf.js
+++ b/src/server/middleware/csrf.js
@@ -1,0 +1,85 @@
+/**
+ * Cross-site request forgery protection for the state-changing API.
+ *
+ * A session cookie is attached by the browser to *every* request that reaches
+ * this origin, including one a page on an unrelated site caused. So a cookie
+ * alone proves the request came from a browser that is logged in — not that the
+ * dashboard is what asked for it. Without a second factor, any page an operator
+ * visits while logged in can start a simulation or delete a topology.
+ *
+ * The second factor is a token bound to the server-side session, handed to the
+ * dashboard in a readable cookie at login and echoed back in the `X-CSRF-Token`
+ * header. A cross-site page can cause the cookie to be *sent*, but the same
+ * origin policy stops it from ever *reading* the cookie, so it cannot produce
+ * the header. The comparison is against the token held in the session record
+ * rather than against the cookie, so a request that carries an attacker-chosen
+ * cookie pair is checked against what the server issued, not against itself.
+ *
+ * This layers on top of `SameSite=Lax`, which already blocks the plain
+ * cross-site POST in current browsers; the token is what still holds when the
+ * request comes from a browser that does not enforce it, or through a path
+ * (a same-site subdomain, a redirect chain) where Lax does not apply.
+ *
+ * Safe methods are untouched: they change nothing, and requiring a header on
+ * `GET` would break every plain navigation and every link.
+ */
+const { forbidden } = require("./errors");
+const { timingSafeCompare } = require("../auth/passwords");
+
+/** Methods that must not change state, and therefore need no token. */
+const SAFE_METHODS = ["GET", "HEAD", "OPTIONS"];
+
+/**
+ * Paths (relative to the `/api` mount) exempt from the check.
+ *
+ * Login is the one state-changing request that provably cannot carry a token:
+ * it is what issues the token. It is protected instead by the credential itself
+ * and by a dedicated rate limit — a forged login can only log a victim in as
+ * somebody whose password the attacker already knows.
+ */
+const EXEMPT_PATHS = ["/auth/login"];
+
+/** The header the dashboard echoes the session's token back in. */
+const CSRF_HEADER = "x-csrf-token";
+
+/**
+ * @param {String} value Raw `req.path`
+ * @returns {String} Path without a trailing slash (except the root)
+ */
+const normalizePath = (value) => {
+  const trimmed = String(value || "/").replace(/\/+$/, "");
+  return trimmed === "" ? "/" : trimmed;
+};
+
+/**
+ * Build the CSRF guard. Mounted on `/api`, after the authentication gate, so
+ * `req.auth` — and with it the session's token — is already resolved.
+ *
+ * @returns {Function} Express middleware
+ */
+function createCsrfMiddleware() {
+  return function csrfProtection(req, res, next) {
+    if (SAFE_METHODS.indexOf(req.method) !== -1) {
+      return next();
+    }
+    if (EXEMPT_PATHS.indexOf(normalizePath(req.path)) !== -1) {
+      return next();
+    }
+
+    // No `req.auth` on a state-changing request means the gate did not run or
+    // did not attach one, which is a wiring mistake in this file's own mount
+    // order. Refuse rather than fall through to the handler.
+    const expected = req.auth && req.auth.csrfToken;
+    const offered = req.get(CSRF_HEADER);
+
+    if (!expected || typeof offered !== "string" || offered === "") {
+      return next(forbidden("Invalid CSRF token"));
+    }
+    if (!timingSafeCompare(offered, expected)) {
+      return next(forbidden("Invalid CSRF token"));
+    }
+    return next();
+  };
+}
+
+module.exports = { createCsrfMiddleware, CSRF_HEADER, SAFE_METHODS, EXEMPT_PATHS };

--- a/src/server/middleware/errors.js
+++ b/src/server/middleware/errors.js
@@ -44,6 +44,9 @@ class ApiError extends Error {
 const badRequest = (message, details) =>
   new ApiError(400, message || "Invalid request", { details });
 
+/** The caller has not proved who it is (or the proof it had has expired). */
+const unauthorized = (message) => new ApiError(401, message || "Unauthorized");
+
 /** The caller may not have what it asked for. */
 const forbidden = (message) => new ApiError(403, message || "Forbidden");
 
@@ -265,6 +268,7 @@ const apiNotFound = (req, res, next) => next(notFound("Not found"));
 module.exports = {
   ApiError,
   badRequest,
+  unauthorized,
   forbidden,
   notFound,
   conflict,

--- a/src/server/routes/auth.js
+++ b/src/server/routes/auth.js
@@ -1,0 +1,205 @@
+/**
+ * Login, logout, and "who am I?".
+ *
+ * These three endpoints are the whole authentication surface. There is no
+ * registration and no user administration: TaS is single-tenant, and its one
+ * administrator credential is provisioned from the environment (see
+ * `auth/credentials.js`), so there is nothing here that can create an account.
+ *
+ * Two properties are load-bearing and easy to lose in a later edit:
+ *
+ *   - A failed login is told exactly one thing: "Invalid credentials". Never
+ *     which half was wrong, and never whether the username exists. The
+ *     credential verifier spends the same work on both cases so the response
+ *     time does not say it either.
+ *   - Every failure is recorded, with the attempted username, the client
+ *     address and a running count of consecutive failures from that address, so
+ *     a brute-force run is visible in the log as a run rather than as isolated
+ *     lines. The password itself is never part of that record.
+ *
+ * `GET /session` answers 200 either way, on purpose. The dashboard asks it on
+ * every load to decide which screen to draw; answering 401 for "not logged in"
+ * would make a normal cold start indistinguishable from a real failure, and
+ * would bury genuine 401s in the log.
+ */
+const express = require("express");
+const Joi = require("joi");
+const { validate } = require("../middleware/validate");
+const { errorHandler, unauthorized, unavailable } = require("../middleware/errors");
+const {
+  setSessionCookies,
+  clearSessionCookies,
+  resolveSession,
+} = require("../middleware/auth");
+
+/**
+ * How many client addresses the consecutive-failure counter remembers.
+ *
+ * Bounded on purpose: an unbounded map keyed by a value the caller controls
+ * (its source address) is a memory-exhaustion sink, and the counter only has to
+ * make a brute-force run legible in the log, not be an accounting record.
+ */
+const FAILURE_TRACKER_LIMIT = 1000;
+
+/** Longest username or user-agent fragment that goes into a log line. */
+const LOG_FIELD_MAX = 200;
+
+/**
+ * Make an externally supplied value safe to interpolate into a log line.
+ *
+ * A newline in a username would let a caller write a second, invented log line
+ * - including one that looks like a successful login from somewhere else.
+ *
+ * @param {*} value Raw value
+ * @returns {String} One line's worth of printable text
+ */
+const sanitizeForLog = (value) =>
+  String(value === undefined || value === null ? "" : value)
+    .replace(/[\r\n]+/g, " ")
+    // Control characters cannot appear in a log line at all; a quote would end
+    // the quoted field early and let a caller fake the fields after it.
+    .replace(/[\u0000-\u001f\u007f]/g, "")
+    .replace(/"/g, "'")
+    .slice(0, LOG_FIELD_MAX);
+
+/**
+ * Track consecutive failed logins per client address.
+ * @returns {{fail: Function, reset: Function, get: Function}}
+ */
+function createFailureTracker() {
+  const failures = new Map();
+  return {
+    /**
+     * @param {String} ip Client address
+     * @returns {Number} Consecutive failures from that address, this one included
+     */
+    fail: function (ip) {
+      const key = String(ip || "unknown");
+      const count = (failures.get(key) || 0) + 1;
+      // Re-insert so the map stays ordered by recency, then evict the oldest.
+      failures.delete(key);
+      failures.set(key, count);
+      while (failures.size > FAILURE_TRACKER_LIMIT) {
+        failures.delete(failures.keys().next().value);
+      }
+      return count;
+    },
+    /** @param {String} ip Client address */
+    reset: function (ip) {
+      failures.delete(String(ip || "unknown"));
+    },
+    /**
+     * @param {String} ip Client address
+     * @returns {Number} Current consecutive failure count
+     */
+    get: function (ip) {
+      return failures.get(String(ip || "unknown")) || 0;
+    },
+  };
+}
+
+const loginBody = Joi.object({
+  username: Joi.string().max(256).required(),
+  password: Joi.string().max(1024).required(),
+}).required();
+
+/**
+ * Build the authentication router.
+ *
+ * @param {Object} deps
+ * @param {Object} deps.credential The configured administrator credential
+ * @param {Object} deps.sessions The session store
+ * @param {Object} deps.config The loaded configuration
+ * @returns {express.Router} The router to mount at `/api/auth`
+ */
+function createAuthRouter({ credential, sessions, config }) {
+  const router = express.Router();
+  const tracker = createFailureTracker();
+
+  /**
+   * Record one authentication outcome, as a single string.
+   *
+   * One argument deliberately: `logger/index.js` replaces `console.error` with
+   * a single-argument function, so anything passed as a second argument is
+   * dropped on the floor once a logger exists.
+   *
+   * @param {Object} req The login request
+   * @param {String} username The attempted username
+   * @param {String|null} reason Failure reason, or null for a success
+   * @param {Number} failures Consecutive failures from this address
+   */
+  function logAttempt(req, username, reason, failures) {
+    const ip = sanitizeForLog(req.ip);
+    const ua = sanitizeForLog(req.get("user-agent") || "-");
+    const user = sanitizeForLog(username);
+    if (reason === null) {
+      console.error(`[AUTH] login succeeded user="${user}" ip=${ip} ua="${ua}"`);
+      return;
+    }
+    console.error(
+      `[AUTH] login failed user="${user}" ip=${ip} ua="${ua}" reason=${reason} failures=${failures}`
+    );
+  }
+
+  router.post("/login", validate({ body: loginBody }), (req, res, next) => {
+    const username = req.body.username;
+    const password = req.body.password;
+
+    if (!credential.configured) {
+      logAttempt(req, username, "not_configured", tracker.fail(req.ip));
+      return next(unavailable("Authentication is not configured"));
+    }
+
+    if (!credential.verify(username, password)) {
+      logAttempt(req, username, "invalid_credentials", tracker.fail(req.ip));
+      // One message for both halves: naming which one was wrong turns the login
+      // form into a username oracle.
+      return next(unauthorized("Invalid credentials"));
+    }
+
+    tracker.reset(req.ip);
+    const session = sessions.create(credential.username);
+    setSessionCookies(res, session, config);
+    logAttempt(req, credential.username, null, 0);
+    // The token is returned in the body as well as in the cookie so a
+    // non-browser client can drive the API without parsing Set-Cookie.
+    return res.json({
+      authenticated: true,
+      user: session.user,
+      csrfToken: session.csrfToken,
+    });
+  });
+
+  router.post("/logout", validate(), (req, res) => {
+    // Not on the public allowlist, so both the session gate and the CSRF guard
+    // have already run: `req.auth` is present and its token was verified.
+    if (req.auth && req.auth.sessionId) {
+      sessions.destroy(req.auth.sessionId);
+    }
+    clearSessionCookies(res, config);
+    return res.json({ authenticated: false });
+  });
+
+  router.get("/session", validate(), (req, res) => {
+    const session = resolveSession(req, sessions);
+    if (!session) {
+      return res.json({ authenticated: false });
+    }
+    // Refresh the cookies so a dashboard that only polls this endpoint keeps
+    // the browser cookie in step with the sliding server-side session.
+    setSessionCookies(res, session, config);
+    return res.json({
+      authenticated: true,
+      user: session.user,
+      csrfToken: session.csrfToken,
+    });
+  });
+
+  router.use(errorHandler);
+
+  return router;
+}
+
+module.exports = createAuthRouter;
+module.exports.createFailureTracker = createFailureTracker;
+module.exports.sanitizeForLog = sanitizeForLog;

--- a/src/server/routes/auth.js
+++ b/src/server/routes/auth.js
@@ -26,11 +26,7 @@ const express = require("express");
 const Joi = require("joi");
 const { validate } = require("../middleware/validate");
 const { errorHandler, unauthorized, unavailable } = require("../middleware/errors");
-const {
-  setSessionCookies,
-  clearSessionCookies,
-  resolveSession,
-} = require("../middleware/auth");
+const { setSessionCookies, clearSessionCookies } = require("../middleware/auth");
 
 /**
  * How many client addresses the consecutive-failure counter remembers.
@@ -181,17 +177,18 @@ function createAuthRouter({ credential, sessions, config }) {
   });
 
   router.get("/session", validate(), (req, res) => {
-    const session = resolveSession(req, sessions);
-    if (!session) {
+    // The gate ahead of this router resolves identity for every request,
+    // allowlisted or not, and refreshes the cookies while it does — so this
+    // endpoint only has to report what it found. Resolving it a second time
+    // here would also miss the identity a trusted reverse proxy delegated,
+    // which arrives as a header rather than as a cookie.
+    if (!req.auth) {
       return res.json({ authenticated: false });
     }
-    // Refresh the cookies so a dashboard that only polls this endpoint keeps
-    // the browser cookie in step with the sliding server-side session.
-    setSessionCookies(res, session, config);
     return res.json({
       authenticated: true,
-      user: session.user,
-      csrfToken: session.csrfToken,
+      user: req.auth.user,
+      csrfToken: req.auth.csrfToken,
     });
   });
 

--- a/src/server/routes/health.js
+++ b/src/server/routes/health.js
@@ -1,0 +1,27 @@
+/**
+ * The liveness probe.
+ *
+ * Deliberately the thinnest possible endpoint, and deliberately the only one
+ * outside the authentication gate that an anonymous caller may read. A
+ * container orchestrator, a load balancer or an uptime monitor has to be able
+ * to ask "is this process answering?" without holding a credential, so this
+ * answers exactly that and nothing else.
+ *
+ * It reports no uptime, no version, no build identifier and no dependency
+ * status: every one of those is reconnaissance handed to an anonymous caller,
+ * and none of them is needed to decide whether the process is alive. The
+ * operational detail lives behind the gate, on the existing `/status` routes.
+ */
+const express = require("express");
+const { validate } = require("../middleware/validate");
+const { errorHandler } = require("../middleware/errors");
+
+const router = express.Router();
+
+router.get("/", validate(), (req, res) => {
+  res.json({ status: "ok" });
+});
+
+router.use(errorHandler);
+
+module.exports = router;

--- a/test/_http.js
+++ b/test/_http.js
@@ -2,22 +2,34 @@ const http = require("http");
 
 /**
  * Make an HTTP request against a running server.
+ *
+ * When the server was started through `test/helpers/start-app.js` with a login
+ * (the default), the session cookie and CSRF token it obtained are attached
+ * automatically - so a suite written before the API was closed keeps working
+ * unchanged. Pass `{ __anonymous: true }` in `headers` to send the request with
+ * no credentials, which is what the authentication suites need.
+ *
  * @param {http.Server} server The listening server
  * @param {String} method HTTP method
  * @param {String} path Request path (may contain URL-encoded sequences)
  * @param {Object} [body] Optional JSON body
- * @returns {Promise<{status: Number, body: Object, raw: String}>}
+ * @param {Object} [headers] Optional extra request headers
+ * @returns {Promise<{status: Number, body: Object, raw: String, headers: Object}>}
  */
-const request = (server, method, path, body) =>
+const request = (server, method, path, body, headers) =>
   new Promise((resolve, reject) => {
     const port = server.address().port;
     const data = body ? JSON.stringify(body) : null;
+    const extra = Object.assign({}, headers);
+    const anonymous = extra.__anonymous === true;
+    delete extra.__anonymous;
+    const auth = anonymous ? {} : server.__authHeaders || {};
     const options = {
       hostname: "127.0.0.1",
       port,
       path,
       method,
-      headers: {},
+      headers: Object.assign({}, auth, extra),
     };
     if (data) options.headers["Content-Type"] = "application/json";
     const req = http.request(options, (res) => {
@@ -32,7 +44,7 @@ const request = (server, method, path, body) =>
         } catch (e) {
           /* not JSON */
         }
-        resolve({ status: res.statusCode, body: parsed, raw });
+        resolve({ status: res.statusCode, body: parsed, raw, headers: res.headers });
       });
     });
     req.on("error", reject);

--- a/test/auth-csrf.test.js
+++ b/test/auth-csrf.test.js
@@ -1,0 +1,183 @@
+/**
+ * Cross-site request forgery protection (issue #9, AC4).
+ *
+ * A session cookie is attached by the browser to any request that reaches this
+ * origin, including one an unrelated page caused - so the cookie alone cannot
+ * be what authorises a state-changing call. These tests pin the second factor:
+ * the token bound to the server-side session, which a cross-site page can never
+ * read and therefore never send.
+ */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { startApp, TEST_CREDENTIALS } = require("./helpers/start-app");
+
+const USERNAME = TEST_CREDENTIALS.AUTH_ADMIN_USERNAME;
+const PASSWORD = TEST_CREDENTIALS.AUTH_ADMIN_PASSWORD;
+
+/**
+ * Issue a request and read the response.
+ * @param {Object} ctx Started application context
+ * @param {String} method HTTP method
+ * @param {String} path Request path
+ * @param {Object} [options] {body, headers}
+ * @returns {Promise<{status:Number,body:Object|null,raw:String,res:Response}>}
+ */
+async function call(ctx, method, path, options = {}) {
+  const res = await fetch(ctx.base + path, {
+    method,
+    headers: {
+      ...(options.body ? { "Content-Type": "application/json" } : {}),
+      ...(options.headers || {}),
+    },
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+  const raw = await res.text();
+  let body = null;
+  try {
+    body = JSON.parse(raw);
+  } catch (_) {
+    /* not JSON */
+  }
+  return { status: res.status, body, raw, res };
+}
+
+/**
+ * Run a block against a freshly started, logged-in instance.
+ * @param {Function} fn Receives (ctx, session)
+ * @returns {Promise<void>}
+ */
+async function withSession(fn) {
+  const ctx = await startApp({}, { login: false });
+  try {
+    const res = await call(ctx, "POST", "/api/auth/login", {
+      body: { username: USERNAME, password: PASSWORD },
+    });
+    assert.equal(res.status, 200, res.raw);
+    const cookie = res.res.headers
+      .getSetCookie()
+      .map((value) => value.split(";")[0])
+      .join("; ");
+    await fn(ctx, { cookie, csrfToken: res.body.csrfToken });
+  } finally {
+    await new Promise((resolve) => ctx.server.close(resolve));
+    ctx.restore();
+  }
+}
+
+test("a state-changing request without the CSRF header is refused", async () => {
+  await withSession(async (ctx, session) => {
+    const res = await call(ctx, "POST", "/api/data-storage", {
+      headers: { Cookie: session.cookie },
+      body: { dataStorage: { type: "MongoDB", host: "localhost", port: 27017 } },
+    });
+    assert.equal(res.status, 403, `expected a CSRF rejection, got ${res.status}: ${res.raw}`);
+    assert.equal(res.body.error, "Invalid CSRF token");
+  });
+});
+
+test("a state-changing request with the wrong CSRF token is refused", async () => {
+  await withSession(async (ctx, session) => {
+    for (const token of ["not-the-token", "", session.csrfToken + "x", session.csrfToken.slice(1)]) {
+      const res = await call(ctx, "POST", "/api/data-storage", {
+        headers: { Cookie: session.cookie, "X-CSRF-Token": token },
+        body: { dataStorage: { type: "MongoDB", host: "localhost", port: 27017 } },
+      });
+      assert.equal(res.status, 403, `token ${JSON.stringify(token)}: ${res.raw}`);
+      assert.equal(res.body.error, "Invalid CSRF token");
+    }
+  });
+});
+
+test("the correct CSRF token lets the dashboard's own request through", async () => {
+  await withSession(async (ctx, session) => {
+    // What is asserted is that CSRF did NOT reject it. The route itself may
+    // still answer 400/404/500 depending on the payload and on whether a
+    // database is reachable - that is not this middleware's business.
+    const post = await call(ctx, "POST", "/api/data-storage", {
+      headers: { Cookie: session.cookie, "X-CSRF-Token": session.csrfToken },
+      body: { dataStorage: { type: "MongoDB", host: "localhost", port: 27017 } },
+    });
+    assert.notEqual(post.status, 403, `a correctly tokened POST must not be refused: ${post.raw}`);
+    assert.notEqual(post.body && post.body.error, "Invalid CSRF token");
+
+    const del = await call(ctx, "DELETE", "/api/models/no-such-model.json", {
+      headers: { Cookie: session.cookie, "X-CSRF-Token": session.csrfToken },
+    });
+    assert.notEqual(del.status, 403, `a correctly tokened DELETE must not be refused: ${del.raw}`);
+  });
+});
+
+test("a DELETE without the CSRF header is refused", async () => {
+  await withSession(async (ctx, session) => {
+    const res = await call(ctx, "DELETE", "/api/models/no-such-model.json", {
+      headers: { Cookie: session.cookie },
+    });
+    assert.equal(res.status, 403, res.raw);
+    assert.equal(res.body.error, "Invalid CSRF token");
+  });
+});
+
+test("safe methods never require the CSRF header", async () => {
+  await withSession(async (ctx, session) => {
+    for (const path of ["/api/models", "/api/devops/status", "/api/auth/session"]) {
+      const res = await call(ctx, "GET", path, { headers: { Cookie: session.cookie } });
+      assert.notEqual(res.status, 403, `${path} must not require a token for GET: ${res.raw}`);
+    }
+  });
+});
+
+test("the forged cross-site POST - session cookie, attacker-chosen token - is refused", async () => {
+  await withSession(async (ctx, session) => {
+    // Exactly what a hostile page can produce: the browser attaches the session
+    // cookie, and the page supplies whatever header value it likes (it cannot
+    // read the real token, because the same-origin policy stops it).
+    const forged = await call(ctx, "POST", "/api/models", {
+      headers: {
+        Cookie: session.cookie,
+        Origin: ctx.base,
+        "X-CSRF-Token": "value-chosen-by-the-attacker",
+      },
+      body: { model: { name: "forged", devices: [] } },
+    });
+    assert.equal(forged.status, 403, `a forged POST must be refused: ${forged.raw}`);
+    assert.equal(forged.body.error, "Invalid CSRF token");
+
+    // And with no header at all - the plain cross-site form post.
+    const noHeader = await call(ctx, "POST", "/api/models", {
+      headers: { Cookie: session.cookie },
+      body: { model: { name: "forged", devices: [] } },
+    });
+    assert.equal(noHeader.status, 403, `a headerless POST must be refused: ${noHeader.raw}`);
+  });
+});
+
+test("a token from a different session does not authorise a request", async () => {
+  await withSession(async (ctx, session) => {
+    const second = await call(ctx, "POST", "/api/auth/login", {
+      body: { username: USERNAME, password: PASSWORD },
+    });
+    assert.equal(second.status, 200, second.raw);
+    assert.notEqual(second.body.csrfToken, session.csrfToken, "each session gets its own token");
+
+    const res = await call(ctx, "POST", "/api/models", {
+      headers: { Cookie: session.cookie, "X-CSRF-Token": second.body.csrfToken },
+      body: { model: { name: "crossed", devices: [] } },
+    });
+    assert.equal(res.status, 403, `a token from another session must not work: ${res.raw}`);
+  });
+});
+
+test("login itself is exempt, because it is what issues the token", async () => {
+  const ctx = await startApp({}, { login: false });
+  try {
+    const res = await fetch(ctx.base + "/api/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: USERNAME, password: PASSWORD }),
+    });
+    assert.equal(res.status, 200, "login must not require a token it has not issued yet");
+  } finally {
+    await new Promise((resolve) => ctx.server.close(resolve));
+    ctx.restore();
+  }
+});

--- a/test/auth-csrf.test.js
+++ b/test/auth-csrf.test.js
@@ -277,109 +277,167 @@ test("a forged CORS preflight cannot enumerate the routing table", async () => {
 // ---------------------------------------------------------------------------
 
 /**
- * Every `GET`/`HEAD` route in the API that has been read and found to change
- * nothing, as `<router file>:<path relative to the /api mount>`.
+ * Every `GET`/`HEAD` route under `/api` that has been read and found to change
+ * nothing a caller can see or choose, as its `/api`-relative path.
  *
- * This is the counterpart to `MUTATING_SAFE_METHOD_PATHS`: between them the two
- * lists have to account for every safe-method route the application mounts. A
- * route added later belongs to one or the other, and the test below fails until
- * somebody says which — which is the point, because the failure mode this
- * guards is a new `GET /reset` that nothing refuses and no test notices.
+ * "Read-only" is meant at the level this guard is about: several of these do
+ * refresh a module-level cache, a running-status flag or a lazily opened
+ * database connection. None of them takes a payload, creates or destroys
+ * anything, or does something a cross-site page would gain by triggering. What
+ * disqualifies a route from this list is state a caller supplies or chooses.
+ *
+ * This is the counterpart to `MUTATING_SAFE_METHOD_PATHS` in the CSRF guard:
+ * between them, the two lists have to account for every safe-method route the
+ * application mounts. A route added later belongs to one or the other and the
+ * test below fails until somebody says which — which is the point, because the
+ * failure mode it guards is a new `GET /reset` that nothing refuses and no test
+ * notices.
  */
-/**
- * Where `src/server/app.js` mounts each router, so a route declared relative to
- * its router can be turned into the `/api`-relative path the guard compares.
- * `logs.js` is mounted three times under `/logs/...`; one of them is enough to
- * classify its routes, which are identical across the three.
- */
-const MOUNTS = {
-  "auth.js": "/auth",
-  "data-recorders.js": "/data-recorders",
-  "data-sets.js": "/data-sets",
-  "data-storage.js": "/data-storage",
-  "db-connector.js": null,
-  "devops.js": "/devops",
-  "events.js": "/events",
-  "health.js": "/health",
-  "logs.js": "/logs/data-recorders",
-  "model.js": "/models",
-  "path-safety.js": null,
-  "reports.js": "/reports",
-  "simulation.js": "/simulation",
-  "test-campaigns.js": "/test-campaigns",
-  "test-cases.js": "/test-cases",
-};
-
 const READ_ONLY_SAFE_ROUTES = new Set([
-  "auth.js:/session",
-  "data-recorders.js:/",
-  "data-recorders.js:/:fileName",
-  "data-recorders.js:/models/",
-  "data-recorders.js:/models/:fileName",
-  "data-recorders.js:/status",
-  "data-sets.js:/",
-  "data-sets.js:/:datasetId",
-  "data-storage.js:/",
-  "data-storage.js:/test",
-  "devops.js:/",
-  "devops.js:/status",
-  "events.js:/",
-  "events.js:/:eventId",
-  "health.js:/",
-  "logs.js:/",
-  "logs.js:/:fileName",
-  "model.js:/",
-  "model.js:/:fileName",
-  "reports.js:/",
-  "reports.js:/:reportId",
-  "simulation.js:/stats",
-  "simulation.js:/status",
-  "test-campaigns.js:/",
-  "test-campaigns.js:/:testCampaignId",
-  "test-cases.js:/",
-  "test-cases.js:/:testCaseId",
+  "/auth/session",
+  "/data-recorders/models",
+  "/data-recorders/models/:fileName",
+  "/data-recorders/status",
+  "/data-sets",
+  "/data-sets/:datasetId",
+  "/data-storage",
+  "/data-storage/test",
+  "/devops",
+  "/devops/status",
+  "/events",
+  "/events/:eventId",
+  "/health",
+  "/logs/data-recorders",
+  "/logs/data-recorders/:fileName",
+  "/logs/simulations",
+  "/logs/simulations/:fileName",
+  "/logs/test-campaigns",
+  "/logs/test-campaigns/:fileName",
+  "/models",
+  "/models/:fileName",
+  "/reports",
+  "/reports/:reportId",
+  "/simulation/stats",
+  "/simulation/status",
+  "/test-campaigns",
+  "/test-campaigns/:testCampaignId",
+  "/test-cases",
+  "/test-cases/:testCaseId",
 ]);
 
-test("every safe-method route is classified as read-only or as needing a token", async () => {
-  const fs = require("node:fs");
-  const path = require("node:path");
-  const routesDir = path.resolve(__dirname, "../src/server/routes");
-  const unclassified = [];
-  const files = fs.readdirSync(routesDir).filter((name) => name.endsWith(".js"));
+/**
+ * Recover the path a layer was mounted at from the regexp Express compiled for
+ * it. Express keeps no copy of the original string, and reading the live stack
+ * is the only way to see what the guard actually sees: a source-text scan would
+ * miss a computed path, a `router.route(...)`, a route registered outside
+ * `src/server/routes/`, and every extra mount of a router mounted more than
+ * once — each of which is a way for an unprotected route to ship green.
+ *
+ * @param {Object} layer An Express router-stack layer
+ * @returns {String} The mount path, or "" for a layer that matches everything
+ */
+function layerPath(layer) {
+  if (layer.regexp && layer.regexp.fast_slash) return "";
+  const source = String((layer.regexp && layer.regexp.source) || "");
+  const trimmed = source
+    .replace(/^\^/, "")
+    .replace(/\\\/\?\(\?=\\\/\|\$\)$/, "")
+    .replace(/\\\/\?\$$/, "")
+    .replace(/\$$/, "");
+  return trimmed.replace(/\\(.)/g, "$1");
+}
 
-  assert.deepEqual(
-    files.filter((file) => !(file in MOUNTS)),
-    [],
-    "a new router file must be added to MOUNTS so its safe-method routes are classified"
+/**
+ * Walk a mounted Express application and yield every route it can reach.
+ *
+ * @param {Object} stack A router stack
+ * @param {String} prefix The path this stack is mounted at
+ * @returns {Array<{path: String, methods: Object}>} The routes found
+ */
+function collectRoutes(stack, prefix) {
+  const found = [];
+  for (const layer of stack || []) {
+    if (layer.route) {
+      const routePath = layer.route.path === "/" ? "" : layer.route.path;
+      found.push({
+        path: (prefix + routePath).replace(/\/+$/, "") || "/",
+        methods: layer.route.methods || {},
+      });
+    } else if (layer.handle && layer.handle.stack) {
+      found.push(...collectRoutes(layer.handle.stack, prefix + layerPath(layer)));
+    }
+  }
+  return found;
+}
+
+test("every safe-method route under /api is classified read-only or token-bearing", async () => {
+  // Boot the real application so the route table is the one the guard sees.
+  const appPath = require.resolve("../src/server/app.js");
+  const saved = {};
+  const env = {
+    AUTH_ADMIN_USERNAME: USERNAME,
+    AUTH_ADMIN_PASSWORD: PASSWORD,
+    SESSION_SECRET: "route-walk-secret",
+  };
+  Object.keys(env).forEach((key) => {
+    saved[key] = process.env[key];
+    process.env[key] = env[key];
+  });
+  delete require.cache[appPath];
+  delete require.cache[require.resolve("../src/server/config.js")];
+  let app;
+  try {
+    app = require(appPath);
+  } finally {
+    Object.keys(saved).forEach((key) => {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    });
+    delete require.cache[appPath];
+    delete require.cache[require.resolve("../src/server/config.js")];
+  }
+
+  const router = app._router || app.router;
+  assert.ok(router && router.stack, "the Express route table must be reachable");
+
+  const safeApiRoutes = collectRoutes(router.stack, "")
+    .filter((route) => route.path === "/api" || route.path.startsWith("/api/"))
+    .filter((route) => route.methods.get || route.methods.head)
+    .map((route) => route.path.slice("/api".length) || "/");
+
+  assert.ok(
+    safeApiRoutes.length > 20,
+    `the walk must actually find routes, found ${safeApiRoutes.length}`
   );
 
-  for (const file of files) {
-    const source = fs.readFileSync(path.join(routesDir, file), "utf8");
-    const pattern = /router\.(get|head)\(\s*["'`]([^"'`]*)["'`]/g;
-    let match;
-    while ((match = pattern.exec(source)) !== null) {
-      const routePath = match[2];
-      const key = `${file}:${routePath}`;
-      if (READ_ONLY_SAFE_ROUTES.has(key)) continue;
-      // The router's own mount prefix is what makes the guard's path absolute;
-      // `isMutatingSafeMethodPath` is deliberately checked with a concrete
-      // example rather than the parameterised form.
-      const mounted = MOUNTS[file];
-      const concrete = mounted
-        ? `${mounted}${routePath.replace(/:[^/]+/g, "placeholder.json")}`.replace(/\/+$/, "") ||
-          mounted
-        : null;
-      if (concrete && isMutatingSafeMethodPath(concrete)) continue;
-      unclassified.push(key);
+  const seen = new Set();
+  const unclassified = [];
+  for (const path of safeApiRoutes) {
+    if (READ_ONLY_SAFE_ROUTES.has(path)) {
+      seen.add(path);
+      continue;
     }
+    // Checked with the parameter left in place *and* filled in, because the
+    // guard matches a concrete request path at runtime.
+    const concrete = path.replace(/:[^/]+/g, "placeholder.json");
+    if (isMutatingSafeMethodPath(path) && isMutatingSafeMethodPath(concrete)) continue;
+    unclassified.push(path);
   }
 
   assert.deepEqual(
-    unclassified,
+    [...new Set(unclassified)].sort(),
     [],
-    "a safe-method route is neither on the reviewed read-only list nor covered by " +
-      "the CSRF guard's mutating-path list - classify it in one of the two, and if " +
-      "it changes state add it to MUTATING_SAFE_METHOD_PATHS in " +
+    "a safe-method route under /api is neither on the reviewed read-only list nor " +
+      "covered by the CSRF guard's mutating-path list - classify it in one of the " +
+      "two, and if it changes state add it to MUTATING_SAFE_METHOD_PATHS in " +
       "src/server/middleware/csrf.js"
+  );
+
+  // A stale entry is a pre-authorisation for a route nobody reviewed: it would
+  // wave through a future route that happens to reuse the path.
+  assert.deepEqual(
+    [...READ_ONLY_SAFE_ROUTES].filter((path) => !seen.has(path)).sort(),
+    [],
+    "READ_ONLY_SAFE_ROUTES lists a path that no longer exists - remove it"
   );
 });

--- a/test/auth-csrf.test.js
+++ b/test/auth-csrf.test.js
@@ -10,6 +10,7 @@
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const { startApp, TEST_CREDENTIALS } = require("./helpers/start-app");
+const { isMutatingSafeMethodPath } = require("../src/server/middleware/csrf");
 
 const USERNAME = TEST_CREDENTIALS.AUTH_ADMIN_USERNAME;
 const PASSWORD = TEST_CREDENTIALS.AUTH_ADMIN_PASSWORD;
@@ -269,4 +270,116 @@ test("a forged CORS preflight cannot enumerate the routing table", async () => {
       ctx.restore();
     }
   });
+});
+
+// ---------------------------------------------------------------------------
+// The mutating-safe-method list must not silently fall behind the routers
+// ---------------------------------------------------------------------------
+
+/**
+ * Every `GET`/`HEAD` route in the API that has been read and found to change
+ * nothing, as `<router file>:<path relative to the /api mount>`.
+ *
+ * This is the counterpart to `MUTATING_SAFE_METHOD_PATHS`: between them the two
+ * lists have to account for every safe-method route the application mounts. A
+ * route added later belongs to one or the other, and the test below fails until
+ * somebody says which — which is the point, because the failure mode this
+ * guards is a new `GET /reset` that nothing refuses and no test notices.
+ */
+/**
+ * Where `src/server/app.js` mounts each router, so a route declared relative to
+ * its router can be turned into the `/api`-relative path the guard compares.
+ * `logs.js` is mounted three times under `/logs/...`; one of them is enough to
+ * classify its routes, which are identical across the three.
+ */
+const MOUNTS = {
+  "auth.js": "/auth",
+  "data-recorders.js": "/data-recorders",
+  "data-sets.js": "/data-sets",
+  "data-storage.js": "/data-storage",
+  "db-connector.js": null,
+  "devops.js": "/devops",
+  "events.js": "/events",
+  "health.js": "/health",
+  "logs.js": "/logs/data-recorders",
+  "model.js": "/models",
+  "path-safety.js": null,
+  "reports.js": "/reports",
+  "simulation.js": "/simulation",
+  "test-campaigns.js": "/test-campaigns",
+  "test-cases.js": "/test-cases",
+};
+
+const READ_ONLY_SAFE_ROUTES = new Set([
+  "auth.js:/session",
+  "data-recorders.js:/",
+  "data-recorders.js:/:fileName",
+  "data-recorders.js:/models/",
+  "data-recorders.js:/models/:fileName",
+  "data-recorders.js:/status",
+  "data-sets.js:/",
+  "data-sets.js:/:datasetId",
+  "data-storage.js:/",
+  "data-storage.js:/test",
+  "devops.js:/",
+  "devops.js:/status",
+  "events.js:/",
+  "events.js:/:eventId",
+  "health.js:/",
+  "logs.js:/",
+  "logs.js:/:fileName",
+  "model.js:/",
+  "model.js:/:fileName",
+  "reports.js:/",
+  "reports.js:/:reportId",
+  "simulation.js:/stats",
+  "simulation.js:/status",
+  "test-campaigns.js:/",
+  "test-campaigns.js:/:testCampaignId",
+  "test-cases.js:/",
+  "test-cases.js:/:testCaseId",
+]);
+
+test("every safe-method route is classified as read-only or as needing a token", async () => {
+  const fs = require("node:fs");
+  const path = require("node:path");
+  const routesDir = path.resolve(__dirname, "../src/server/routes");
+  const unclassified = [];
+  const files = fs.readdirSync(routesDir).filter((name) => name.endsWith(".js"));
+
+  assert.deepEqual(
+    files.filter((file) => !(file in MOUNTS)),
+    [],
+    "a new router file must be added to MOUNTS so its safe-method routes are classified"
+  );
+
+  for (const file of files) {
+    const source = fs.readFileSync(path.join(routesDir, file), "utf8");
+    const pattern = /router\.(get|head)\(\s*["'`]([^"'`]*)["'`]/g;
+    let match;
+    while ((match = pattern.exec(source)) !== null) {
+      const routePath = match[2];
+      const key = `${file}:${routePath}`;
+      if (READ_ONLY_SAFE_ROUTES.has(key)) continue;
+      // The router's own mount prefix is what makes the guard's path absolute;
+      // `isMutatingSafeMethodPath` is deliberately checked with a concrete
+      // example rather than the parameterised form.
+      const mounted = MOUNTS[file];
+      const concrete = mounted
+        ? `${mounted}${routePath.replace(/:[^/]+/g, "placeholder.json")}`.replace(/\/+$/, "") ||
+          mounted
+        : null;
+      if (concrete && isMutatingSafeMethodPath(concrete)) continue;
+      unclassified.push(key);
+    }
+  }
+
+  assert.deepEqual(
+    unclassified,
+    [],
+    "a safe-method route is neither on the reviewed read-only list nor covered by " +
+      "the CSRF guard's mutating-path list - classify it in one of the two, and if " +
+      "it changes state add it to MUTATING_SAFE_METHOD_PATHS in " +
+      "src/server/middleware/csrf.js"
+  );
 });

--- a/test/auth-csrf.test.js
+++ b/test/auth-csrf.test.js
@@ -181,3 +181,92 @@ test("login itself is exempt, because it is what issues the token", async () => 
     ctx.restore();
   }
 });
+
+// ---------------------------------------------------------------------------
+// The endpoints that mutate over a safe method
+// ---------------------------------------------------------------------------
+
+/**
+ * Endpoints that change state over `GET`. They predate the method-based rule
+ * and `SameSite=Lax` does not cover them: the cookie is still attached to a
+ * top-level `GET` navigation, so a link on any page an operator visits while
+ * logged in would otherwise reach them with full authority.
+ */
+const MUTATING_GETS = [
+  "/api/devops/start",
+  "/api/devops/stop",
+  "/api/simulation/stop/anything.json",
+  "/api/data-recorders/stop/anything.json",
+];
+
+test("state-changing GET endpoints require the CSRF token too", async () => {
+  await withSession(async (ctx, session) => {
+    for (const path of MUTATING_GETS) {
+      const res = await call(ctx, "GET", path, {
+        headers: { Cookie: session.cookie },
+      });
+      assert.equal(
+        res.status,
+        403,
+        `${path} mutates, so a tokenless GET must be refused: ${res.status} ${res.raw}`
+      );
+      assert.equal(res.body.error, "Invalid CSRF token");
+    }
+  });
+});
+
+test("the same endpoints are reachable once the token is sent", async () => {
+  await withSession(async (ctx, session) => {
+    // `/api/devops/start` is left out: it reaches for the configured data
+    // storage and blocks until that connection attempt times out, which says
+    // nothing about the guard under test here. Its refusal without a token is
+    // asserted above, which is the property this pair exists to pin.
+    for (const path of MUTATING_GETS.filter((p) => p !== "/api/devops/start")) {
+      const res = await call(ctx, "GET", path, {
+        headers: { Cookie: session.cookie, "X-CSRF-Token": session.csrfToken },
+      });
+      assert.notEqual(
+        res.status,
+        403,
+        `${path} must still work for the dashboard: ${res.status} ${res.raw}`
+      );
+    }
+  });
+});
+
+test("the mutating-GET list is matched case-insensitively, as Express routes are", async () => {
+  await withSession(async (ctx, session) => {
+    // `/api/DevOps/stop` reaches the same handler, so a case-sensitive list
+    // would be a way straight around the check.
+    const res = await call(ctx, "GET", "/api/DevOps/stop", {
+      headers: { Cookie: session.cookie },
+    });
+    assert.equal(res.status, 403, `case variation must not evade the check: ${res.raw}`);
+  });
+});
+
+test("a forged CORS preflight cannot enumerate the routing table", async () => {
+  await startApp({}, { login: false }).then(async (ctx) => {
+    try {
+      // The two headers that define a preflight are trivially forged by a
+      // non-browser client. The exemption must therefore stop at answering the
+      // preflight: passing it on hands Express's own OPTIONS responder an
+      // anonymous caller, and its `Allow` header - plus the 404 an unrouted
+      // path gets - maps every endpoint and the methods it takes.
+      const probes = ["/api/models", "/api/models/x.json", "/api/devops/start", "/api/nope"];
+      const seen = new Set();
+      for (const path of probes) {
+        const res = await call(ctx, "OPTIONS", path, {
+          headers: { Origin: ctx.base, "Access-Control-Request-Method": "GET" },
+        });
+        assert.equal(res.status, 204, `${path} preflight must be answered here: ${res.raw}`);
+        assert.equal(res.res.headers.get("allow"), null, `${path} must not leak an Allow header`);
+        seen.add(res.status);
+      }
+      assert.equal(seen.size, 1, "an existing path must not be distinguishable from an unknown one");
+    } finally {
+      await new Promise((resolve) => ctx.server.close(resolve));
+      ctx.restore();
+    }
+  });
+});

--- a/test/auth-logging.test.js
+++ b/test/auth-logging.test.js
@@ -1,0 +1,199 @@
+/**
+ * Authentication failure logging (issue #9, AC7).
+ *
+ * A rejected login that leaves no trace is a brute-force run nobody can see.
+ * These tests pin the shape of the record: one line per attempt, carrying the
+ * attempted username, the client address, the user agent, the reason and a
+ * running count of consecutive failures from that address - and never the
+ * password, the session identifier or the CSRF token.
+ */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { startApp, TEST_CREDENTIALS } = require("./helpers/start-app");
+const {
+  createFailureTracker,
+  sanitizeForLog,
+} = require("../src/server/routes/auth");
+
+const USERNAME = TEST_CREDENTIALS.AUTH_ADMIN_USERNAME;
+const PASSWORD = TEST_CREDENTIALS.AUTH_ADMIN_PASSWORD;
+
+/**
+ * Log in (or try to) and return the response.
+ * @param {Object} ctx Started application context
+ * @param {Object} credentials {username, password}
+ * @param {Object} [headers] Extra request headers
+ * @returns {Promise<{status:Number,raw:String}>}
+ */
+async function attempt(ctx, credentials, headers = {}) {
+  const res = await fetch(ctx.base + "/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(credentials),
+  });
+  return { status: res.status, raw: await res.text() };
+}
+
+/**
+ * Run a block with `console.error` captured.
+ * @param {Object} env Environment overrides
+ * @param {Function} fn Receives (ctx, lines)
+ * @returns {Promise<String[]>} Everything written while the block ran
+ */
+async function withCapturedLog(env, fn) {
+  const ctx = await startApp(env, { login: false });
+  const original = console.error;
+  const lines = [];
+  console.error = (line) => lines.push(String(line));
+  try {
+    await fn(ctx, lines);
+  } finally {
+    console.error = original;
+    await new Promise((resolve) => ctx.server.close(resolve));
+    ctx.restore();
+  }
+  return lines;
+}
+
+test("every failed login is recorded with an incrementing failure count", async () => {
+  const password = "guess-number-";
+  const lines = await withCapturedLog({}, async (ctx) => {
+    for (let i = 1; i <= 5; i += 1) {
+      const res = await attempt(
+        ctx,
+        { username: USERNAME, password: password + i },
+        { "User-Agent": "brute-force-tool/1.0" }
+      );
+      assert.equal(res.status, 401, `attempt ${i} must be refused`);
+    }
+  });
+
+  const failures = lines.filter((line) => line.startsWith("[AUTH] login failed"));
+  assert.equal(failures.length, 5, `expected 5 failure lines, got: ${lines.join(" | ")}`);
+
+  failures.forEach((line, index) => {
+    assert.match(line, new RegExp(`user="${USERNAME}"`), line);
+    assert.match(line, /ip=127\.0\.0\.1/, line);
+    assert.match(line, /ua="brute-force-tool\/1\.0"/, line);
+    assert.match(line, /reason=invalid_credentials/, line);
+    assert.match(line, new RegExp(`failures=${index + 1}(\\s|$)`), `line ${index + 1}: ${line}`);
+  });
+
+  // Nothing in the log may carry what was guessed.
+  for (const line of lines) {
+    assert.ok(!line.includes(password), `a password reached the log: ${line}`);
+    assert.ok(!line.includes(PASSWORD), `the real password reached the log: ${line}`);
+  }
+});
+
+test("a successful login is recorded and resets the failure counter", async () => {
+  const lines = await withCapturedLog({}, async (ctx) => {
+    await attempt(ctx, { username: USERNAME, password: "wrong-1" });
+    await attempt(ctx, { username: USERNAME, password: "wrong-2" });
+    const ok = await attempt(ctx, { username: USERNAME, password: PASSWORD });
+    assert.equal(ok.status, 200, ok.raw);
+    const again = await attempt(ctx, { username: USERNAME, password: "wrong-3" });
+    assert.equal(again.status, 401);
+  });
+
+  const failures = lines.filter((line) => line.startsWith("[AUTH] login failed"));
+  const successes = lines.filter((line) => line.startsWith("[AUTH] login succeeded"));
+
+  assert.equal(successes.length, 1, `expected one success line: ${lines.join(" | ")}`);
+  assert.match(successes[0], new RegExp(`user="${USERNAME}"`));
+  assert.match(successes[0], /ip=127\.0\.0\.1/);
+  assert.match(successes[0], /ua="/);
+
+  assert.equal(failures.length, 3);
+  assert.match(failures[0], /failures=1(\s|$)/);
+  assert.match(failures[1], /failures=2(\s|$)/);
+  // The success in between reset the counter, so this run starts over at 1.
+  assert.match(failures[2], /failures=1(\s|$)/, failures[2]);
+
+  for (const line of lines) {
+    assert.ok(!line.includes(PASSWORD), `the password reached the log: ${line}`);
+    assert.ok(!line.includes("csrfToken"), `a token reached the log: ${line}`);
+  }
+});
+
+test("a login refused because nothing is configured says so", async () => {
+  const lines = await withCapturedLog(
+    { AUTH_ADMIN_PASSWORD: "", AUTH_ADMIN_PASSWORD_HASH: "" },
+    async (ctx) => {
+      const res = await attempt(ctx, { username: "admin", password: "anything" });
+      assert.equal(res.status, 503, res.raw);
+    }
+  );
+  const failure = lines.find((line) => line.startsWith("[AUTH] login failed"));
+  assert.ok(failure, `expected a failure line: ${lines.join(" | ")}`);
+  assert.match(failure, /reason=not_configured/);
+  assert.match(failure, /failures=1(\s|$)/);
+});
+
+test("no session identifier or CSRF token is ever written to the log", async () => {
+  let secrets = [];
+  const lines = await withCapturedLog({}, async (ctx) => {
+    const res = await fetch(ctx.base + "/api/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: USERNAME, password: PASSWORD }),
+    });
+    const body = JSON.parse(await res.text());
+    const cookies = res.headers.getSetCookie();
+    secrets = [body.csrfToken].concat(cookies.map((c) => c.split(";")[0].split("=")[1]));
+  });
+  for (const line of lines) {
+    for (const secret of secrets) {
+      if (!secret) continue;
+      assert.ok(!line.includes(secret), `a session secret reached the log: ${line}`);
+    }
+  }
+});
+
+test("a username carrying newlines cannot forge extra log lines", async () => {
+  const hostile = 'victim"\n[AUTH] login succeeded user="attacker" ip=1.2.3.4';
+  const lines = await withCapturedLog({}, async (ctx) => {
+    const res = await attempt(ctx, { username: hostile, password: "wrong" });
+    assert.equal(res.status, 401, res.raw);
+  });
+  for (const line of lines) {
+    assert.ok(!line.includes("\n"), `a log line must stay one line: ${JSON.stringify(line)}`);
+  }
+  assert.equal(
+    lines.filter((line) => line.startsWith("[AUTH] login succeeded")).length,
+    0,
+    "an injected success line must not appear"
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The pieces the log line is built from
+// ---------------------------------------------------------------------------
+
+test("sanitizeForLog strips what could forge or break a log line", () => {
+  assert.equal(sanitizeForLog("plain-user"), "plain-user");
+  assert.equal(sanitizeForLog("a\r\nb"), "a b");
+  assert.equal(sanitizeForLog("a\u0000\u001fb\u007f"), "ab", "control characters are removed");
+  assert.equal(sanitizeForLog('say "hi"'), "say 'hi'");
+  assert.equal(sanitizeForLog(undefined), "");
+  assert.equal(sanitizeForLog(null), "");
+  assert.equal(sanitizeForLog("x".repeat(500)).length, 200);
+});
+
+test("the failure tracker counts per address, resets on success and stays bounded", () => {
+  const tracker = createFailureTracker();
+  assert.equal(tracker.get("1.1.1.1"), 0);
+  assert.equal(tracker.fail("1.1.1.1"), 1);
+  assert.equal(tracker.fail("1.1.1.1"), 2);
+  assert.equal(tracker.fail("2.2.2.2"), 1, "each address counts on its own");
+  tracker.reset("1.1.1.1");
+  assert.equal(tracker.get("1.1.1.1"), 0);
+  assert.equal(tracker.fail("1.1.1.1"), 1);
+
+  // An unbounded map keyed by the caller's own address would be a memory sink.
+  for (let i = 0; i < 1500; i += 1) {
+    tracker.fail(`10.0.${Math.floor(i / 256)}.${i % 256}`);
+  }
+  assert.equal(tracker.get("10.0.0.0"), 0, "the oldest entries must be evicted");
+  assert.equal(tracker.get("10.0.5.219"), 1, "the newest entries must be kept");
+});

--- a/test/auth-primitives.test.js
+++ b/test/auth-primitives.test.js
@@ -15,7 +15,14 @@ const {
   timingSafeCompare,
 } = require("../src/server/auth/passwords");
 const { createCredential } = require("../src/server/auth/credentials");
-const { createSessionStore } = require("../src/server/auth/session-store");
+const {
+  createSessionStore,
+  DEFAULT_MAX_SESSIONS,
+} = require("../src/server/auth/session-store");
+const { loadConfig } = require("../src/server/config");
+
+const os = require("node:os");
+const path = require("node:path");
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -101,6 +108,47 @@ test("a plaintext password is hashed at construction and not retained", () => {
   );
   for (const value of Object.values(credential)) {
     assert.notEqual(value, "plain-password");
+  }
+});
+
+test("the plaintext is erased from the configuration object it was read from", () => {
+  // `app.js` holds the configuration object for the lifetime of the process and
+  // hands it to the middleware, the router and the cookie helpers. A plaintext
+  // left on it would outlive its one use and be reachable from a heap dump, a
+  // debugger or a careless `console.error(config)`.
+  const config = {
+    authAdminUsername: "operator",
+    authAdminPassword: "plain-password",
+    AUTH_ADMIN_PASSWORD: "plain-password",
+    sessionIdleTtlMs: 1000,
+  };
+  const credential = createCredential(config);
+  assert.equal(credential.verify("operator", "plain-password"), true, "the hash still verifies");
+  assert.equal(config.authAdminPassword, "");
+  assert.equal(config.AUTH_ADMIN_PASSWORD, "");
+  assert.ok(
+    !JSON.stringify(config).includes("plain-password"),
+    "the plaintext must not be reachable from the config object either"
+  );
+  // Every other setting is untouched.
+  assert.equal(config.sessionIdleTtlMs, 1000);
+  assert.equal(config.authAdminUsername, "operator");
+});
+
+test("loadConfig never exposes a plaintext password once the credential is built", () => {
+  const missing = path.join(os.tmpdir(), `missing-${Date.now()}-${Math.random()}.env`);
+  const saved = process.env.AUTH_ADMIN_PASSWORD;
+  process.env.AUTH_ADMIN_PASSWORD = "bootstrap-plaintext";
+  try {
+    const config = loadConfig({ path: missing });
+    createCredential(config);
+    assert.ok(
+      !JSON.stringify(config).includes("bootstrap-plaintext"),
+      "the loaded configuration must not retain the plaintext"
+    );
+  } finally {
+    if (saved === undefined) delete process.env.AUTH_ADMIN_PASSWORD;
+    else process.env.AUTH_ADMIN_PASSWORD = saved;
   }
 });
 
@@ -206,4 +254,36 @@ test("sweep removes expired records without a timer holding the process open", a
   store.create("d");
   assert.equal(store.get(live.id), null);
   assert.equal(store.size(), 1);
+});
+
+test("the table has a hard size cap and evicts rather than growing without bound", () => {
+  // Lazy expiry alone is not a bound: a caller can mint records faster than the
+  // idle window ages them out. The cap is the defence in depth, mirroring how
+  // the login failure tracker is bounded by FAILURE_TRACKER_LIMIT.
+  const store = createSessionStore({ idleTtlMs: 60000, absoluteTtlMs: 60000, maxSessions: 5 });
+  assert.equal(store.maxSessions(), 5);
+
+  const created = [];
+  for (let i = 0; i < 50; i += 1) {
+    created.push(store.create(`user-${i}`));
+    assert.ok(store.size() <= 5, `the table must never exceed the cap, saw ${store.size()}`);
+  }
+  assert.equal(store.size(), 5);
+  // The five most recent survive; the earliest were evicted.
+  for (const session of created.slice(-5)) {
+    assert.ok(store.get(session.id), "the most recent records must be kept");
+  }
+  assert.equal(store.get(created[0].id), null, "the least recently seen record is evicted");
+
+  // Eviction is by recency, not by creation order: a record that keeps being
+  // used outlives newer, idle ones.
+  const busy = created[created.length - 1];
+  for (let i = 0; i < 4; i += 1) {
+    assert.ok(store.touch(busy.id), "the busy session stays alive");
+    store.create(`later-${i}`);
+  }
+  assert.ok(store.get(busy.id), "a session in continuous use must not be evicted");
+
+  assert.equal(DEFAULT_MAX_SESSIONS, 1000, "the shipped default is documented in the README");
+  assert.equal(createSessionStore({}).maxSessions(), DEFAULT_MAX_SESSIONS);
 });

--- a/test/auth-primitives.test.js
+++ b/test/auth-primitives.test.js
@@ -1,0 +1,209 @@
+/**
+ * The primitives authentication is built out of (issue #9).
+ *
+ * `middleware/auth.js` is only as good as these three: a password store that
+ * cannot be reversed and cannot be probed by timing, a credential that is
+ * provisioned from configuration and never keeps the plaintext, and a session
+ * table with two-sided expiry.
+ */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  hashPassword,
+  verifyPassword,
+  timingSafeCompare,
+} = require("../src/server/auth/passwords");
+const { createCredential } = require("../src/server/auth/credentials");
+const { createSessionStore } = require("../src/server/auth/session-store");
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ---------------------------------------------------------------------------
+// passwords.js
+// ---------------------------------------------------------------------------
+
+test("a hashed password verifies, and a wrong one does not", () => {
+  const hash = hashPassword("correct horse battery staple");
+  assert.equal(verifyPassword("correct horse battery staple", hash), true);
+  assert.equal(verifyPassword("correct horse battery stapl", hash), false);
+  assert.equal(verifyPassword("", hash), false);
+  assert.equal(verifyPassword("CORRECT HORSE BATTERY STAPLE", hash), false);
+});
+
+test("the stored form carries the algorithm and cost, and never the plaintext", () => {
+  const hash = hashPassword("s3cr3t-value");
+  assert.match(hash, /^scrypt\$16384\$8\$1\$[A-Za-z0-9+/=]+\$[A-Za-z0-9+/=]+$/);
+  assert.ok(!hash.includes("s3cr3t-value"), "the plaintext must not appear in the hash");
+});
+
+test("two hashes of the same password differ, because each is salted", () => {
+  const a = hashPassword("same-password");
+  const b = hashPassword("same-password");
+  assert.notEqual(a, b, "an unsalted store would produce identical values");
+  assert.equal(verifyPassword("same-password", a), true);
+  assert.equal(verifyPassword("same-password", b), true);
+});
+
+test("a malformed stored value verifies as false rather than throwing", () => {
+  for (const bad of [
+    "",
+    null,
+    undefined,
+    "not-a-hash",
+    "scrypt$16384$8$1$onlyfourfields",
+    "scrypt$16384$8$1$$",
+    "bcrypt$16384$8$1$c2FsdA==$aGFzaA==",
+    "scrypt$abc$8$1$c2FsdA==$aGFzaA==",
+    "scrypt$1$8$1$c2FsdA==$aGFzaA==",
+    "scrypt$16384$8$1$c2FsdA==$aGFzaA==$extra",
+    {},
+    12345,
+  ]) {
+    assert.equal(
+      verifyPassword("anything", bad),
+      false,
+      `${JSON.stringify(bad)} should verify as false`
+    );
+  }
+});
+
+test("timingSafeCompare is an equality test that tolerates any input", () => {
+  assert.equal(timingSafeCompare("abc", "abc"), true);
+  assert.equal(timingSafeCompare("abc", "abd"), false);
+  assert.equal(timingSafeCompare("abc", "abcd"), false, "a length mismatch is not equal");
+  assert.equal(timingSafeCompare("", ""), true);
+  assert.equal(timingSafeCompare(undefined, ""), true);
+  assert.equal(timingSafeCompare(null, "x"), false);
+});
+
+// ---------------------------------------------------------------------------
+// credentials.js
+// ---------------------------------------------------------------------------
+
+test("a plaintext password is hashed at construction and not retained", () => {
+  const credential = createCredential({
+    authAdminUsername: "operator",
+    authAdminPassword: "plain-password",
+  });
+  assert.equal(credential.configured, true);
+  assert.equal(credential.source, "password");
+  assert.equal(credential.username, "operator");
+  assert.equal(credential.verify("operator", "plain-password"), true);
+  assert.equal(credential.verify("operator", "wrong"), false);
+  assert.equal(credential.verify("someone-else", "plain-password"), false);
+
+  // The plaintext must not be reachable from the object the rest of the
+  // application holds on to.
+  assert.ok(
+    !JSON.stringify(credential).includes("plain-password"),
+    "the plaintext must not survive on the credential"
+  );
+  for (const value of Object.values(credential)) {
+    assert.notEqual(value, "plain-password");
+  }
+});
+
+test("a pre-hashed password takes precedence over a plaintext one", () => {
+  const hash = hashPassword("the-hashed-one");
+  const credential = createCredential({
+    authAdminUsername: "operator",
+    authAdminPassword: "the-plaintext-one",
+    authAdminPasswordHash: hash,
+  });
+  assert.equal(credential.source, "hash");
+  assert.equal(credential.verify("operator", "the-hashed-one"), true);
+  assert.equal(credential.verify("operator", "the-plaintext-one"), false);
+});
+
+test("an unconfigured credential refuses everything", () => {
+  for (const config of [
+    {},
+    { authAdminPassword: "", authAdminPasswordHash: "" },
+    { authAdminPasswordHash: "   " },
+  ]) {
+    const credential = createCredential(config);
+    assert.equal(credential.configured, false);
+    assert.equal(credential.source, null);
+    assert.equal(credential.username, "admin", "the default username still applies");
+    assert.equal(credential.verify("admin", ""), false);
+    assert.equal(credential.verify("admin", "anything"), false);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// session-store.js
+// ---------------------------------------------------------------------------
+
+test("a created session is retrievable, unguessable and carries its own CSRF token", () => {
+  const store = createSessionStore({ idleTtlMs: 1000, absoluteTtlMs: 5000 });
+  const session = store.create("operator");
+  assert.equal(store.get(session.id).user, "operator");
+  assert.equal(store.size(), 1);
+  assert.ok(session.id.length >= 40, "the identifier must be long enough not to be guessed");
+  assert.ok(session.csrfToken.length >= 40);
+  assert.notEqual(session.id, session.csrfToken);
+
+  const second = store.create("operator");
+  assert.notEqual(second.id, session.id, "identifiers must not repeat");
+  assert.notEqual(second.csrfToken, session.csrfToken, "tokens must not repeat");
+});
+
+test("an unknown or malformed identifier resolves to nothing", () => {
+  const store = createSessionStore({});
+  for (const id of ["", null, undefined, 42, "no-such-session", {}]) {
+    assert.equal(store.get(id), null, `${JSON.stringify(id)} must not resolve`);
+  }
+});
+
+test("touch slides the idle window forward, and stopping ends the session", async () => {
+  const store = createSessionStore({ idleTtlMs: 120, absoluteTtlMs: 60000 });
+  const session = store.create("operator");
+  for (let i = 0; i < 4; i += 1) {
+    await sleep(50);
+    assert.ok(store.touch(session.id), `touch ${i + 1} must keep the session alive`);
+  }
+  // Four touches spanning 200ms - well past the 120ms idle window - kept it.
+  await sleep(200);
+  assert.equal(store.get(session.id), null, "an idle session must expire");
+  assert.equal(store.touch(session.id), null);
+});
+
+test("the absolute lifetime is not extended by use", async () => {
+  const store = createSessionStore({ idleTtlMs: 60000, absoluteTtlMs: 150 });
+  const session = store.create("operator");
+  await sleep(60);
+  assert.ok(store.touch(session.id), "still inside the absolute window");
+  await sleep(150);
+  assert.equal(store.get(session.id), null, "the hard cap must not slide");
+});
+
+test("destroy and destroyAll invalidate sessions immediately", () => {
+  const store = createSessionStore({});
+  const first = store.create("operator");
+  const second = store.create("operator");
+  assert.equal(store.destroy(first.id), true);
+  assert.equal(store.destroy(first.id), false, "destroying twice is not an error");
+  assert.equal(store.get(first.id), null);
+  assert.ok(store.get(second.id), "only the named session is destroyed");
+
+  store.destroyAll();
+  assert.equal(store.get(second.id), null);
+  assert.equal(store.size(), 0);
+});
+
+test("sweep removes expired records without a timer holding the process open", async () => {
+  const store = createSessionStore({ idleTtlMs: 40, absoluteTtlMs: 60000 });
+  store.create("a");
+  store.create("b");
+  assert.equal(store.size(), 2);
+  await sleep(120);
+  assert.equal(store.sweep(), 2, "both expired records must be removed");
+  assert.equal(store.size(), 0);
+  // Creating also sweeps, so the table cannot grow without bound.
+  const live = store.create("c");
+  await sleep(120);
+  store.create("d");
+  assert.equal(store.get(live.id), null);
+  assert.equal(store.size(), 1);
+});

--- a/test/auth-proxy.test.js
+++ b/test/auth-proxy.test.js
@@ -178,3 +178,146 @@ test("the public allowlist is exactly the three documented routes", () => {
     { method: "GET", path: "/auth/session" },
   ]);
 });
+
+// ---------------------------------------------------------------------------
+// The SPA's boot sequence behind the proxy
+// ---------------------------------------------------------------------------
+
+test("GET /api/auth/session reports the delegated identity on the dashboard's first call", async () => {
+  await withApp(
+    { AUTH_TRUST_PROXY_HEADER: "true", AUTH_TRUSTED_PROXIES: "127.0.0.1" },
+    async (ctx) => {
+      // This is exactly what `App.componentDidMount -> checkSession` sends: no
+      // cookie yet, because the browser has never had one from this origin, and
+      // the identity header the proxy attached. Answering `authenticated:false`
+      // here would show a password form for an account whose password a proxy
+      // deployment deliberately does not hand out.
+      const boot = await call(ctx, "GET", "/api/auth/session", {
+        "X-Forwarded-User": "proxy-operator",
+      });
+      assert.equal(boot.status, 200, boot.raw);
+      assert.equal(boot.body.authenticated, true, `the SPA must boot logged in: ${boot.raw}`);
+      assert.equal(boot.body.user, "proxy-operator");
+      assert.equal(typeof boot.body.csrfToken, "string");
+      assert.ok(boot.body.csrfToken.length >= 40, "the boot call must hand over a usable token");
+
+      // And the same endpoint still says "no" when the proxy asserts nothing,
+      // so the anonymous cold start is unchanged.
+      const anonymous = await call(ctx, "GET", "/api/auth/session");
+      assert.equal(anonymous.status, 200);
+      assert.deepEqual(anonymous.body, { authenticated: false });
+    }
+  );
+});
+
+test("password login still works while delegation is active", async () => {
+  await withApp(
+    { AUTH_TRUST_PROXY_HEADER: "true", AUTH_TRUSTED_PROXIES: "127.0.0.1" },
+    async (ctx) => {
+      const res = await fetch(ctx.base + "/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username: "test-admin", password: "test-password" }),
+      });
+      const body = await res.json();
+      assert.equal(res.status, 200, JSON.stringify(body));
+      assert.equal(body.authenticated, true);
+      assert.equal(body.user, "test-admin");
+    }
+  );
+});
+
+// ---------------------------------------------------------------------------
+// One session per delegated identity, not one per request
+// ---------------------------------------------------------------------------
+
+test("repeated cookieless requests from the proxy reuse one session record", async () => {
+  await withApp(
+    { AUTH_TRUST_PROXY_HEADER: "true", AUTH_TRUSTED_PROXIES: "127.0.0.1" },
+    async (ctx) => {
+      // A curl call, a monitoring probe or a CI script behind the proxy sends no
+      // cookie at all. Minting a record per request would grow the session table
+      // with traffic rather than with users, and `sweep()` only reclaims records
+      // that have already expired.
+      const ids = new Set();
+      for (let i = 0; i < 10; i += 1) {
+        const res = await call(ctx, "GET", "/api/devops/status", {
+          "X-Forwarded-User": "probe",
+        });
+        assert.equal(res.status, 200, res.raw);
+        const sid = res.res.headers
+          .getSetCookie()
+          .find((c) => c.startsWith("tas.sid="));
+        assert.ok(sid, "a delegated request must carry its session cookie");
+        ids.add(sid.split(";")[0]);
+      }
+      assert.equal(ids.size, 1, `10 requests must share one session, got ${ids.size}`);
+
+      // A different asserted identity is a different session, of course.
+      const other = await call(ctx, "GET", "/api/devops/status", {
+        "X-Forwarded-User": "somebody-else",
+      });
+      const otherSid = other.res.headers
+        .getSetCookie()
+        .find((c) => c.startsWith("tas.sid="))
+        .split(";")[0];
+      assert.ok(!ids.has(otherSid), "identities must not share a session record");
+    }
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Delegation does not exempt anything from CSRF
+// ---------------------------------------------------------------------------
+
+test("a delegated state-changing request without a CSRF token is still refused", async () => {
+  await withApp(
+    { AUTH_TRUST_PROXY_HEADER: "true", AUTH_TRUSTED_PROXIES: "127.0.0.1" },
+    async (ctx) => {
+      // The proxy attaches the identity header to whatever reaches it, cookies
+      // or no cookies, so a cross-site forged POST from evil.com arrives in
+      // exactly this shape. Exempting it would hand an attacker authenticated
+      // state-changing access.
+      const forged = await call(ctx, "POST", "/api/auth/logout", {
+        "X-Forwarded-User": "proxy-operator",
+      });
+      assert.equal(forged.status, 403, `delegation must not bypass CSRF: ${forged.raw}`);
+      assert.equal(forged.body.error, "Invalid CSRF token");
+
+      const wrongToken = await call(ctx, "POST", "/api/auth/logout", {
+        "X-Forwarded-User": "proxy-operator",
+        "X-CSRF-Token": "not-the-token",
+      });
+      assert.equal(wrongToken.status, 403, wrongToken.raw);
+    }
+  );
+});
+
+test("a delegated client that fetches its token first can then write", async () => {
+  await withApp(
+    { AUTH_TRUST_PROXY_HEADER: "true", AUTH_TRUSTED_PROXIES: "127.0.0.1" },
+    async (ctx) => {
+      // The documented recipe for a non-browser client behind the proxy: ask
+      // `GET /api/auth/session` for the token, then echo it back.
+      const boot = await call(ctx, "GET", "/api/auth/session", {
+        "X-Forwarded-User": "ci-script",
+      });
+      assert.equal(boot.body.authenticated, true, boot.raw);
+
+      const write = await call(ctx, "POST", "/api/auth/logout", {
+        "X-Forwarded-User": "ci-script",
+        "X-CSRF-Token": boot.body.csrfToken,
+      });
+      assert.equal(write.status, 200, `the documented flow must work: ${write.raw}`);
+      assert.deepEqual(write.body, { authenticated: false });
+
+      // Logging out destroyed the cached record; the next delegated request
+      // must fall back to minting a fresh one rather than failing.
+      const again = await call(ctx, "GET", "/api/auth/session", {
+        "X-Forwarded-User": "ci-script",
+      });
+      assert.equal(again.body.authenticated, true, again.raw);
+      assert.notEqual(again.body.csrfToken, boot.body.csrfToken, "a destroyed session is not reused");
+    }
+  );
+});

--- a/test/auth-proxy.test.js
+++ b/test/auth-proxy.test.js
@@ -1,0 +1,180 @@
+/**
+ * Reverse-proxy identity delegation (issue #9, AC5).
+ *
+ * A deployment that already sits behind an authenticating proxy should be able
+ * to delegate identity to it rather than maintain a second credential. The
+ * danger is that the mechanism - a request header - is trivially forgeable by
+ * anyone who can reach the port, so the feature is only ever the intended one
+ * when the peer address is pinned as well.
+ *
+ * These tests pin all four states: off (the default), on but unpinned, on and
+ * correctly pinned, and on but pinned to somebody else.
+ */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { startApp } = require("./helpers/start-app");
+
+/**
+ * Issue a request and read the response.
+ * @param {Object} ctx Started application context
+ * @param {String} method HTTP method
+ * @param {String} path Request path
+ * @param {Object} [headers] Request headers
+ * @returns {Promise<{status:Number,body:Object|null,raw:String,res:Response}>}
+ */
+async function call(ctx, method, path, headers = {}) {
+  const res = await fetch(ctx.base + path, { method, headers });
+  const raw = await res.text();
+  let body = null;
+  try {
+    body = JSON.parse(raw);
+  } catch (_) {
+    /* not JSON */
+  }
+  return { status: res.status, body, raw, res };
+}
+
+/**
+ * Run a block against a freshly started instance.
+ * @param {Object} env Environment overrides
+ * @param {Function} fn Receives the started context
+ * @returns {Promise<void>}
+ */
+async function withApp(env, fn) {
+  const ctx = await startApp(env, { login: false });
+  try {
+    await fn(ctx);
+  } finally {
+    await new Promise((resolve) => ctx.server.close(resolve));
+    ctx.restore();
+  }
+}
+
+test("with delegation off (the default) a proxy identity header is completely inert", async () => {
+  await withApp({}, async (ctx) => {
+    for (const header of [
+      { "X-Forwarded-User": "test-admin" },
+      { "x-forwarded-user": "admin" },
+      { "X-Forwarded-User": "test-admin", "X-Forwarded-For": "127.0.0.1" },
+      { "X-Remote-User": "test-admin" },
+    ]) {
+      const res = await call(ctx, "GET", "/api/models", header);
+      assert.equal(
+        res.status,
+        401,
+        `${JSON.stringify(header)} must not authenticate anything: ${res.raw}`
+      );
+      assert.equal(res.body.error, "Authentication required");
+      assert.deepEqual(
+        res.res.headers.getSetCookie(),
+        [],
+        "a spoofed header must not mint a session"
+      );
+    }
+  });
+});
+
+test("the flag alone, with no trusted proxies, leaves delegation disabled and warns", async () => {
+  const original = console.error;
+  const lines = [];
+  console.error = (line) => lines.push(String(line));
+  try {
+    await withApp({ AUTH_TRUST_PROXY_HEADER: "true", AUTH_TRUSTED_PROXIES: "" }, async (ctx) => {
+      const res = await call(ctx, "GET", "/api/models", { "X-Forwarded-User": "test-admin" });
+      assert.equal(res.status, 401, `delegation must stay off without a peer list: ${res.raw}`);
+    });
+  } finally {
+    console.error = original;
+  }
+  const warning = lines.find((line) => line.includes("AUTH_TRUST_PROXY_HEADER"));
+  assert.ok(warning, `expected a startup warning, got: ${lines.join(" | ")}`);
+  assert.match(warning, /^\[AUTH\]/);
+  assert.match(warning, /AUTH_TRUSTED_PROXIES is empty/);
+  assert.match(warning, /stays disabled/);
+});
+
+test("a trusted peer's identity header authenticates and is given a real session", async () => {
+  await withApp(
+    { AUTH_TRUST_PROXY_HEADER: "true", AUTH_TRUSTED_PROXIES: "127.0.0.1" },
+    async (ctx) => {
+      const res = await call(ctx, "GET", "/api/models", { "X-Forwarded-User": "proxy-operator" });
+      assert.equal(res.status, 200, `a trusted peer must be believed: ${res.raw}`);
+
+      const cookies = res.res.headers.getSetCookie();
+      assert.ok(
+        cookies.some((c) => c.startsWith("tas.sid=")),
+        `a delegated identity must get a session cookie: ${cookies.join(" | ")}`
+      );
+      assert.ok(
+        cookies.some((c) => c.startsWith("tas.csrf=")),
+        "a delegated identity must get a CSRF token too"
+      );
+
+      // The session it was given is a real one: it identifies the proxy-supplied
+      // user and works on its own afterwards.
+      const cookie = cookies.map((c) => c.split(";")[0]).join("; ");
+      const session = await call(ctx, "GET", "/api/auth/session", { Cookie: cookie });
+      assert.equal(session.status, 200);
+      assert.equal(session.body.authenticated, true);
+      assert.equal(session.body.user, "proxy-operator");
+    }
+  );
+});
+
+test("a header from an untrusted peer address is ignored", async () => {
+  await withApp(
+    { AUTH_TRUST_PROXY_HEADER: "true", AUTH_TRUSTED_PROXIES: "10.9.8.7, 192.0.2.10" },
+    async (ctx) => {
+      const res = await call(ctx, "GET", "/api/models", { "X-Forwarded-User": "test-admin" });
+      assert.equal(res.status, 401, `only the listed peers may delegate: ${res.raw}`);
+      assert.deepEqual(res.res.headers.getSetCookie(), []);
+    }
+  );
+});
+
+test("an empty identity header from a trusted peer does not authenticate", async () => {
+  await withApp(
+    { AUTH_TRUST_PROXY_HEADER: "true", AUTH_TRUSTED_PROXIES: "127.0.0.1" },
+    async (ctx) => {
+      assert.equal((await call(ctx, "GET", "/api/models", { "X-Forwarded-User": "  " })).status, 401);
+      assert.equal((await call(ctx, "GET", "/api/models")).status, 401);
+    }
+  );
+});
+
+test("the identity header name is configurable, and only that name is honoured", async () => {
+  await withApp(
+    {
+      AUTH_TRUST_PROXY_HEADER: "true",
+      AUTH_TRUSTED_PROXIES: "127.0.0.1",
+      AUTH_PROXY_USER_HEADER: "x-remote-user",
+    },
+    async (ctx) => {
+      const wrongName = await call(ctx, "GET", "/api/models", { "X-Forwarded-User": "someone" });
+      assert.equal(wrongName.status, 401, "the default header must stop being honoured");
+
+      const rightName = await call(ctx, "GET", "/api/models", { "X-Remote-User": "someone" });
+      assert.equal(rightName.status, 200, rightName.raw);
+    }
+  );
+});
+
+test("normalizeAddress unwraps IPv4-mapped peers without conflating loopbacks", () => {
+  const { normalizeAddress } = require("../src/server/middleware/auth");
+  assert.equal(normalizeAddress("::ffff:127.0.0.1"), "127.0.0.1");
+  assert.equal(normalizeAddress("::FFFF:10.0.0.5"), "10.0.0.5");
+  assert.equal(normalizeAddress("127.0.0.1"), "127.0.0.1");
+  // ::1 and 127.0.0.1 are different addresses; folding them together would
+  // silently widen a configured trusted-peer list.
+  assert.equal(normalizeAddress("::1"), "::1");
+  assert.equal(normalizeAddress(undefined), "");
+});
+
+test("the public allowlist is exactly the three documented routes", () => {
+  const { PUBLIC_API_ROUTES } = require("../src/server/middleware/auth");
+  assert.deepEqual(PUBLIC_API_ROUTES, [
+    { method: "GET", path: "/health" },
+    { method: "POST", path: "/auth/login" },
+    { method: "GET", path: "/auth/session" },
+  ]);
+});

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -1,0 +1,449 @@
+/**
+ * API authentication and session protection (issue #9).
+ *
+ * The API used to answer any caller that could reach the port. These tests pin
+ * what replaced that: every endpoint but a short, explicit allowlist requires a
+ * session, the administrator credential comes from configuration rather than
+ * from the repository, and a session expires, slides while it is in use, and
+ * can be thrown away.
+ */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { startApp, TEST_CREDENTIALS } = require("./helpers/start-app");
+
+/** Every API prefix the application mounts a router on. */
+const API_PREFIXES = [
+  "/api/models",
+  "/api/data-recorders",
+  "/api/data-storage",
+  "/api/logs/data-recorders",
+  "/api/logs/simulations",
+  "/api/logs/test-campaigns",
+  "/api/data-sets",
+  "/api/test-cases",
+  "/api/test-campaigns",
+  "/api/events",
+  "/api/reports",
+  "/api/simulation",
+  "/api/devops",
+];
+
+const USERNAME = TEST_CREDENTIALS.AUTH_ADMIN_USERNAME;
+const PASSWORD = TEST_CREDENTIALS.AUTH_ADMIN_PASSWORD;
+
+/**
+ * Issue a request against a started context.
+ * @param {Object} ctx Started application context
+ * @param {String} method HTTP method
+ * @param {String} path Request path
+ * @param {Object} [options] {body, headers}
+ * @returns {Promise<{status:Number,body:Object|null,raw:String,res:Response}>}
+ */
+async function call(ctx, method, path, options = {}) {
+  const res = await fetch(ctx.base + path, {
+    method,
+    headers: {
+      ...(options.body ? { "Content-Type": "application/json" } : {}),
+      ...(options.headers || {}),
+    },
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+  const raw = await res.text();
+  let body = null;
+  try {
+    body = JSON.parse(raw);
+  } catch (_) {
+    /* not JSON */
+  }
+  return { status: res.status, body, raw, res };
+}
+
+/**
+ * Log in and return the headers an authenticated client sends.
+ * @param {Object} ctx Started application context
+ * @param {Object} [credentials] {username, password}
+ * @returns {Promise<{headers:Object,csrfToken:String,cookie:String,setCookie:String[]}>}
+ */
+async function login(ctx, credentials = { username: USERNAME, password: PASSWORD }) {
+  const res = await call(ctx, "POST", "/api/auth/login", { body: credentials });
+  assert.equal(res.status, 200, `login should succeed: ${res.raw}`);
+  const setCookie = res.res.headers.getSetCookie();
+  const cookie = setCookie.map((value) => value.split(";")[0]).join("; ");
+  return {
+    setCookie,
+    cookie,
+    csrfToken: res.body.csrfToken,
+    headers: { Cookie: cookie, "X-CSRF-Token": res.body.csrfToken },
+  };
+}
+
+/**
+ * Run a block against a freshly started instance.
+ * @param {Object} env Environment overrides
+ * @param {Object} opts startApp options
+ * @param {Function} fn Receives the started context
+ * @returns {Promise<void>}
+ */
+async function withApp(env, opts, fn) {
+  const ctx = await startApp(env, opts);
+  try {
+    await fn(ctx);
+  } finally {
+    await new Promise((resolve) => ctx.server.close(resolve));
+    ctx.restore();
+  }
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ---------------------------------------------------------------------------
+// 1. The API is closed, and the allowlist is exactly what it says it is
+// ---------------------------------------------------------------------------
+
+test("every mounted API router rejects an anonymous GET with 401", async () => {
+  await withApp({}, { login: false }, async (ctx) => {
+    for (const prefix of API_PREFIXES) {
+      const res = await call(ctx, "GET", prefix);
+      assert.equal(res.status, 401, `${prefix} must be closed, got ${res.status}`);
+      assert.equal(
+        typeof res.body.error,
+        "string",
+        `${prefix} must answer with the central error shape: ${res.raw}`
+      );
+      assert.equal(res.body.error, "Authentication required");
+    }
+  });
+});
+
+test("anonymous state-changing requests and unknown API paths are rejected with 401", async () => {
+  await withApp({}, { login: false }, async (ctx) => {
+    const post = await call(ctx, "POST", "/api/models", {
+      body: { model: { name: "anon", devices: [] } },
+    });
+    assert.equal(post.status, 401, `anonymous POST must be refused: ${post.raw}`);
+
+    const del = await call(ctx, "DELETE", "/api/models/anything.json");
+    assert.equal(del.status, 401, `anonymous DELETE must be refused: ${del.raw}`);
+
+    // An unknown path must not disclose that it is unknown before the caller
+    // has proved who it is.
+    const unknown = await call(ctx, "GET", "/api/not-a-real-endpoint");
+    assert.equal(unknown.status, 401);
+    assert.equal(unknown.body.error, "Authentication required");
+  });
+});
+
+test("the documented allowlist answers anonymously and nothing else does", async () => {
+  await withApp({}, { login: false }, async (ctx) => {
+    const health = await call(ctx, "GET", "/api/health");
+    assert.equal(health.status, 200);
+    assert.deepEqual(health.body, { status: "ok" });
+
+    const session = await call(ctx, "GET", "/api/auth/session");
+    assert.equal(session.status, 200);
+    assert.deepEqual(session.body, { authenticated: false });
+
+    // Reachable, and refused on its merits rather than by the gate.
+    const login401 = await call(ctx, "POST", "/api/auth/login", {
+      body: { username: "nobody", password: "nothing" },
+    });
+    assert.equal(login401.status, 401);
+    assert.equal(login401.body.error, "Invalid credentials");
+
+    // Logging out is an act on a session, so it is deliberately NOT allowlisted.
+    const logout = await call(ctx, "POST", "/api/auth/logout");
+    assert.equal(logout.status, 401, `anonymous logout must be refused: ${logout.raw}`);
+
+    // The dashboard bundle itself stays public so the login page can load.
+    const dashboard = await call(ctx, "GET", "/");
+    assert.equal(dashboard.status, 200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Login
+// ---------------------------------------------------------------------------
+
+test("a correct credential issues a session cookie, a CSRF cookie and a token", async () => {
+  await withApp({}, { login: false }, async (ctx) => {
+    const res = await call(ctx, "POST", "/api/auth/login", {
+      body: { username: USERNAME, password: PASSWORD },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.authenticated, true);
+    assert.equal(res.body.user, USERNAME);
+    assert.equal(typeof res.body.csrfToken, "string");
+    assert.ok(res.body.csrfToken.length >= 32);
+    assert.ok(!res.raw.includes(PASSWORD), "the response must never echo the password");
+
+    const cookies = res.res.headers.getSetCookie();
+    const sid = cookies.find((c) => c.startsWith("tas.sid="));
+    const csrf = cookies.find((c) => c.startsWith("tas.csrf="));
+    assert.ok(sid, `expected a tas.sid cookie, got ${cookies.join(" | ")}`);
+    assert.match(sid, /HttpOnly/i, "the session cookie must not be readable by script");
+    assert.match(sid, /SameSite=Lax/i);
+    assert.ok(!/Secure/i.test(sid), "the default baseline is plain HTTP on loopback");
+    assert.ok(csrf, "expected a tas.csrf cookie");
+    assert.ok(
+      !/HttpOnly/i.test(csrf),
+      "the dashboard has to read the CSRF cookie to echo it back"
+    );
+    assert.match(csrf, /SameSite=Lax/i);
+    assert.ok(!sid.includes(PASSWORD) && !csrf.includes(PASSWORD));
+
+    const cookie = cookies.map((c) => c.split(";")[0]).join("; ");
+    const models = await call(ctx, "GET", "/api/models", { headers: { Cookie: cookie } });
+    assert.equal(models.status, 200, `an authenticated call must be served: ${models.raw}`);
+  });
+});
+
+test("a wrong password and a wrong username are refused identically", async () => {
+  await withApp({}, { login: false }, async (ctx) => {
+    const wrongPassword = await call(ctx, "POST", "/api/auth/login", {
+      body: { username: USERNAME, password: "not-the-password" },
+    });
+    const wrongUsername = await call(ctx, "POST", "/api/auth/login", {
+      body: { username: "not-the-admin", password: PASSWORD },
+    });
+
+    for (const [label, res] of [
+      ["wrong password", wrongPassword],
+      ["wrong username", wrongUsername],
+    ]) {
+      assert.equal(res.status, 401, `${label} must be refused`);
+      assert.equal(res.body.error, "Invalid credentials", `${label} message`);
+      assert.deepEqual(
+        res.res.headers.getSetCookie(),
+        [],
+        `${label} must not issue a session cookie`
+      );
+      assert.ok(!res.raw.includes(PASSWORD), `${label} must not echo the password`);
+    }
+    // Byte-for-byte identical, so the response itself is not a user oracle.
+    assert.equal(wrongPassword.raw, wrongUsername.raw);
+  });
+});
+
+test("SESSION_COOKIE_SECURE marks the cookies Secure", async () => {
+  await withApp({ SESSION_COOKIE_SECURE: "true" }, { login: false }, async (ctx) => {
+    const res = await call(ctx, "POST", "/api/auth/login", {
+      body: { username: USERNAME, password: PASSWORD },
+    });
+    assert.equal(res.status, 200);
+    for (const cookie of res.res.headers.getSetCookie()) {
+      assert.match(cookie, /Secure/i, `expected a Secure attribute on: ${cookie}`);
+    }
+  });
+});
+
+test("a pre-hashed credential is accepted without a plaintext ever being configured", async () => {
+  const { hashPassword } = require("../src/server/auth/passwords");
+  const hash = hashPassword("hashed-only-password");
+  await withApp(
+    { AUTH_ADMIN_PASSWORD: "", AUTH_ADMIN_PASSWORD_HASH: hash, AUTH_ADMIN_USERNAME: "hash-admin" },
+    { login: false },
+    async (ctx) => {
+      const bad = await call(ctx, "POST", "/api/auth/login", {
+        body: { username: "hash-admin", password: "wrong" },
+      });
+      assert.equal(bad.status, 401);
+      const good = await call(ctx, "POST", "/api/auth/login", {
+        body: { username: "hash-admin", password: "hashed-only-password" },
+      });
+      assert.equal(good.status, 200, good.raw);
+      assert.equal(good.body.user, "hash-admin");
+    }
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 3. Session lifetime
+// ---------------------------------------------------------------------------
+
+test("a session expires once it has been idle longer than SESSION_TTL_MS", async () => {
+  await withApp({ SESSION_TTL_MS: "60" }, { login: false }, async (ctx) => {
+    const session = await login(ctx);
+    const before = await call(ctx, "GET", "/api/models", { headers: session.headers });
+    assert.equal(before.status, 200);
+
+    await sleep(200);
+
+    const after = await call(ctx, "GET", "/api/models", { headers: session.headers });
+    assert.equal(after.status, 401, `an idle session must expire: ${after.raw}`);
+    assert.equal(after.body.error, "Authentication required");
+  });
+});
+
+test("a session in continuous use is never logged out spuriously", async () => {
+  await withApp({ SESSION_TTL_MS: "400" }, { login: false }, async (ctx) => {
+    const session = await login(ctx);
+    // Six requests spaced under the idle window, spanning more than twice it:
+    // a non-sliding expiry would fail here.
+    for (let i = 0; i < 6; i += 1) {
+      await sleep(150);
+      const res = await call(ctx, "GET", "/api/models", { headers: session.headers });
+      assert.equal(res.status, 200, `request ${i + 1} must still be served: ${res.raw}`);
+    }
+  });
+});
+
+test("SESSION_ABSOLUTE_TTL_MS caps a session that is being kept alive", async () => {
+  await withApp(
+    { SESSION_TTL_MS: "10000", SESSION_ABSOLUTE_TTL_MS: "300" },
+    { login: false },
+    async (ctx) => {
+      const session = await login(ctx);
+      let sawExpiry = false;
+      for (let i = 0; i < 8; i += 1) {
+        await sleep(80);
+        const res = await call(ctx, "GET", "/api/models", { headers: session.headers });
+        if (res.status === 401) {
+          sawExpiry = true;
+          break;
+        }
+        assert.equal(res.status, 200, res.raw);
+      }
+      assert.ok(sawExpiry, "the absolute cap must end the session despite continuous use");
+    }
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 4. Invalidation
+// ---------------------------------------------------------------------------
+
+test("logging out invalidates the session and replaying its cookie fails", async () => {
+  await withApp({}, { login: false }, async (ctx) => {
+    const session = await login(ctx);
+    assert.equal((await call(ctx, "GET", "/api/models", { headers: session.headers })).status, 200);
+
+    const logout = await call(ctx, "POST", "/api/auth/logout", { headers: session.headers });
+    assert.equal(logout.status, 200, logout.raw);
+    assert.deepEqual(logout.body, { authenticated: false });
+    const cleared = logout.res.headers.getSetCookie();
+    for (const name of ["tas.sid", "tas.csrf"]) {
+      // The last Set-Cookie for a name is the one the browser keeps, and it
+      // must be the expiring one.
+      const last = cleared.filter((c) => c.startsWith(`${name}=`)).pop();
+      assert.ok(last, `logout must send a ${name} cookie: ${cleared.join(" | ")}`);
+      assert.match(last, /Expires=Thu, 01 Jan 1970/, `logout must expire ${name}: ${last}`);
+      assert.match(last, new RegExp(`^${name.replace(".", "\\.")}=;`), `${name} must be emptied: ${last}`);
+    }
+
+    const replay = await call(ctx, "GET", "/api/models", { headers: session.headers });
+    assert.equal(replay.status, 401, "a destroyed session must not be replayable");
+
+    const state = await call(ctx, "GET", "/api/auth/session", {
+      headers: { Cookie: session.cookie },
+    });
+    assert.equal(state.status, 200);
+    assert.deepEqual(state.body, { authenticated: false });
+  });
+});
+
+test("GET /api/auth/session reports a live session without a 401 storm", async () => {
+  await withApp({}, { login: false }, async (ctx) => {
+    const session = await login(ctx);
+    const res = await call(ctx, "GET", "/api/auth/session", {
+      headers: { Cookie: session.cookie },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.authenticated, true);
+    assert.equal(res.body.user, USERNAME);
+    assert.equal(res.body.csrfToken, session.csrfToken);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Configuration failure modes
+// ---------------------------------------------------------------------------
+
+test("with no administrator credential the API is closed and login answers 503", async () => {
+  await withApp(
+    { AUTH_ADMIN_PASSWORD: "", AUTH_ADMIN_PASSWORD_HASH: "" },
+    { login: false },
+    async (ctx) => {
+      const login503 = await call(ctx, "POST", "/api/auth/login", {
+        body: { username: "admin", password: "anything" },
+      });
+      assert.equal(login503.status, 503, login503.raw);
+      assert.equal(login503.body.error, "Authentication is not configured");
+
+      const models = await call(ctx, "GET", "/api/models");
+      assert.equal(models.status, 401, "an unconfigured server must refuse, not open up");
+
+      // The liveness probe still answers, so an orchestrator can still tell the
+      // process apart from a dead one.
+      assert.equal((await call(ctx, "GET", "/api/health")).status, 200);
+    }
+  );
+});
+
+test("a missing SESSION_SECRET boots with a loud warning; a configured one is silent", async () => {
+  const original = console.error;
+  const lines = [];
+  console.error = (line) => lines.push(String(line));
+  try {
+    await withApp({ SESSION_SECRET: "" }, { login: false }, async (ctx) => {
+      assert.equal((await call(ctx, "GET", "/api/health")).status, 200, "it must still boot");
+    });
+    const warning = lines.find((line) => line.includes("SESSION_SECRET is not set"));
+    assert.ok(warning, `expected a SESSION_SECRET warning, got: ${lines.join(" | ")}`);
+    assert.match(warning, /^\[AUTH\]/);
+    assert.match(warning, /ephemeral/);
+    assert.match(warning, /Set SESSION_SECRET in production/);
+
+    lines.length = 0;
+    await withApp({ SESSION_SECRET: "a-configured-secret" }, { login: false }, async (ctx) => {
+      assert.equal((await call(ctx, "GET", "/api/health")).status, 200);
+    });
+    assert.equal(
+      lines.filter((line) => line.includes("SESSION_SECRET")).length,
+      0,
+      `a configured secret must not warn: ${lines.join(" | ")}`
+    );
+    // And the secret itself is never written out.
+    assert.equal(
+      lines.filter((line) => line.includes("a-configured-secret")).length,
+      0,
+      "the secret value must never be logged"
+    );
+  } finally {
+    console.error = original;
+  }
+});
+
+test("failed logins are rate-limited without locking out a legitimate operator", async () => {
+  await withApp(
+    { AUTH_LOGIN_RATE_LIMIT_MAX: "3", AUTH_LOGIN_RATE_LIMIT_WINDOW_MS: "60000" },
+    { login: false },
+    async (ctx) => {
+      for (let i = 0; i < 3; i += 1) {
+        const res = await call(ctx, "POST", "/api/auth/login", {
+          body: { username: USERNAME, password: "wrong" },
+        });
+        assert.equal(res.status, 401, `attempt ${i + 1}: ${res.raw}`);
+      }
+      const limited = await call(ctx, "POST", "/api/auth/login", {
+        body: { username: USERNAME, password: "wrong" },
+      });
+      assert.equal(limited.status, 429, `the guessing run must be cut off: ${limited.raw}`);
+      assert.equal(typeof limited.body.error, "string");
+    }
+  );
+
+  // Successful logins do not count towards the limit, so a working dashboard
+  // is never locked out by its own traffic.
+  await withApp(
+    { AUTH_LOGIN_RATE_LIMIT_MAX: "2", AUTH_LOGIN_RATE_LIMIT_WINDOW_MS: "60000" },
+    { login: false },
+    async (ctx) => {
+      for (let i = 0; i < 6; i += 1) {
+        const res = await call(ctx, "POST", "/api/auth/login", {
+          body: { username: USERNAME, password: PASSWORD },
+        });
+        assert.equal(res.status, 200, `successful login ${i + 1} must not be limited`);
+      }
+    }
+  );
+});

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -447,3 +447,39 @@ test("failed logins are rate-limited without locking out a legitimate operator",
     }
   );
 });
+
+// ---------------------------------------------------------------------------
+// 6. OPTIONS is exempt only when it is a real CORS preflight
+// ---------------------------------------------------------------------------
+
+test("a bare anonymous OPTIONS does not enumerate the routing table", async () => {
+  await withApp({}, { login: false }, async (ctx) => {
+    // Express's built-in OPTIONS responder answers with an `Allow` header built
+    // from the registered handlers, while an unrouted path 404s - so a blanket
+    // exemption tells an anonymous caller which endpoints exist and which
+    // methods they take, which is exactly what the deliberate 401 on unknown
+    // `/api` paths exists to prevent.
+    for (const path of ["/api/models", "/api/devops/status", "/api/simulation"]) {
+      const res = await call(ctx, "OPTIONS", path);
+      assert.equal(res.status, 401, `bare OPTIONS ${path} must be refused: ${res.raw}`);
+      assert.equal(res.body.error, "Authentication required");
+      assert.equal(res.res.headers.get("allow"), null, "no Allow header may leak");
+    }
+  });
+});
+
+test("a genuine CORS preflight is still answered without a session", async () => {
+  await withApp({}, { login: false }, async (ctx) => {
+    // Both headers together are what defines a preflight. Refusing it with a
+    // 401 would make the browser report a CORS failure for a request that would
+    // in fact have been authorised.
+    const res = await call(ctx, "OPTIONS", "/api/models", {
+      headers: {
+        Origin: ctx.base,
+        "Access-Control-Request-Method": "GET",
+      },
+    });
+    assert.notEqual(res.status, 401, `a preflight must not be gated: ${res.raw}`);
+    assert.ok(res.status < 400, `a preflight must be answered: ${res.status} ${res.raw}`);
+  });
+});

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -56,13 +56,18 @@ test('cross-origin mutating requests from unlisted origins are rejected with 403
 test('explicitly allowed origins receive CORS headers and pass', async function () {
   var ctx = await startApp({ CORS_ALLOWED_ORIGINS: 'https://ops.example.com' });
   try {
+    // The API requires a session (issue #9); the CORS decision is what is under
+    // test here, so the request is made as an authenticated client would.
     var res = await fetch(ctx.base + '/api/devops/status', {
-      headers: { Origin: 'https://ops.example.com' }
+      headers: Object.assign({ Origin: 'https://ops.example.com' }, ctx.authHeaders)
     });
     assert.strictEqual(res.status, 200);
     assert.strictEqual(res.headers.get('Access-Control-Allow-Origin'), 'https://ops.example.com');
     assert.strictEqual(res.headers.get('Access-Control-Allow-Methods'), 'GET, POST, DELETE, OPTIONS');
-    assert.strictEqual(res.headers.get('Access-Control-Allow-Headers'), 'Content-Type');
+    // X-CSRF-Token joined the allowed headers with authentication: a
+    // cross-origin dashboard cannot send it otherwise, and every state-changing
+    // request carries it.
+    assert.strictEqual(res.headers.get('Access-Control-Allow-Headers'), 'Content-Type, X-CSRF-Token');
     assert.strictEqual(res.headers.get('Access-Control-Allow-Credentials'), 'true');
   } finally {
     ctx.server.close();
@@ -109,7 +114,7 @@ test('the wildcard origin is never emitted', async function () {
   var ctx = await startApp({ CORS_ALLOWED_ORIGINS: 'https://ops.example.com' });
   try {
     var res = await fetch(ctx.base + '/api/devops/status', {
-      headers: { Origin: 'https://ops.example.com' }
+      headers: Object.assign({ Origin: 'https://ops.example.com' }, ctx.authHeaders)
     });
     assert.notStrictEqual(res.headers.get('Access-Control-Allow-Origin'), '*');
     assert.notStrictEqual(res.headers.get('Access-Control-Allow-Origin'), null);

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -26,6 +26,29 @@ const allowedOrigin = "http://allowed.example";
 const hostileOrigin = "http://evil.example";
 
 /**
+ * Credentials every spawned instance in this directory boots with.
+ *
+ * The API is closed by default (issue #9), so a suite that drives a real
+ * instance needs an account. Passed through the child's environment and used by
+ * `startServer` to log in once, so the existing assertions keep driving the API
+ * the way they always have.
+ */
+const testCredentials = {
+  AUTH_ADMIN_USERNAME: "e2e-admin",
+  AUTH_ADMIN_PASSWORD: "e2e-password",
+  SESSION_SECRET: "e2e-session-secret",
+};
+
+/**
+ * Session headers per running instance, keyed by base URL.
+ *
+ * `request` attaches them by default so every call site written before the API
+ * was closed keeps working unchanged; pass `{ anonymous: true }` to send a
+ * request with no credentials.
+ */
+const sessions = new Map();
+
+/**
  * Make an HTTP request against a running instance.
  * @param {String} baseUrl e.g. http://127.0.0.1:3004
  * @param {String} method  HTTP method
@@ -33,12 +56,14 @@ const hostileOrigin = "http://evil.example";
  * @param {Object} [options]
  * @param {Object} [options.body] JSON body to send
  * @param {Object} [options.headers] Extra request headers (e.g. Origin)
+ * @param {Boolean} [options.anonymous] Send no session credentials
  * @returns {Promise<{status:Number,headers:Object,raw:String,body:Object|null}>}
  */
-function request(baseUrl, method, requestPath, { body, headers = {} } = {}) {
+function request(baseUrl, method, requestPath, { body, headers = {}, anonymous = false } = {}) {
   return new Promise((resolve, reject) => {
     const u = new URL(baseUrl);
     const data = body ? JSON.stringify(body) : null;
+    const auth = anonymous ? {} : sessions.get(baseUrl) || {};
     const req = http.request(
       {
         hostname: u.hostname,
@@ -47,6 +72,7 @@ function request(baseUrl, method, requestPath, { body, headers = {} } = {}) {
         method,
         headers: {
           ...(data ? { "Content-Type": "application/json" } : {}),
+          ...auth,
           ...headers,
         },
       },
@@ -78,6 +104,31 @@ function request(baseUrl, method, requestPath, { body, headers = {} } = {}) {
   });
 }
 
+/**
+ * Log in against a running instance and return the headers every later request
+ * needs: the session cookie and the CSRF token bound to it.
+ * @param {String} baseUrl Instance base URL
+ * @param {Object} credentials {username, password}
+ * @returns {Promise<{cookie:String,csrfToken:String,authHeaders:Object}>}
+ */
+async function logIn(baseUrl, credentials) {
+  const res = await request(baseUrl, "POST", "/api/auth/login", {
+    anonymous: true,
+    body: { username: credentials.username, password: credentials.password },
+  });
+  if (res.status !== 200 || !res.body || !res.body.csrfToken) {
+    throw new Error(`e2e login failed (${res.status}): ${res.raw}`);
+  }
+  const cookie = (res.headers["set-cookie"] || [])
+    .map((value) => value.split(";")[0])
+    .join("; ");
+  return {
+    cookie,
+    csrfToken: res.body.csrfToken,
+    authHeaders: { Cookie: cookie, "X-CSRF-Token": res.body.csrfToken },
+  };
+}
+
 /** Return a currently-free localhost port (small race window, fine for E2E). */
 function getFreePort() {
   return new Promise((resolve, reject) => {
@@ -106,6 +157,7 @@ async function startServer(env = {}) {
       ...process.env,
       SERVER_HOST: "127.0.0.1",
       SERVER_PORT: String(seedPort),
+      ...testCredentials,
       ...env,
     },
     stdio: ["ignore", "pipe", "pipe"],
@@ -135,10 +187,18 @@ async function startServer(env = {}) {
       try {
         const res = await request(baseUrl, "GET", "/");
         if (res.status >= 200 && res.status < 500) {
+          const session = await logIn(baseUrl, {
+            username: env.AUTH_ADMIN_USERNAME || testCredentials.AUTH_ADMIN_USERNAME,
+            password: env.AUTH_ADMIN_PASSWORD || testCredentials.AUTH_ADMIN_PASSWORD,
+          });
+          sessions.set(baseUrl, session.authHeaders);
           return {
             baseUrl,
             port,
             child,
+            cookie: session.cookie,
+            csrfToken: session.csrfToken,
+            authHeaders: session.authHeaders,
             stop: () =>
               new Promise((resolveStop) => {
                 if (child.exitCode !== null) return resolveStop();
@@ -248,6 +308,8 @@ module.exports = {
   hostileOrigin,
   request,
   startServer,
+  logIn,
+  testCredentials,
   unique,
   inModelsDir,
   inRecordersDir,

--- a/test/e2e/limits.test.js
+++ b/test/e2e/limits.test.js
@@ -32,8 +32,10 @@ test("oversized bodies are rejected (413) rather than served", async () => {
 });
 
 test("burst traffic is rate-limited (429) rather than served", async () => {
+  // One over the three requests asserted below: the helper's login (issue #9)
+  // is itself an /api request and consumes a slot before the loop starts.
   const server = await startServer({
-    RATE_LIMIT_MAX: "3",
+    RATE_LIMIT_MAX: "4",
     RATE_LIMIT_WINDOW_MS: String(60 * 1000),
   });
   servers.push(server);

--- a/test/helpers/start-app.js
+++ b/test/helpers/start-app.js
@@ -1,23 +1,111 @@
 var path = require('path');
+var http = require('http');
 
+/**
+ * Credentials every in-process suite boots with.
+ *
+ * The API is closed by default (issue #9), so a suite that boots the real
+ * application needs an account to reach it. These are injected only when the
+ * caller has not said anything about them itself, so a test that wants an
+ * unconfigured server (or a different password) still gets exactly what it
+ * asked for.
+ */
+var TEST_CREDENTIALS = {
+  AUTH_ADMIN_USERNAME: 'test-admin',
+  AUTH_ADMIN_PASSWORD: 'test-password',
+  SESSION_SECRET: 'test-session-secret'
+};
+
+/**
+ * POST /api/auth/login against a listening server and collect the session.
+ * @param {Number} port Bound port
+ * @param {String} host Bound host
+ * @param {Object} credentials {username, password}
+ * @returns {Promise<{cookie: String, csrfToken: String, authHeaders: Object}>}
+ */
+function login(port, host, credentials) {
+  return new Promise(function (resolve, reject) {
+    var payload = JSON.stringify({
+      username: credentials.username,
+      password: credentials.password
+    });
+    var req = http.request(
+      {
+        hostname: host,
+        port: port,
+        path: '/api/auth/login',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(payload)
+        }
+      },
+      function (res) {
+        var raw = '';
+        res.setEncoding('utf8');
+        res.on('data', function (chunk) {
+          raw += chunk;
+        });
+        res.on('end', function () {
+          if (res.statusCode !== 200) {
+            return reject(new Error('test login failed (' + res.statusCode + '): ' + raw));
+          }
+          var body = JSON.parse(raw);
+          var cookie = (res.headers['set-cookie'] || [])
+            .map(function (value) {
+              return value.split(';')[0];
+            })
+            .join('; ');
+          resolve({
+            cookie: cookie,
+            csrfToken: body.csrfToken,
+            authHeaders: { Cookie: cookie, 'X-CSRF-Token': body.csrfToken }
+          });
+        });
+      }
+    );
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+/**
+ * Boot the real application on an ephemeral port.
+ *
+ * @param {Object} [envOverrides] Environment values to apply for this instance
+ * @param {Object} [opts]
+ * @param {String} [opts.host] Address to bind (default 127.0.0.1)
+ * @param {Boolean} [opts.login] Log in after booting (default true). Pass
+ *   `false` for a suite that has to observe the anonymous behaviour.
+ * @returns {Promise<Object>} The started context
+ */
 function startApp(envOverrides, opts) {
   var host = (opts && opts.host) || '127.0.0.1';
+  var shouldLogin = !(opts && opts.login === false);
   var appPath = path.join(__dirname, '..', '..', 'src', 'server', 'app.js');
   var configPath = path.join(__dirname, '..', '..', 'src', 'server', 'config.js');
 
   delete require.cache[require.resolve(configPath)];
   delete require.cache[require.resolve(appPath)];
 
+  var overrides = Object.assign({}, envOverrides);
+  Object.keys(TEST_CREDENTIALS).forEach(function (key) {
+    if (!(key in overrides)) {
+      overrides[key] = TEST_CREDENTIALS[key];
+    }
+  });
+
   var saved = {};
-  Object.keys(envOverrides || {}).forEach(function (key) {
+  Object.keys(overrides).forEach(function (key) {
     saved[key] = process.env[key];
-    process.env[key] = envOverrides[key];
+    process.env[key] = overrides[key];
   });
 
   var app = require(appPath);
 
   function restore() {
-    Object.keys(envOverrides || {}).forEach(function (key) {
+    Object.keys(overrides).forEach(function (key) {
       if (saved[key] === undefined) {
         delete process.env[key];
       } else {
@@ -26,19 +114,41 @@ function startApp(envOverrides, opts) {
     });
   }
 
-  return new Promise(function (resolve) {
+  return new Promise(function (resolve, reject) {
     var server = app.listen(0, host, function () {
       var port = server.address().port;
-      resolve({
+      var ctx = {
         app: app,
         server: server,
         base: 'http://127.0.0.1:' + port,
         baseUrl: 'http://127.0.0.1:' + port,
         port: port,
         restore: restore
-      });
+      };
+      if (!shouldLogin) {
+        return resolve(ctx);
+      }
+      login(port, '127.0.0.1', {
+        username: overrides.AUTH_ADMIN_USERNAME,
+        password: overrides.AUTH_ADMIN_PASSWORD
+      })
+        .then(function (session) {
+          ctx.cookie = session.cookie;
+          ctx.csrfToken = session.csrfToken;
+          ctx.authHeaders = session.authHeaders;
+          // `test/_http.js` attaches these to every request it makes against
+          // this server, so the suites that predate authentication keep working
+          // unchanged rather than each growing a login preamble.
+          server.__authHeaders = session.authHeaders;
+          resolve(ctx);
+        })
+        .catch(function (err) {
+          server.close();
+          restore();
+          reject(err);
+        });
     });
   });
 }
 
-module.exports = { startApp: startApp };
+module.exports = { startApp: startApp, TEST_CREDENTIALS: TEST_CREDENTIALS };

--- a/test/http-status.test.js
+++ b/test/http-status.test.js
@@ -665,8 +665,12 @@ test("the dashboard's request layer honours the status code", async () => {
     path.resolve(__dirname, "../src/client/src/api/index.js"),
     "utf8"
   );
-  const fetches = (apiSource.match(/await fetch\(/g) || []).length;
-  const parsed = (apiSource.match(/await parseResponse\(response\)/g) || []).length;
+  // `apiFetch` is that single funnel on the request side (#9): it is the one
+  // place the session cookie and the CSRF header are attached, so a request
+  // that does not go through it would be missing both as well as the status
+  // check.
+  const fetches = (apiSource.match(/await apiFetch\(/g) || []).length;
+  const parsed = (apiSource.match(/await parseResponse\(response[,)]/g) || []).length;
   assert.ok(fetches > 0, "the request layer must still make requests");
   assert.equal(
     parsed,

--- a/test/http-status.test.js
+++ b/test/http-status.test.js
@@ -669,6 +669,18 @@ test("the dashboard's request layer honours the status code", async () => {
   // place the session cookie and the CSRF header are attached, so a request
   // that does not go through it would be missing both as well as the status
   // check.
+  // No request may bypass that funnel. A raw `await fetch(...)` whose response
+  // never reaches `parseResponse` would skip the CSRF header, the
+  // `credentials: 'same-origin'` cookie, the status check and the 401
+  // session-expiry notification, all at once — and the counters below would not
+  // notice, because it is neither an `apiFetch` nor a `parseResponse`. The only
+  // legitimate raw call is the non-awaited `return fetch(url, ...)` inside
+  // `apiFetch` itself, so the exact expected count is zero.
+  assert.equal(
+    (apiSource.match(/await fetch\(/g) || []).length,
+    0,
+    "every request must go through apiFetch"
+  );
   const fetches = (apiSource.match(/await apiFetch\(/g) || []).length;
   const parsed = (apiSource.match(/await parseResponse\(response[,)]/g) || []).length;
   assert.ok(fetches > 0, "the request layer must still make requests");

--- a/test/rate-limit.test.js
+++ b/test/rate-limit.test.js
@@ -3,15 +3,17 @@ var assert = require('node:assert');
 var { startApp } = require('./helpers/start-app');
 
 test('per-client rate limiting trips with 429 after the configured maximum', async function () {
-  var ctx = await startApp({ RATE_LIMIT_MAX: '3', RATE_LIMIT_WINDOW_MS: '60000' });
+  // One over the three requests asserted below: the helper's login (issue #9)
+  // is itself an /api request and consumes a slot before the loop starts.
+  var ctx = await startApp({ RATE_LIMIT_MAX: '4', RATE_LIMIT_WINDOW_MS: '60000' });
   try {
     var statuses = [];
     for (var i = 0; i < 5; i++) {
-      var res = await fetch(ctx.base + '/api/devops/status');
+      var res = await fetch(ctx.base + '/api/devops/status', { headers: ctx.authHeaders });
       statuses.push(res.status);
     }
     assert.deepStrictEqual(statuses, [200, 200, 200, 429, 429]);
-    var limited = await fetch(ctx.base + '/api/devops/status');
+    var limited = await fetch(ctx.base + '/api/devops/status', { headers: ctx.authHeaders });
     assert.strictEqual(limited.status, 429);
     var body = await limited.json();
     assert.ok(body.error);
@@ -22,7 +24,9 @@ test('per-client rate limiting trips with 429 after the configured maximum', asy
 });
 
 test('rate limiting is keyed per client (by IP)', async function () {
-  var ctx = await startApp({ RATE_LIMIT_MAX: '2', RATE_LIMIT_WINDOW_MS: '60000' }, { host: '::' });
+  // One over the two requests asserted per client: the helper's login (issue #9)
+  // consumes a slot in the 127.0.0.1 bucket before the assertions start.
+  var ctx = await startApp({ RATE_LIMIT_MAX: '3', RATE_LIMIT_WINDOW_MS: '60000' }, { host: '::' });
   try {
     // Bind to the dual-stack wildcard so we can reach the same listener from
     // two distinct source addresses (127.0.0.1 and ::1). Each gets its own
@@ -31,12 +35,12 @@ test('rate limiting is keyed per client (by IP)', async function () {
     var clientA = 'http://127.0.0.1:' + port;
     var clientB = 'http://[::1]:' + port;
 
-    await fetch(clientA + '/api/devops/status');
-    await fetch(clientA + '/api/devops/status');
-    var aLimited = await fetch(clientA + '/api/devops/status');
+    await fetch(clientA + '/api/devops/status', { headers: ctx.authHeaders });
+    await fetch(clientA + '/api/devops/status', { headers: ctx.authHeaders });
+    var aLimited = await fetch(clientA + '/api/devops/status', { headers: ctx.authHeaders });
     assert.strictEqual(aLimited.status, 429);
 
-    var bOk = await fetch(clientB + '/api/devops/status');
+    var bOk = await fetch(clientB + '/api/devops/status', { headers: ctx.authHeaders });
     assert.strictEqual(bOk.status, 200);
   } finally {
     ctx.server.close();
@@ -49,7 +53,7 @@ test('normal dashboard-style usage never trips a default-configured limiter', as
   try {
     var ok = 0;
     for (var i = 0; i < 50; i++) {
-      var res = await fetch(ctx.base + '/api/devops/status');
+      var res = await fetch(ctx.base + '/api/devops/status', { headers: ctx.authHeaders });
       if (res.status === 200) {
         ok++;
       }
@@ -64,8 +68,8 @@ test('normal dashboard-style usage never trips a default-configured limiter', as
 test('the rate limiter returns a JSON error body when tripped', async function () {
   var ctx = await startApp({ RATE_LIMIT_MAX: '1', RATE_LIMIT_WINDOW_MS: '60000' });
   try {
-    await fetch(ctx.base + '/api/devops/status');
-    var res = await fetch(ctx.base + '/api/devops/status');
+    await fetch(ctx.base + '/api/devops/status', { headers: ctx.authHeaders });
+    var res = await fetch(ctx.base + '/api/devops/status', { headers: ctx.authHeaders });
     assert.strictEqual(res.status, 429);
     var ct = res.headers.get('Content-Type') || '';
     assert.ok(ct.indexOf('application/json') !== -1);

--- a/test/server-smoke.test.js
+++ b/test/server-smoke.test.js
@@ -20,11 +20,11 @@ function getFreePort() {
   });
 }
 
-function waitForStatus(url, timeoutMs = 15000) {
+function waitForStatus(url, timeoutMs = 15000, headers = {}) {
   const started = Date.now();
   return new Promise((resolve, reject) => {
     const attempt = () => {
-      const req = http.get(url, (res) => {
+      const req = http.get(url, { headers }, (res) => {
         res.resume();
         resolve(res.statusCode);
       });
@@ -39,6 +39,42 @@ function waitForStatus(url, timeoutMs = 15000) {
   });
 }
 
+/**
+ * Log in against a freshly started instance and return the session cookie.
+ * @param {String} base Instance base URL
+ * @param {Object} credentials {username, password}
+ * @returns {Promise<String>} The `Cookie` header value
+ */
+function login(base, credentials) {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(credentials);
+    const req = http.request(
+      `${base}/api/auth/login`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(payload)
+        }
+      },
+      (res) => {
+        let raw = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => (raw += chunk));
+        res.on('end', () => {
+          if (res.statusCode !== 200) {
+            return reject(new Error(`login failed (${res.statusCode}): ${raw}`));
+          }
+          resolve((res.headers['set-cookie'] || []).map((c) => c.split(';')[0]).join('; '));
+        });
+      }
+    );
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
 test('server starts and serves dashboard + API without a tracked .env file', async () => {
   const port = await getFreePort();
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tas-smoke-'));
@@ -46,13 +82,32 @@ test('server starts and serves dashboard + API without a tracked .env file', asy
   const appFile = path.join(REPO, 'src/server/app.js');
   const child = spawn(process.execPath, [appFile], {
     cwd: tmp,
-    env: { ...process.env, NODE_ENV: 'production' },
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      // The API is closed by default (issue #9), so a smoke test needs an
+      // account - provisioned the way an operator provisions one.
+      AUTH_ADMIN_USERNAME: 'smoke-admin',
+      AUTH_ADMIN_PASSWORD: 'smoke-password',
+      SESSION_SECRET: 'smoke-session-secret'
+    },
     stdio: 'ignore'
   });
   try {
-    const apiStatus = await waitForStatus(`http://127.0.0.1:${port}/api/models`);
+    const base = `http://127.0.0.1:${port}`;
+    // The liveness probe is on the documented public allowlist, so it is what
+    // tells us the process is up before there is a session to use.
+    const healthStatus = await waitForStatus(`${base}/api/health`);
+    assert.strictEqual(healthStatus, 200, 'GET /api/health should return 200');
+
+    const anonymous = await waitForStatus(`${base}/api/models`);
+    assert.strictEqual(anonymous, 401, 'GET /api/models should be closed to anonymous callers');
+
+    const cookie = await login(base, { username: 'smoke-admin', password: 'smoke-password' });
+    const apiStatus = await waitForStatus(`${base}/api/models`, 15000, { Cookie: cookie });
     assert.strictEqual(apiStatus, 200, 'GET /api/models should return 200');
-    const indexStatus = await waitForStatus(`http://127.0.0.1:${port}/`);
+
+    const indexStatus = await waitForStatus(`${base}/`);
     assert.strictEqual(indexStatus, 200, 'GET / should return 200');
   } finally {
     child.kill('SIGKILL');


### PR DESCRIPTION
## Summary

The API had no concept of a user: all twelve routers were mounted anonymously, so anyone who could reach the service had full administrative control over topologies, simulations, test campaigns, stored data and the database connection settings. This adds a single-tenant authentication layer — a bootstrap administrator provisioned from configuration, server-side sessions, CSRF protection on every state-changing request, and opt-in identity delegation for deployments already behind an authenticating proxy.

Closes #9

## Approach

The reporter's recommended shape was followed exactly: a single-tenant login with a bootstrap admin from env vars, plus optional reverse-proxy header trust. There is no multi-user system, no registration flow and no user table.

**Zero new runtime dependencies.** `package.json` and `package-lock.json` are byte-identical. Node's stdlib `crypto` (`scryptSync`, `timingSafeEqual`, `randomBytes`) plus the already-mounted `cookie-parser` and `express-rate-limit` cover everything. This deliberately avoids `bcrypt` (a native addon that would break `npm ci --omit=dev` on the alpine image), the deprecated `csurf`, and `express-session` (whose MemoryStore emits a production warning onto the stderr the e2e suites capture).

### Security design

| Concern | Mechanism |
|---|---|
| Credential at rest | scrypt (`N=16384, r=8, p=1`, 64-byte key, 16-byte random salt), serialised as `scrypt$N$r$p$salt$hash`. `AUTH_ADMIN_PASSWORD_HASH` is preferred; a plaintext `AUTH_ADMIN_PASSWORD` is hashed once at startup and then erased from the config object. Nothing is committed to the repo. |
| Secret comparison | `crypto.timingSafeEqual` behind an equal-length guard, for the password, the username and the CSRF token. The password is verified even when the username does not match, so response time does not reveal which was wrong. |
| Session | Opaque `randomBytes(32)` id in a signed, `HttpOnly`, `SameSite=Lax` cookie (`tas.sid`), backed by an in-process table. Sliding idle TTL (`SESSION_TTL_MS`, 1 h) refreshed per request so a normal dashboard workflow never logs out spuriously, plus a hard absolute cap (`SESSION_ABSOLUTE_TTL_MS`, 12 h). Logout destroys the record server-side; replaying the cookie afterwards 401s. Bounded at `SESSION_MAX_RECORDS` (1000) with least-recently-seen eviction. No timers — a `setInterval` would keep the process alive; expiry is swept lazily. |
| Session secret | `SESSION_SECRET`, with **no hardcoded default**. When unset the server generates an ephemeral per-process secret and warns loudly on stderr. **Justification for warn-rather-than-refuse:** refusing to start would turn a missing hardening knob into an outage for every existing deployment, container healthcheck and smoke test, whereas an ephemeral secret is fail-safe — it can never be guessed, is never shared, and degrades only across restarts, which the warning states explicitly. |
| Cookie `secure` | `SESSION_COOKIE_SECURE`, default `false`, because the documented deployment baseline is plain HTTP on loopback behind a TLS-terminating proxy; hard-coding `secure: true` would break the shipped `docker run`. The README tells operators to set it to `true` whenever TLS reaches the app. |
| CSRF | A token bound to the server-side session (not a bare cookie-vs-header double submit), issued in a JS-readable `tas.csrf` cookie and in the login/session response bodies, required in `X-CSRF-Token` on every `POST`/`DELETE`/`PUT`/`PATCH` under `/api`, compared in constant time. Only `POST /api/auth/login` is exempt. `X-CSRF-Token` was added to `Access-Control-Allow-Headers` so configured cross-origin dashboards keep working. |
| Proxy delegation | Off by default. Requires **both** `AUTH_TRUST_PROXY_HEADER=true` **and** a non-empty `AUTH_TRUSTED_PROXIES`; the flag alone leaves it disabled and warns. The identity header is honoured only when the normalised `req.socket.remoteAddress` (never `X-Forwarded-For`, which is spoofable) is on the trusted list. Delegated requests are **not** exempt from CSRF — a cross-site forged POST reaches the app through the same proxy, which attaches the identity header regardless of cookies, so exempting it would be the hole. |
| Brute force | Failed logins are rate-limited per IP (`AUTH_LOGIN_RATE_LIMIT_MAX`, 10 per 15 min) with `skipSuccessfulRequests`, so legitimate use is never throttled. Every attempt emits one single-argument `console.error` carrying `user=`, `ip=`, `ua=`, `reason=` and an incrementing `failures=` counter from a bounded per-IP tracker. Passwords, session ids, CSRF tokens, cookie values and the session secret are never logged, and usernames/user-agents are stripped of control characters so log lines cannot be forged. |

401/403/429/503 all flow through the existing central `errorHandler` and its `{error, details?}` shape (#11). Every new route declares a schema through the existing `validate(...)` middleware (#10). New configuration follows the `SECURITY_DEFAULTS` + `parseBoolean` conventions from #13 and is documented in both the README table and `env.example`.

### Allowlist

`requireAuth` resolves identity first and the allowlist decides only whether a request *without* identity is refused. The exported, tested `PUBLIC_API_ROUTES` is the single source of truth and matches the README:

- `GET /api/health` (new — nothing operational in the body)
- `POST /api/auth/login`
- `GET /api/auth/session` (answers 200 either way, so the dashboard can discover its state without a 401 storm)

A genuine CORS preflight (`Origin` **and** `Access-Control-Request-Method`) is also exempt; a bare `OPTIONS` is refused with 401 so the routing table cannot be enumerated. The static bundle and the SPA shell stay public by design — the login page has to load — and the README says so explicitly. Everything else under `/api`, including unknown paths, returns 401.

## Changes

| Area | Files |
|---|---|
| Auth primitives | `src/server/auth/passwords.js`, `credentials.js`, `session-store.js` |
| Middleware | `src/server/middleware/auth.js`, `csrf.js`, `errors.js` (+`unauthorized`) |
| Routes | `src/server/routes/auth.js`, `routes/health.js` |
| Wiring / config | `src/server/app.js`, `src/server/config.js` |
| Dashboard | `src/client/src/api/index.js`, `App.js`, `pages/LoginPage.js`, `components/LoginForm/`, `components/SessionExpiredModal/`, `reducers/authReducer.js`, `sagas/authSaga.js`, `actions/index.js`, `components/TSHeader/TSHeader.js` |
| Tests | `test/auth.test.js`, `auth-csrf.test.js`, `auth-proxy.test.js`, `auth-logging.test.js`, `auth-primitives.test.js`, plus helper updates |
| Docs | `README.md`, `env.example` |

40 files, +3.9k/−0.2k. `src/public/` is untouched — see the caveat below.

## ⚠ The served bundle was not rebuilt

`src/public/` is the committed CRA build output, and rebuilding it is deliberately out of scope (#42 tracks removing the committed bundle, #34/#35 track the frontend rebuild). **The dashboard's login flow therefore exists in `src/client/src/` but is not in the bundle the server actually serves.** This is not a working end-to-end login in a browser yet: until the bundle is rebuilt, the served dashboard will receive 401s it cannot render a login form for. The server-side layer is complete and fully tested; the client source is complete and reviewed but dormant. #14 (e2e authenticated journey) remains the verification gate for the browser flow.

## Test Results

`timeout 600 npm test` → **255 tests, 254 pass, 0 fail, 1 skipped** (the skip is the pre-existing `TAS_IMAGE` docker test). Baseline on `master` was 193/192.

**62 new tests** covering, explicitly: anonymous 401 across all thirteen mounted `/api` prefixes and unknown paths; the allowlist working anonymously; successful login and its cookie attributes (`HttpOnly`, `SameSite`, `Secure` on and off); indistinguishable wrong-username and wrong-password responses; the pre-hashed credential path; idle expiry, sliding non-expiry across six spaced requests, and the absolute cap; logout invalidation and cookie clearing, with replay 401; CSRF missing/wrong/cross-session/forged-cross-site/login-exempt/safe-method; proxy delegation in all four configuration states plus the SPA boot sequence, session reuse for cookieless clients, and the delegated-POST-without-token 403; five-attempt brute-force logging with an incrementing counter, no password in the logs, counter reset on success, and log-injection via a newline in the username; the login limiter tripping on failures but never on successes; the missing-`SESSION_SECRET` warning; the unconfigured-credential 503/401; session-store eviction; and the plaintext password being absent from the config object.

The four protected suites keep their original counts and every original assertion: `routes-security` 32, `input-validation` 45, `http-status` 28, `security-headers` 15.

### Pre-existing assertions changed — each justified

1. **`test/cors.test.js`** — expected `Access-Control-Allow-Headers` changed from `'Content-Type'` to `'Content-Type, X-CSRF-Token'`. The CSRF header is now required on every state-changing request; without it in the allow-list a cross-origin dashboard configured via `CORS_ALLOWED_ORIGINS` could not work. The assertion is still exact equality, not loosened.
2. **`test/server-smoke.test.js`** — `GET /api/models → 200` now runs *after* a login, and an anonymous `→ 401` assertion plus a `GET /api/health → 200` readiness check were **added** alongside it. The original 200 assertion is preserved verbatim for the authenticated case; the bar was raised, not lowered.
3. **`test/http-status.test.js`** — the client request-layer scan was retargeted from `await fetch(` to `await apiFetch(` (the funnel was renamed to attach the cookie and CSRF header). Review flagged that this dropped one property, so an assertion that the client source contains **zero** `await fetch(` was added to restore it exactly. Assertion count went 95 → 96; test count unchanged at 28.

Test *inputs* changed with no assertion weakened: `test/rate-limit.test.js` `RATE_LIMIT_MAX` 3→4 and 2→3, and `test/e2e/limits.test.js` 3→4 — the helpers' login is itself an `/api` request and consumes one slot. The asserted status sequences are unchanged.

Everything else stayed green by teaching the helpers to authenticate rather than by relaxing assertions: `test/helpers/start-app.js` injects test credentials and logs in by default (opt out with `{ login: false }`), `test/_http.js` sends the session automatically (opt out with `{ __anonymous: true }`), and `test/e2e/helpers.js` does the same per base URL (`{ anonymous: true }`). The anonymous-rejection tests use those opt-outs, so AC1 is genuinely exercised rather than papered over.

## Decision Record

- **Selected option:** balanced — full server layer, a real client login source, a new `/api/health`, complete docs, and a test-helper login path, accepting that `src/public/` is not rebuilt.
- **Rejected — minimal (server-only, no health endpoint, server-rendered form):** left AC1's health allowlist and AC6 materially unmet and would have shipped a server whose own SPA could not pass CSRF once rebuilt, for almost no saving — the dominant cost (migrating ~70 anonymous test requests) is identical either way.
- **Rejected — comprehensive (login lockout, pluggable session store, CSRF rotation, rebuilt bundle, wholesale test migration):** rebuilding `src/public/` contradicts #42/#34/#35, would produce an unreviewable diff inside a security PR, and would perturb the CSP inline-script hashes that `security-headers.test.js` depends on; the wholesale test migration is exactly the manoeuvre most likely to silently drop an assertion. The valuable pieces (lockout, session persistence) are cleanly separable follow-ups.
- **QA:** two review cycles. Cycle 1 found five issues, all fixed: proxy delegation was invisible to `GET /api/auth/session` so the SPA showed a login form to proxy-authenticated users; delegation minted a new session per cookieless request (unbounded growth); `OPTIONS` was blanket-allowed and leaked the routing table; the retargeted client scan had lost a property; the plaintext password lingered on the config object. One reviewer suggestion was **overridden** — exempting proxy-delegated requests from CSRF — because it would have been a real forgery hole; delegated sessions are cached by identity instead. Cycle 2 verified all five fixes, re-ran the path-normalisation battery and a session-fixation check against a live server, and returned clean. Code-level UI review returned PASS.

## Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|---|---|---|
| 1 | Unauthenticated requests rejected, documented allowlist for health and login | ✅ Met | 401 across all 13 `/api` prefixes and unknown paths; `PUBLIC_API_ROUTES` is a single exported array, asserted for exact contents and mirrored in the README; bare `OPTIONS` also refused |
| 2 | Initial administrator credential provisioned from configuration | ✅ Met | `AUTH_ADMIN_PASSWORD_HASH` (preferred) or `AUTH_ADMIN_PASSWORD`; nothing committed; unconfigured ⇒ 503 on login, 401 everywhere, loud warning |
| 3 | Sessions expire, can be invalidated, survive a normal workflow | ✅ Met | Idle + absolute TTLs, server-side destroy on logout with replay 401, sliding behaviour asserted across six spaced requests |
| 4 | State-changing requests protected against CSRF | ✅ Met | Session-bound token, constant-time compare, forged cross-site POST explicitly modelled and rejected; the dashboard's own token-bearing request is asserted not to be rejected |
| 5 | Deployments behind an authenticating proxy can delegate identity | ✅ Met | Two-key gate (flag + trusted peer list), inert when off, warns when half-configured, spoofing tested in all four states, worked nginx example in the README |
| 6 | Dashboard login flow, session expiry without silently losing unsaved work | ⚠️ Met in source, unverified in a browser | Server endpoints complete and tested. Client renders a non-dismissible modal over the still-mounted view — no redirect, no unmount, unsaved form state survives, and re-login closes the modal in place. **Not exercisable until `src/public/` is rebuilt** (see the caveat above) |
| 7 | Authentication failures logged in enough detail to detect brute force | ✅ Met | One single-argument line per attempt with `user=`, `ip=`, `ua=`, `reason=`, `failures=`; bounded per-IP counter reset on success; inputs sanitised against log forgery; no credentials or tokens logged |

## Follow-ups (not in scope here)

- #14 — e2e authenticated journey and unauthenticated rejection suite (the browser-level verification gate for this change)
- #42 / #34 / #35 — remove the committed bundle and rebuild the frontend, which is what makes criterion 6 live
- Login lockout and session persistence across restarts, deliberately deferred from the comprehensive option
