### PR TITLE
test(e2e): assert the authenticated journey and anonymous rejection (#14)

### DIFF
--- a/test/auth-csrf.test.js
+++ b/test/auth-csrf.test.js
@@ -11,6 +11,7 @@ const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const { startApp, TEST_CREDENTIALS } = require("./helpers/start-app");
 const { isMutatingSafeMethodPath } = require("../src/server/middleware/csrf");
+const { collectRoutes } = require("./helpers/route-table");
 
 const USERNAME = TEST_CREDENTIALS.AUTH_ADMIN_USERNAME;
 const PASSWORD = TEST_CREDENTIALS.AUTH_ADMIN_PASSWORD;
@@ -324,51 +325,6 @@ const READ_ONLY_SAFE_ROUTES = new Set([
   "/test-cases",
   "/test-cases/:testCaseId",
 ]);
-
-/**
- * Recover the path a layer was mounted at from the regexp Express compiled for
- * it. Express keeps no copy of the original string, and reading the live stack
- * is the only way to see what the guard actually sees: a source-text scan would
- * miss a computed path, a `router.route(...)`, a route registered outside
- * `src/server/routes/`, and every extra mount of a router mounted more than
- * once — each of which is a way for an unprotected route to ship green.
- *
- * @param {Object} layer An Express router-stack layer
- * @returns {String} The mount path, or "" for a layer that matches everything
- */
-function layerPath(layer) {
-  if (layer.regexp && layer.regexp.fast_slash) return "";
-  const source = String((layer.regexp && layer.regexp.source) || "");
-  const trimmed = source
-    .replace(/^\^/, "")
-    .replace(/\\\/\?\(\?=\\\/\|\$\)$/, "")
-    .replace(/\\\/\?\$$/, "")
-    .replace(/\$$/, "");
-  return trimmed.replace(/\\(.)/g, "$1");
-}
-
-/**
- * Walk a mounted Express application and yield every route it can reach.
- *
- * @param {Object} stack A router stack
- * @param {String} prefix The path this stack is mounted at
- * @returns {Array<{path: String, methods: Object}>} The routes found
- */
-function collectRoutes(stack, prefix) {
-  const found = [];
-  for (const layer of stack || []) {
-    if (layer.route) {
-      const routePath = layer.route.path === "/" ? "" : layer.route.path;
-      found.push({
-        path: (prefix + routePath).replace(/\/+$/, "") || "/",
-        methods: layer.route.methods || {},
-      });
-    } else if (layer.handle && layer.handle.stack) {
-      found.push(...collectRoutes(layer.handle.stack, prefix + layerPath(layer)));
-    }
-  }
-  return found;
-}
 
 test("every safe-method route under /api is classified read-only or token-bearing", async () => {
   // Boot the real application so the route table is the one the guard sees.

--- a/test/e2e/auth-journey.test.js
+++ b/test/e2e/auth-journey.test.js
@@ -57,8 +57,16 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 /**
  * Text that must never appear in a response body: this checkout's own location
  * (derived, so the check still means something wherever CI puts it), the shape
- * of a raw fs error, and the shape of a stack trace. Mirrors the canary list in
- * `test/http-status.test.js`.
+ * of a raw fs error, and the shape of a stack trace.
+ *
+ * The first eight are the canary list from `test/http-status.test.js`, which
+ * was written against the filesystem-backed routes. This suite additionally
+ * drives the DATABASE-backed ones and asserts the shape of the 503 they answer
+ * with, and a Mongoose connection failure carries its own disclosures the fs
+ * list has no entry for: the connection string (host, port and, where one is
+ * configured, credentials) and the error class names that name the driver. A
+ * regression that echoed the raw connector error into the 503 body would pass
+ * every fs canary, so the database ones are added here.
  */
 const DISCLOSURES = [
   repoRoot,
@@ -69,6 +77,11 @@ const DISCLOSURES = [
   "at Function.",
   "node_modules",
   "node:internal",
+  "mongodb://",
+  "mongodb+srv://",
+  "Mongoose",
+  "MongoServerError",
+  "EAI_AGAIN",
 ];
 
 // ---------------------------------------------------------------------------
@@ -161,9 +174,11 @@ test("the live route table yields a plausible number of API endpoints", () => {
   assert.ok(
     apiRouteCount >= 55,
     `the walk must find the real route table: it currently holds 62 /api routes, ` +
-      `and this walk found only ${apiRouteCount}. A drop of this size means a ` +
-      "router stopped being mounted, not that the API shrank - fix the mount " +
-      "(or, if the removal was deliberate and reviewed, lower this floor)"
+      `and this walk found only ${apiRouteCount}. This floor catches a walker ` +
+      "that stopped finding routes; a router that stopped being MOUNTED is " +
+      "caught by the anchors below, which name it rather than leaving it to be " +
+      "absorbed into a total. If a removal was deliberate and reviewed, lower " +
+      "this floor in the same change"
   );
   assert.ok(
     apiPairs.length >= apiRouteCount,
@@ -319,20 +334,40 @@ test("journey step 4: an authenticated caller is authorised to run a simulation"
   const start = await request(journey.baseUrl, "POST", "/api/simulation/start", {
     body: { modelFileName: journeyFileName },
   });
-  // Authorisation is what this step asserts. Whether the run itself completes
-  // depends on a reachable data storage, which this suite does not provision -
-  // so the accepted statuses are the documented ones the route can answer
-  // without one, and 401/403 is a failure however the run went.
+  // The run has to actually START, not merely be authorised. The route reads
+  // its data-storage configuration off disk and registers the run without
+  // needing a reachable database, so 200 is the outcome here - a 409 (topology
+  // already in use, impossible for a name minted for this run) or a 503 would
+  // mean the journey's central step never happened. An accepted-status set wide
+  // enough to absorb those would let this test stay green with no simulation
+  // ever running, which is exactly the vacuity this suite exists to prevent.
   assert.notEqual(start.status, 401, `an authenticated caller must not be refused: ${start.raw}`);
   assert.notEqual(start.status, 403, `a correctly tokened start must not be refused: ${start.raw}`);
-  assert.ok(
-    [200, 409, 503].includes(start.status),
-    `expected a documented start outcome, got ${start.status}: ${start.raw}`
+  assert.equal(start.status, 200, `the run must start, not merely be authorised: ${start.raw}`);
+
+  // The registry entry is the evidence the run exists; the status code alone is
+  // not, because the route answers before the registry is consulted.
+  const started = Object.values(start.body.simulationStatus || {}).find(
+    (entry) => entry && entry.model === journeyName
   );
+  assert.ok(started, `the run must be registered under ${journeyName}: ${start.raw}`);
+  assert.equal(
+    started.modelFileName,
+    journeyFileName,
+    `the registered run must name the topology it was started from: ${start.raw}`
+  );
+  assert.equal(started.isRunning, true, `the registered run must be running: ${start.raw}`);
 
   const status = await request(journey.baseUrl, "GET", "/api/simulation/status");
   assert.equal(status.status, 200, `the simulation status must be readable: ${status.raw}`);
-  assert.ok(status.body.simulationStatus, `expected a status map: ${status.raw}`);
+  // `assert.ok(status.body.simulationStatus)` would be a tautology: the route
+  // sends an empty object when nothing ran, and `{}` is truthy. The run this
+  // journey started has to be in it.
+  const reported = Object.values(status.body.simulationStatus || {}).find(
+    (entry) => entry && entry.model === journeyName
+  );
+  assert.ok(reported, `the status map must report the run this journey started: ${status.raw}`);
+  assert.equal(reported.isRunning, true, `the run must be reported as running: ${status.raw}`);
 });
 
 test("journey step 5: the report endpoint is authorised, and answers 503 when no database is reachable", async () => {
@@ -369,6 +404,21 @@ test("journey step 6: stopping the simulation is accepted with the CSRF token", 
   });
   assert.notEqual(res.status, 403, `a correctly tokened stop must not be refused: ${res.raw}`);
   assert.equal(res.status, 200, `stopping the run must succeed: ${res.raw}`);
+
+  // 200 on its own proves nothing about stopping: the route answers it whether
+  // or not the topology names a live run. What proves the stop reached the
+  // registry is the run this journey started being marked stopped in the
+  // response the route sends back.
+  const stopped = Object.values(res.body.simulationStatus || {}).find(
+    (entry) => entry && entry.model === journeyName
+  );
+  assert.ok(stopped, `the stopped run must still be reported: ${res.raw}`);
+  assert.equal(stopped.isRunning, false, `the run must be marked stopped: ${res.raw}`);
+  assert.equal(
+    typeof stopped.endTime,
+    "number",
+    `a stopped run must carry the time it stopped: ${res.raw}`
+  );
 });
 
 test("journey step 7: logging out ends the session, and replaying its cookie fails", async () => {

--- a/test/e2e/auth-journey.test.js
+++ b/test/e2e/auth-journey.test.js
@@ -81,7 +81,13 @@ const DISCLOSURES = [
   "mongodb+srv://",
   "Mongoose",
   "MongoServerError",
+  // The two shapes an unreachable connector actually fails with: a name that
+  // will not resolve (`EAI_AGAIN mongodb`) and a port nothing is listening on
+  // (`ECONNREFUSED 127.0.0.1:27017`). Both name the host the server was
+  // configured with, which is the disclosure this list exists to catch.
   "EAI_AGAIN",
+  "ECONNREFUSED",
+  "27017",
 ];
 
 // ---------------------------------------------------------------------------
@@ -147,22 +153,36 @@ after(async () => {
 });
 
 /**
- * Structurally distinct mounts, one per router, that the walk must find.
+ * One anchor per `/api` mount in `src/server/app.js`, that the walk must find.
  *
  * A bare count cannot tell "the API shrank by four endpoints" from "a whole
  * router stopped being mounted" - and an unmounted router is the regression
  * that would make the enumeration below report a clean bill of health for
- * endpoints it never probed. These anchors span the routers independently, so
- * losing any one of them is named rather than absorbed into the total.
+ * endpoints it never probed. Unmounting one router leaves the total well above
+ * any floor worth setting (the largest router here is 8 routes of 62), so the
+ * floor cannot be what catches it.
+ *
+ * Every mount is anchored, deliberately: an anchor set that covered only some
+ * of them would leave the uncovered ones able to disappear silently, which is
+ * the same hole one level down. `app.use('/api', ...)` is mounted three times
+ * for `logs/*`, and each mount is anchored separately, because they are three
+ * independent registrations that can be lost independently.
  */
 const REQUIRED_API_PAIRS = [
   "GET /api/health",
   "POST /api/auth/login",
   "GET /api/models",
+  "GET /api/data-recorders/status",
+  "POST /api/data-storage",
+  "GET /api/logs/data-recorders",
+  "GET /api/logs/simulations",
+  "GET /api/logs/test-campaigns",
+  "GET /api/data-sets",
   "POST /api/test-cases",
+  "GET /api/test-campaigns",
+  "GET /api/events",
   "GET /api/reports",
   "GET /api/simulation/status",
-  "POST /api/data-storage",
   "GET /api/devops",
 ];
 
@@ -175,10 +195,10 @@ test("the live route table yields a plausible number of API endpoints", () => {
     apiRouteCount >= 55,
     `the walk must find the real route table: it currently holds 62 /api routes, ` +
       `and this walk found only ${apiRouteCount}. This floor catches a walker ` +
-      "that stopped finding routes; a router that stopped being MOUNTED is " +
-      "caught by the anchors below, which name it rather than leaving it to be " +
-      "absorbed into a total. If a removal was deliberate and reviewed, lower " +
-      "this floor in the same change"
+      "that stopped finding routes at all; a router that stopped being MOUNTED " +
+      "is caught by the per-mount anchors below, which name it rather than " +
+      "leaving it to be absorbed into a total. If a removal was deliberate and " +
+      "reviewed, lower this floor in the same change"
   );
   assert.ok(
     apiPairs.length >= apiRouteCount,
@@ -341,6 +361,11 @@ test("journey step 4: an authenticated caller is authorised to run a simulation"
   // mean the journey's central step never happened. An accepted-status set wide
   // enough to absorb those would let this test stay green with no simulation
   // ever running, which is exactly the vacuity this suite exists to prevent.
+  //
+  // The run stays running until it is stopped because step 2 creates the
+  // topology with no devices, and a run only returns to OFFLINE when a device
+  // reports finished. Giving step 2 a real device would make the `isRunning`
+  // assertions below timing-dependent.
   assert.notEqual(start.status, 401, `an authenticated caller must not be refused: ${start.raw}`);
   assert.notEqual(start.status, 403, `a correctly tokened start must not be refused: ${start.raw}`);
   assert.equal(start.status, 200, `the run must start, not merely be authorised: ${start.raw}`);

--- a/test/e2e/auth-journey.test.js
+++ b/test/e2e/auth-journey.test.js
@@ -109,10 +109,13 @@ before(async () => {
   );
   apiRouteCount = apiRoutes.length;
   for (const route of apiRoutes) {
-    for (const method of Object.keys(route.methods)) {
-      // Express records `_all` as a pseudo-method for `router.all(...)`; it is
-      // not something a client can send.
-      if (method === "_all") continue;
+    // Express records `_all` as a pseudo-method for `router.all(...)`; it is not
+    // something a client can send. Dropping it would drop the whole route from
+    // the enumeration, so it is expanded into a concrete GET probe instead - a
+    // `router.all(...)` endpoint added later is then still covered.
+    const methods = Object.keys(route.methods).filter((method) => method !== "_all");
+    if (route.methods._all && !methods.includes("get")) methods.push("get");
+    for (const method of methods) {
       apiPairs.push({
         method: method.toUpperCase(),
         // The gate matches a concrete request path at runtime, so the
@@ -367,8 +370,12 @@ test("the journey leaves the topology directory exactly as it found it", async (
 // ---------------------------------------------------------------------------
 
 test("a session that has been idle past SESSION_TTL_MS is refused", async () => {
+  // The TTL has to outlast spawning a process and issuing the first request, or
+  // a loaded runner turns the pre-expiry assertion red for reasons that have
+  // nothing to do with session expiry. The property under test - that an idle
+  // session past its TTL is refused - is unchanged by the wider window.
   const expiring = await startServer({
-    SESSION_TTL_MS: "60",
+    SESSION_TTL_MS: "500",
     RATE_LIMIT_MAX: NO_RATE_LIMIT,
   });
   try {
@@ -378,7 +385,7 @@ test("a session that has been idle past SESSION_TTL_MS is refused", async () => 
     });
     assert.equal(before.status, 200, `the fresh session must be served: ${before.raw}`);
 
-    await sleep(250);
+    await sleep(1200);
 
     const after = await request(expiring.baseUrl, "GET", "/api/models", {
       anonymous: true,
@@ -715,30 +722,64 @@ const PHASE_0_FILES = [
   "test/e2e/helpers.js",
 ];
 
-test("the Phase 0 end-to-end suite is byte-identical to its committed content", (t) => {
-  let head;
-  try {
-    head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot }).toString().trim();
-  } catch (err) {
-    return t.skip(`git is not available here, so the Phase 0 files cannot be compared: ${err.message}`);
+/** The refs this branch may have been cut from, most specific first. */
+const BASE_REFS = ["origin/master", "master", "origin/main", "main"];
+
+/**
+ * The commit this branch forked from.
+ *
+ * Comparing against `HEAD` would be worthless: on any clean checkout - which is
+ * every CI run - the working tree equals HEAD by definition, so the test would
+ * pass whatever the branch did to the Phase 0 files. The fork point is what
+ * makes an edit made *inside this pull request* visible.
+ *
+ * @returns {String|null} The base commit, or null where none can be resolved
+ *   (a shallow clone or a fork with no base ref fetched)
+ */
+const resolveBaseCommit = () => {
+  for (const ref of BASE_REFS) {
+    try {
+      const base = execFileSync("git", ["merge-base", "HEAD", ref], {
+        cwd: repoRoot,
+        stdio: ["ignore", "pipe", "ignore"],
+      })
+        .toString()
+        .trim();
+      if (base.length > 0) return base;
+    } catch (_) {
+      // That ref is absent here; try the next one.
+    }
   }
-  assert.ok(head.length > 0, "HEAD must resolve to a commit");
+  return null;
+};
+
+test("the Phase 0 end-to-end suite is byte-identical to the base branch's content", (t) => {
+  const base = resolveBaseCommit();
+  if (base === null) {
+    // Never a silent pass: the reason the gate could not run is stated.
+    return t.skip(
+      `no base commit could be resolved (tried ${BASE_REFS.join(", ")}), so the ` +
+        "Phase 0 files cannot be compared against the branch point"
+    );
+  }
 
   for (const file of PHASE_0_FILES) {
     let committed;
     try {
-      committed = execFileSync("git", ["show", `HEAD:${file}`], {
+      committed = execFileSync("git", ["show", `${base}:${file}`], {
         cwd: repoRoot,
         maxBuffer: 8 * 1024 * 1024,
       });
     } catch (err) {
-      return t.skip(`${file} is not in HEAD yet, so there is nothing to compare: ${err.message}`);
+      return t.skip(
+        `${file} is not in the base commit ${base} yet, so there is nothing to compare: ${err.message}`
+      );
     }
     const working = fs.readFileSync(path.resolve(repoRoot, file));
     assert.ok(
       Buffer.compare(committed, working) === 0,
-      `${file} differs from its committed content - the Phase 0 gate must not be ` +
-        "weakened to make the Phase 1 suite pass"
+      `${file} differs from its content at the base commit ${base} - the Phase 0 ` +
+        "gate must not be weakened to make the Phase 1 suite pass"
     );
   }
 });

--- a/test/e2e/auth-journey.test.js
+++ b/test/e2e/auth-journey.test.js
@@ -33,7 +33,7 @@ const { test, before, after } = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
-const { execFileSync } = require("node:child_process");
+const { createHash } = require("node:crypto");
 
 const { startApp } = require("../helpers/start-app");
 const { collectRoutes } = require("../helpers/route-table");
@@ -133,18 +133,50 @@ after(async () => {
   }
 });
 
+/**
+ * Structurally distinct mounts, one per router, that the walk must find.
+ *
+ * A bare count cannot tell "the API shrank by four endpoints" from "a whole
+ * router stopped being mounted" - and an unmounted router is the regression
+ * that would make the enumeration below report a clean bill of health for
+ * endpoints it never probed. These anchors span the routers independently, so
+ * losing any one of them is named rather than absorbed into the total.
+ */
+const REQUIRED_API_PAIRS = [
+  "GET /api/health",
+  "POST /api/auth/login",
+  "GET /api/models",
+  "POST /api/test-cases",
+  "GET /api/reports",
+  "GET /api/simulation/status",
+  "POST /api/data-storage",
+  "GET /api/devops",
+];
+
 test("the live route table yields a plausible number of API endpoints", () => {
   // Without this, a walker that stopped finding routes would make every
   // enumeration below pass vacuously - the failure mode that matters most here,
   // because "no endpoint was reachable anonymously" is also what a broken walk
   // reports.
   assert.ok(
-    apiRouteCount > 20,
-    `the walk must find the real route table, found ${apiRouteCount} routes`
+    apiRouteCount >= 55,
+    `the walk must find the real route table: it currently holds 62 /api routes, ` +
+      `and this walk found only ${apiRouteCount}. A drop of this size means a ` +
+      "router stopped being mounted, not that the API shrank - fix the mount " +
+      "(or, if the removal was deliberate and reviewed, lower this floor)"
   );
   assert.ok(
     apiPairs.length >= apiRouteCount,
     `every route must expand to at least one method, got ${apiPairs.length} pairs`
+  );
+
+  const enumerated = apiPairs.map((pair) => `${pair.method} ${pair.path}`);
+  const missing = REQUIRED_API_PAIRS.filter((pair) => !enumerated.includes(pair));
+  assert.deepEqual(
+    missing,
+    [],
+    `these mounts are absent from the walk, so the router carrying each of them ` +
+      `is no longer mounted:\n${missing.join("\n")}`
   );
 });
 
@@ -708,78 +740,65 @@ test("the database-unavailable refusal is a documented 503 that discloses nothin
 // ---------------------------------------------------------------------------
 
 /**
- * The Phase 0 end-to-end suite (issue #8) and the helper it is built on.
+ * The Phase 0 end-to-end suite (issue #8) and the helper it is built on, pinned
+ * by content digest.
  *
- * The actual proof that Phase 0 still passes is the full `npm test` run, which
- * executes these files unchanged alongside this one. What is asserted here is
- * the other half: that they were not quietly edited to make Phase 1 green. A
- * future change to this suite that weakens the earlier gate fails loudly.
+ * The contract these digests express: these four files ARE the Phase 0 gate.
+ * Changing any of them must be a deliberate, reviewed act that also updates the
+ * digest below in the same change - so the edit is visible in the diff and has
+ * to be argued for, rather than slipping through as a line removed from a file
+ * nobody re-read. This test exists so that a future edit to the Phase 1 suite
+ * cannot silently weaken the Phase 0 one.
+ *
+ * The actual proof that Phase 0 still PASSES is the full `npm test` run, which
+ * executes these files unchanged alongside this one. This test asserts only the
+ * other half: that they are still the files that were reviewed.
+ *
+ * Deliberately git-free. An earlier version resolved a fork point with
+ * `git merge-base` and diffed against it, which does not gate in CI: the
+ * workflow checks out at depth 1, so no base ref exists, the comparison cannot
+ * be made, and the run goes green having asserted nothing. A digest of the
+ * bytes on disk needs no repository, no network and no environment, so it
+ * always runs and always means the same thing.
+ *
+ * Line endings are normalised to LF before hashing so a CRLF checkout on
+ * Windows does not report a difference that is not there.
  */
-const PHASE_0_FILES = [
-  "test/e2e/security-suite.test.js",
-  "test/e2e/limits.test.js",
-  "test/e2e/container-nonroot.test.js",
-  "test/e2e/helpers.js",
-];
-
-/** The refs this branch may have been cut from, most specific first. */
-const BASE_REFS = ["origin/master", "master", "origin/main", "main"];
-
-/**
- * The commit this branch forked from.
- *
- * Comparing against `HEAD` would be worthless: on any clean checkout - which is
- * every CI run - the working tree equals HEAD by definition, so the test would
- * pass whatever the branch did to the Phase 0 files. The fork point is what
- * makes an edit made *inside this pull request* visible.
- *
- * @returns {String|null} The base commit, or null where none can be resolved
- *   (a shallow clone or a fork with no base ref fetched)
- */
-const resolveBaseCommit = () => {
-  for (const ref of BASE_REFS) {
-    try {
-      const base = execFileSync("git", ["merge-base", "HEAD", ref], {
-        cwd: repoRoot,
-        stdio: ["ignore", "pipe", "ignore"],
-      })
-        .toString()
-        .trim();
-      if (base.length > 0) return base;
-    } catch (_) {
-      // That ref is absent here; try the next one.
-    }
-  }
-  return null;
+const PHASE_0_DIGESTS = {
+  "test/e2e/security-suite.test.js":
+    "e4771a52ea818735f491515c18589e17feb34bdb8ba22ef8ad7b6fd1ca91c5cb",
+  "test/e2e/limits.test.js": "50843edc10bed9cf6572caa79a3a1642468a9d4acfcaca27ebd50094b3dc5153",
+  "test/e2e/container-nonroot.test.js":
+    "a9da0cd421cc3fcbcf0178a380b26e6c91d7f377a2a01bbd0b18836692bf42d6",
+  "test/e2e/helpers.js": "6e90734d5059a64aa4a9ef7dab6a15a0cb63b315e19208ff76c24374aa0ded69",
 };
 
-test("the Phase 0 end-to-end suite is byte-identical to the base branch's content", (t) => {
-  const base = resolveBaseCommit();
-  if (base === null) {
-    // Never a silent pass: the reason the gate could not run is stated.
-    return t.skip(
-      `no base commit could be resolved (tried ${BASE_REFS.join(", ")}), so the ` +
-        "Phase 0 files cannot be compared against the branch point"
-    );
-  }
+/**
+ * The SHA-256 of a file's content with line endings normalised to LF.
+ * @param {String} file Repo-relative path
+ * @returns {String} Lowercase hex digest
+ */
+const phase0Digest = (file) =>
+  createHash("sha256")
+    .update(fs.readFileSync(path.resolve(repoRoot, file), "utf8").replace(/\r\n/g, "\n"))
+    .digest("hex");
 
-  for (const file of PHASE_0_FILES) {
-    let committed;
-    try {
-      committed = execFileSync("git", ["show", `${base}:${file}`], {
-        cwd: repoRoot,
-        maxBuffer: 8 * 1024 * 1024,
-      });
-    } catch (err) {
-      return t.skip(
-        `${file} is not in the base commit ${base} yet, so there is nothing to compare: ${err.message}`
-      );
+test("the Phase 0 end-to-end suite is byte-identical to its reviewed content", () => {
+  // Collected rather than thrown on the first mismatch: a reviewer has to see
+  // every Phase 0 file that moved, not just the first one in the list.
+  const drifted = [];
+  for (const [file, expected] of Object.entries(PHASE_0_DIGESTS)) {
+    const actual = phase0Digest(file);
+    if (actual !== expected) {
+      drifted.push(`${file}\n  expected sha256 ${expected}\n  actual   sha256 ${actual}`);
     }
-    const working = fs.readFileSync(path.resolve(repoRoot, file));
-    assert.ok(
-      Buffer.compare(committed, working) === 0,
-      `${file} differs from its content at the base commit ${base} - the Phase 0 ` +
-        "gate must not be weakened to make the Phase 1 suite pass"
-    );
   }
+  assert.deepEqual(
+    drifted,
+    [],
+    "the Phase 0 gate must not be weakened to make the Phase 1 suite pass - " +
+      "these files no longer match their reviewed content. If the change is " +
+      "deliberate, update PHASE_0_DIGESTS in this file in the same commit:\n" +
+      drifted.join("\n")
+  );
 });

--- a/test/e2e/auth-journey.test.js
+++ b/test/e2e/auth-journey.test.js
@@ -1,0 +1,744 @@
+/**
+ * End-to-end authenticated journey and unauthenticated rejection suite
+ * (issue #14) — the Phase 1 milestone gate.
+ *
+ * Everything before this file proved a property of a middleware in isolation.
+ * This one drives the assembled application and proves the seven things an
+ * operator actually depends on:
+ *
+ *   1. Every endpoint the running application mounts refuses an anonymous
+ *      caller, and only the three documented public routes answer without a
+ *      session. The route list is read off the live Express table rather than
+ *      written down here, so an endpoint added later is enumerated whether or
+ *      not anybody remembered this file.
+ *   2. The whole authenticated journey — log in, create a topology, run a
+ *      simulation, read the report, log out — succeeds.
+ *   3. A session that has expired, or been invalidated by logging out, is
+ *      refused when its cookie is replayed.
+ *   4. A state-changing request without valid CSRF protection is refused,
+ *      including over the safe methods that mutate.
+ *   5. A structured value supplied where a plain string is declared is rejected
+ *      before it can reach the database.
+ *   6. Every error response carries the right status and nothing but
+ *      `{error, details?}` — no server path, no stack, no raw error.
+ *   7. The Phase 0 end-to-end suite is unchanged, so this file cannot have been
+ *      made to pass by weakening the gate that came before it.
+ *
+ * Sections 2 and 3 drive REAL, separately spawned instances over HTTP (see
+ * `test/e2e/helpers.js`). Sections 1, 4, 5 and 6 boot the same application
+ * in-process, because they need the live route table and a fresh instance per
+ * configuration, and they still issue real HTTP requests against it.
+ */
+const { test, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+
+const { startApp } = require("../helpers/start-app");
+const { collectRoutes } = require("../helpers/route-table");
+const { request: inProcessRequest } = require("../_http");
+const {
+  startServer,
+  request,
+  unique,
+  repoRoot,
+  modelsDir,
+  inModelsDir,
+  removeIfPresent,
+} = require("./helpers");
+const { PUBLIC_API_ROUTES } = require("../../src/server/middleware/auth");
+
+/** A ceiling high enough that enumerating the whole API cannot trip the limiter. */
+const NO_RATE_LIMIT = "100000";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Text that must never appear in a response body: this checkout's own location
+ * (derived, so the check still means something wherever CI puts it), the shape
+ * of a raw fs error, and the shape of a stack trace. Mirrors the canary list in
+ * `test/http-status.test.js`.
+ */
+const DISCLOSURES = [
+  repoRoot,
+  path.dirname(repoRoot),
+  "ENOENT",
+  "no such file",
+  "at Object.",
+  "at Function.",
+  "node_modules",
+  "node:internal",
+];
+
+// ---------------------------------------------------------------------------
+// 1. AC1 - every endpoint refuses an anonymous caller, bar the allowlist
+// ---------------------------------------------------------------------------
+
+/**
+ * The allowlist as the README documents it. Asserted against the one the gate
+ * actually uses, so widening it has to be a deliberate, reviewed change to this
+ * file as well as to `src/server/middleware/auth.js` - which is the point: an
+ * endpoint silently made public is exactly the regression this suite exists to
+ * catch.
+ */
+const DOCUMENTED_PUBLIC_ROUTES = [
+  { method: "GET", path: "/health" },
+  { method: "POST", path: "/auth/login" },
+  { method: "GET", path: "/auth/session" },
+];
+
+/** The same list as `METHOD /api/path` pairs, which is what the walk produces. */
+const documentedPublicPairs = DOCUMENTED_PUBLIC_ROUTES.map(
+  (route) => `${route.method} /api${route.path}`
+).sort();
+
+let anonymousCtx;
+/** Every (method, path) pair the live route table declares under `/api`. */
+let apiPairs = [];
+/** How many distinct routes the walk found, for the vacuity assertion. */
+let apiRouteCount = 0;
+
+before(async () => {
+  anonymousCtx = await startApp({ RATE_LIMIT_MAX: NO_RATE_LIMIT }, { login: false });
+  const router = anonymousCtx.app._router || anonymousCtx.app.router;
+  assert.ok(router && router.stack, "the Express route table must be reachable");
+
+  const apiRoutes = collectRoutes(router.stack, "").filter(
+    (route) => route.path === "/api" || route.path.startsWith("/api/")
+  );
+  apiRouteCount = apiRoutes.length;
+  for (const route of apiRoutes) {
+    for (const method of Object.keys(route.methods)) {
+      // Express records `_all` as a pseudo-method for `router.all(...)`; it is
+      // not something a client can send.
+      if (method === "_all") continue;
+      apiPairs.push({
+        method: method.toUpperCase(),
+        // The gate matches a concrete request path at runtime, so the
+        // placeholders are filled in with a harmless, well-formed value.
+        path: route.path.replace(/:[^/]+/g, "placeholder.json"),
+      });
+    }
+  }
+});
+
+after(async () => {
+  if (anonymousCtx) {
+    await new Promise((resolve) => anonymousCtx.server.close(resolve));
+    anonymousCtx.restore();
+  }
+});
+
+test("the live route table yields a plausible number of API endpoints", () => {
+  // Without this, a walker that stopped finding routes would make every
+  // enumeration below pass vacuously - the failure mode that matters most here,
+  // because "no endpoint was reachable anonymously" is also what a broken walk
+  // reports.
+  assert.ok(
+    apiRouteCount > 20,
+    `the walk must find the real route table, found ${apiRouteCount} routes`
+  );
+  assert.ok(
+    apiPairs.length >= apiRouteCount,
+    `every route must expand to at least one method, got ${apiPairs.length} pairs`
+  );
+});
+
+test("every API endpoint rejects an anonymous request, bar the documented allowlist", async () => {
+  const violations = [];
+  const answeredAnonymously = [];
+  for (const { method, path: requestPath } of apiPairs) {
+    const res = await inProcessRequest(anonymousCtx.server, method, requestPath, undefined, {
+      __anonymous: true,
+    });
+    const rejected = res.status === 401 && res.body && res.body.error === "Authentication required";
+    if (rejected) continue;
+    answeredAnonymously.push(`${method} ${requestPath}`);
+    if (!documentedPublicPairs.includes(`${method} ${requestPath}`)) {
+      violations.push(`${method} ${requestPath} -> ${res.status} ${res.raw}`);
+    }
+  }
+  // Collected rather than thrown on the first one: a reviewer has to see the
+  // whole set of endpoints that opened up, not just the alphabetically first.
+  assert.deepEqual(
+    violations,
+    [],
+    `these API endpoints answered an anonymous caller:\n${violations.join("\n")}`
+  );
+  assert.deepEqual(
+    answeredAnonymously.sort(),
+    documentedPublicPairs,
+    "exactly the documented public routes may answer without a session"
+  );
+});
+
+test("the public allowlist contains exactly the three documented routes", () => {
+  assert.deepEqual(
+    PUBLIC_API_ROUTES,
+    DOCUMENTED_PUBLIC_ROUTES,
+    "widening the anonymous allowlist must be a deliberate, reviewed change to " +
+      "this test as well as to src/server/middleware/auth.js"
+  );
+});
+
+test("the allowlisted routes answer an anonymous caller rather than being gated", async () => {
+  const health = await inProcessRequest(anonymousCtx.server, "GET", "/api/health", undefined, {
+    __anonymous: true,
+  });
+  assert.equal(health.status, 200, `the liveness probe must stay public: ${health.raw}`);
+
+  const session = await inProcessRequest(
+    anonymousCtx.server,
+    "GET",
+    "/api/auth/session",
+    undefined,
+    { __anonymous: true }
+  );
+  assert.equal(session.status, 200, `the session probe must stay public: ${session.raw}`);
+  assert.equal(session.body.authenticated, false, `expected an anonymous verdict: ${session.raw}`);
+
+  // An empty login body reaching validation is the proof that the gate let it
+  // through: a gated request would never have got as far as a schema.
+  const login = await inProcessRequest(anonymousCtx.server, "POST", "/api/auth/login", undefined, {
+    __anonymous: true,
+  });
+  assert.equal(login.status, 400, `login must reach its schema, not the gate: ${login.raw}`);
+  assert.equal(login.body.error, "Validation failed", login.raw);
+});
+
+test("an unknown API path is refused with the same 401, so its absence is not probeable", async () => {
+  // The gate runs ahead of `apiNotFound`, so an anonymous caller cannot tell an
+  // endpoint that exists from one that does not.
+  for (const unknown of ["/api/not-a-real-endpoint", "/api/models/../../secrets", "/api/x/y/z"]) {
+    const res = await inProcessRequest(anonymousCtx.server, "GET", unknown, undefined, {
+      __anonymous: true,
+    });
+    assert.equal(res.status, 401, `${unknown} must answer 401, got ${res.status}: ${res.raw}`);
+    assert.equal(res.body.error, "Authentication required", res.raw);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 2. AC2 - the full authenticated journey against a real running instance
+// ---------------------------------------------------------------------------
+
+let journey;
+/** The topology this journey creates, as `<name>.json`. */
+let journeyName;
+let journeyFileName;
+
+before(async () => {
+  journey = await startServer({ RATE_LIMIT_MAX: NO_RATE_LIMIT });
+  journeyName = unique("journey");
+});
+
+after(async () => {
+  if (journey) await journey.stop();
+  // Nothing must be left behind: the journey writes a real topology file, and a
+  // run writes a real log file (gitignored, but still this suite's litter).
+  if (journeyFileName) removeIfPresent(inModelsDir(journeyFileName));
+  if (journeyName) {
+    const simulationLogs = path.resolve(repoRoot, "src/server/logs/simulations");
+    let entries = [];
+    try {
+      entries = fs.readdirSync(simulationLogs);
+    } catch (_) {
+      entries = []; // absent, which is the expected case on a fresh checkout
+    }
+    for (const entry of entries) {
+      if (entry.startsWith(`${journeyName}_`)) removeIfPresent(path.join(simulationLogs, entry));
+    }
+  }
+});
+
+test("journey step 1: logging in yields a session cookie and a CSRF token", async () => {
+  assert.ok(journey.cookie, "login must return a session cookie");
+  assert.match(journey.cookie, /tas\.sid=/, `expected a session cookie, got ${journey.cookie}`);
+  assert.equal(typeof journey.csrfToken, "string", "login must return a CSRF token");
+  assert.ok(journey.csrfToken.length > 0, "the CSRF token must not be empty");
+
+  const session = await request(journey.baseUrl, "GET", "/api/auth/session");
+  assert.equal(session.status, 200, `the session probe must answer: ${session.raw}`);
+  assert.equal(session.body.authenticated, true, `expected an authenticated verdict: ${session.raw}`);
+});
+
+test("journey step 2: an authenticated caller creates a topology", async () => {
+  const res = await request(journey.baseUrl, "POST", "/api/models", {
+    body: { model: { name: journeyName, devices: [] } },
+  });
+  assert.equal(res.status, 200, `creating a topology must succeed: ${res.raw}`);
+  journeyFileName = res.body && res.body.modelFileName;
+  assert.equal(journeyFileName, `${journeyName}.json`, `unexpected file name: ${res.raw}`);
+  assert.ok(fs.existsSync(inModelsDir(journeyFileName)), "the topology file must exist on disk");
+});
+
+test("journey step 3: the topology reads back with the name it was created under", async () => {
+  const res = await request(journey.baseUrl, "GET", `/api/models/${journeyFileName}`);
+  assert.equal(res.status, 200, `reading the topology back must succeed: ${res.raw}`);
+  assert.equal(res.body.error, null, res.raw);
+  assert.equal(res.body.model.name, journeyName, `the name must round-trip: ${res.raw}`);
+});
+
+test("journey step 4: an authenticated caller is authorised to run a simulation", async () => {
+  const start = await request(journey.baseUrl, "POST", "/api/simulation/start", {
+    body: { modelFileName: journeyFileName },
+  });
+  // Authorisation is what this step asserts. Whether the run itself completes
+  // depends on a reachable data storage, which this suite does not provision -
+  // so the accepted statuses are the documented ones the route can answer
+  // without one, and 401/403 is a failure however the run went.
+  assert.notEqual(start.status, 401, `an authenticated caller must not be refused: ${start.raw}`);
+  assert.notEqual(start.status, 403, `a correctly tokened start must not be refused: ${start.raw}`);
+  assert.ok(
+    [200, 409, 503].includes(start.status),
+    `expected a documented start outcome, got ${start.status}: ${start.raw}`
+  );
+
+  const status = await request(journey.baseUrl, "GET", "/api/simulation/status");
+  assert.equal(status.status, 200, `the simulation status must be readable: ${status.raw}`);
+  assert.ok(status.body.simulationStatus, `expected a status map: ${status.raw}`);
+});
+
+test("journey step 5: the report endpoint is authorised, and answers 503 when no database is reachable", async () => {
+  // CONSTRAINT: `GET /api/reports` is the one journey step that genuinely needs
+  // MongoDB - it sits behind `dbConnector`. This suite provisions no database,
+  // so in CI the DB-backed body is NOT exercised: what is asserted then is the
+  // documented unavailability contract (503 `Database is unavailable`), which
+  // is a real property of the API, not a stand-in for the 200. Where a database
+  // IS reachable the same test asserts the 200 and its `reports` array.
+  const res = await request(
+    journey.baseUrl,
+    "GET",
+    `/api/reports?topologyFileName=${encodeURIComponent(journeyFileName)}`
+  );
+  assert.notEqual(res.status, 401, `an authenticated caller must not be refused: ${res.raw}`);
+  assert.notEqual(res.status, 403, `a safe-method read must not need a token: ${res.raw}`);
+  assert.ok(
+    [200, 503].includes(res.status),
+    `expected 200 or the documented 503, got ${res.status}: ${res.raw}`
+  );
+  if (res.status === 200) {
+    assert.ok(Array.isArray(res.body.reports), `expected a reports array: ${res.raw}`);
+  } else {
+    assert.equal(res.body.error, "Database is unavailable", res.raw);
+  }
+});
+
+test("journey step 6: stopping the simulation is accepted with the CSRF token", async () => {
+  // `GET /api/simulation/stop/:fileName` mutates over a safe method, so the
+  // guard demands the token here as it would on a POST.
+  const res = await request(journey.baseUrl, "GET", `/api/simulation/stop/${journeyFileName}`, {
+    anonymous: true,
+    headers: { Cookie: journey.cookie, "X-CSRF-Token": journey.csrfToken },
+  });
+  assert.notEqual(res.status, 403, `a correctly tokened stop must not be refused: ${res.raw}`);
+  assert.equal(res.status, 200, `stopping the run must succeed: ${res.raw}`);
+});
+
+test("journey step 7: logging out ends the session, and replaying its cookie fails", async () => {
+  // The topology is removed first, while the session that created it is still
+  // valid - the checkout must be left exactly as it was found.
+  const removed = await request(journey.baseUrl, "DELETE", `/api/models/${journeyFileName}`);
+  assert.equal(removed.status, 200, `deleting the topology must succeed: ${removed.raw}`);
+  assert.ok(!fs.existsSync(inModelsDir(journeyFileName)), "the topology file must be gone");
+
+  const logout = await request(journey.baseUrl, "POST", "/api/auth/logout");
+  assert.equal(logout.status, 200, `logging out must succeed: ${logout.raw}`);
+  assert.equal(logout.body.authenticated, false, logout.raw);
+
+  const replayed = await request(journey.baseUrl, "GET", "/api/models", {
+    anonymous: true,
+    headers: { Cookie: journey.cookie },
+  });
+  assert.equal(replayed.status, 401, `a destroyed session must not be usable: ${replayed.raw}`);
+  assert.equal(replayed.body.error, "Authentication required", replayed.raw);
+});
+
+test("the journey leaves the topology directory exactly as it found it", async () => {
+  assert.ok(
+    !fs.readdirSync(modelsDir).some((entry) => entry.startsWith(journeyName)),
+    "no artifact of the journey may survive it"
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 3. AC3 - an expired or invalidated session is refused
+// ---------------------------------------------------------------------------
+
+test("a session that has been idle past SESSION_TTL_MS is refused", async () => {
+  const expiring = await startServer({
+    SESSION_TTL_MS: "60",
+    RATE_LIMIT_MAX: NO_RATE_LIMIT,
+  });
+  try {
+    const before = await request(expiring.baseUrl, "GET", "/api/models", {
+      anonymous: true,
+      headers: { Cookie: expiring.cookie },
+    });
+    assert.equal(before.status, 200, `the fresh session must be served: ${before.raw}`);
+
+    await sleep(250);
+
+    const after = await request(expiring.baseUrl, "GET", "/api/models", {
+      anonymous: true,
+      headers: { Cookie: expiring.cookie },
+    });
+    assert.equal(after.status, 401, `an idle session must expire: ${after.raw}`);
+    assert.equal(after.body.error, "Authentication required", after.raw);
+  } finally {
+    await expiring.stop();
+  }
+});
+
+test("a session invalidated by logging out is refused when its cookie is replayed", async () => {
+  // The same property as journey step 7, asserted here against a dedicated
+  // instance so the invalidation half stands on its own if the journey changes.
+  const ctx = await startApp({ RATE_LIMIT_MAX: NO_RATE_LIMIT });
+  try {
+    const before = await inProcessRequest(ctx.server, "GET", "/api/models");
+    assert.equal(before.status, 200, `the live session must be served: ${before.raw}`);
+
+    const logout = await inProcessRequest(ctx.server, "POST", "/api/auth/logout");
+    assert.equal(logout.status, 200, `logging out must succeed: ${logout.raw}`);
+
+    const replayed = await inProcessRequest(ctx.server, "GET", "/api/models", undefined, {
+      __anonymous: true,
+      Cookie: ctx.cookie,
+    });
+    assert.equal(replayed.status, 401, `a destroyed session must not be usable: ${replayed.raw}`);
+    assert.equal(replayed.body.error, "Authentication required", replayed.raw);
+  } finally {
+    await new Promise((resolve) => ctx.server.close(resolve));
+    ctx.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 4. AC4 - a state-changing request without valid CSRF protection is refused
+// ---------------------------------------------------------------------------
+
+/**
+ * A state-changing request whose handler writes nothing to disk: it sits behind
+ * the database connector, so even a regression that let it past the guard could
+ * only reach a 503 here. That keeps these assertions about the guard alone.
+ */
+const csrfProbeBody = { testCase: { id: "csrf-probe", name: "csrf probe" } };
+
+let csrfCtx;
+
+before(async () => {
+  csrfCtx = await startApp({ RATE_LIMIT_MAX: NO_RATE_LIMIT });
+});
+
+after(async () => {
+  if (csrfCtx) {
+    await new Promise((resolve) => csrfCtx.server.close(resolve));
+    csrfCtx.restore();
+  }
+});
+
+test("a state-changing request with a session but no CSRF token is refused", async () => {
+  const res = await inProcessRequest(csrfCtx.server, "POST", "/api/test-cases", csrfProbeBody, {
+    __anonymous: true,
+    Cookie: csrfCtx.cookie,
+  });
+  assert.equal(res.status, 403, `expected a CSRF rejection, got ${res.status}: ${res.raw}`);
+  assert.equal(res.body.error, "Invalid CSRF token", res.raw);
+});
+
+test("a state-changing request with the wrong CSRF token is refused", async () => {
+  for (const token of ["not-the-token", "", `${csrfCtx.csrfToken}x`, csrfCtx.csrfToken.slice(1)]) {
+    const res = await inProcessRequest(csrfCtx.server, "POST", "/api/test-cases", csrfProbeBody, {
+      __anonymous: true,
+      Cookie: csrfCtx.cookie,
+      "X-CSRF-Token": token,
+    });
+    assert.equal(res.status, 403, `token ${JSON.stringify(token)}: ${res.raw}`);
+    assert.equal(res.body.error, "Invalid CSRF token", res.raw);
+  }
+});
+
+test("a mutating safe-method route without the CSRF token is refused too", async () => {
+  // The method-based skip is only sound while GET really is safe. These two
+  // change state over GET, so the skip must not reach them - otherwise a link on
+  // any page an operator visits while logged in would trigger them.
+  for (const mutatingGet of ["/api/simulation/stop/placeholder.json", "/api/devops/start"]) {
+    const res = await inProcessRequest(csrfCtx.server, "GET", mutatingGet, undefined, {
+      __anonymous: true,
+      Cookie: csrfCtx.cookie,
+    });
+    assert.equal(res.status, 403, `${mutatingGet} must demand a token: ${res.status} ${res.raw}`);
+    assert.equal(res.body.error, "Invalid CSRF token", res.raw);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 5. AC5 - a structured value where a plain string is declared is rejected
+// ---------------------------------------------------------------------------
+
+/** Assert the standard machine-readable validation failure shape. */
+const assertValidationError = (res, context) => {
+  assert.equal(res.status, 400, `expected 400 for ${context}, got ${res.status}: ${res.raw}`);
+  assert.equal(res.body.error, "Validation failed", `unexpected error text: ${res.raw}`);
+  assert.ok(Array.isArray(res.body.details), `details must be an array: ${res.raw}`);
+  assert.ok(res.body.details.length > 0, `details must name a field: ${res.raw}`);
+};
+
+test("an object supplied where a string is declared is rejected before any handler runs", async () => {
+  const res = await inProcessRequest(csrfCtx.server, "POST", "/api/models", {
+    model: { name: { $ne: null }, devices: [] },
+  });
+  assertValidationError(res, "an operator document in place of a topology name");
+  assert.deepEqual(
+    fs.readdirSync(modelsDir).filter((entry) => entry.includes("$ne")),
+    [],
+    "a rejected name must never reach the filesystem"
+  );
+});
+
+test("an array supplied where a string is declared is rejected", async () => {
+  const res = await inProcessRequest(csrfCtx.server, "POST", "/api/models", {
+    model: { name: ["topology"], devices: [] },
+  });
+  assertValidationError(res, "an array in place of a topology name");
+});
+
+/**
+ * The three requests in this file that reach the database layer, issued
+ * together and answered once.
+ *
+ * Each of them waits out the full connection timeout where no database is
+ * provisioned (the CI case), so issuing them one test at a time costs that
+ * timeout three times over for no extra coverage. They are independent - two
+ * different instances, no shared state - so they are fired concurrently on
+ * first use and each test below asserts its own answer.
+ */
+let databaseProbes = null;
+
+/**
+ * @returns {Promise<{operatorQuery: Object, validQuery: Object, bareQuery: Object}>}
+ */
+const probeDatabaseBackedEndpoints = () => {
+  if (!databaseProbes) {
+    databaseProbes = Promise.all([
+      inProcessRequest(csrfCtx.server, "GET", "/api/reports?topologyFileName[$ne]=x"),
+      inProcessRequest(csrfCtx.server, "GET", "/api/reports?topologyFileName=well-formed.json"),
+      inProcessRequest(errorCtx.server, "GET", "/api/reports"),
+    ]).then(([operatorQuery, validQuery, bareQuery]) => ({
+      operatorQuery,
+      validQuery,
+      bareQuery,
+    }));
+  }
+  return databaseProbes;
+};
+
+test("a Mongo operator cannot be expressed in the query string at all", async () => {
+  // With `query parser: simple` the bracket notation is not parsed, so
+  // `?topologyFileName[$ne]=x` arrives as the literal key
+  // `topologyFileName[$ne]` - which no schema declares, so it is stripped. The
+  // value therefore cannot reach the database as an operator document by any
+  // route: the request is either served (no filter) or refused by the connector.
+  const { operatorQuery: res } = await probeDatabaseBackedEndpoints();
+  assert.notEqual(res.status, 500, `an operator probe must not break the server: ${res.raw}`);
+  assert.ok(
+    [200, 503].includes(res.status),
+    `expected the operator key to be stripped, got ${res.status}: ${res.raw}`
+  );
+  assert.ok(!res.raw.includes("$ne"), `the operator must not be echoed back: ${res.raw}`);
+});
+
+test("validation short-circuits ahead of the database layer", async () => {
+  // The proof that the 400 arrives BEFORE anything is asked of the database:
+  // the same endpoint, with a well-formed query, gets as far as `dbConnector`
+  // and answers 503 (or 200 where a database is reachable). With an
+  // over-long - i.e. schema-violating - value it answers 400 instead, so the
+  // schema decided the outcome without the connector ever being consulted.
+  const { validQuery: valid } = await probeDatabaseBackedEndpoints();
+  assert.ok(
+    [200, 503].includes(valid.status),
+    `a well-formed query must reach the database layer, got ${valid.status}: ${valid.raw}`
+  );
+  if (valid.status === 503) {
+    assert.equal(valid.body.error, "Database is unavailable", valid.raw);
+  }
+
+  const malformed = await inProcessRequest(
+    csrfCtx.server,
+    "GET",
+    `/api/reports?topologyFileName=${"x".repeat(2000)}`
+  );
+  assertValidationError(malformed, "a query value past its declared maximum");
+});
+
+// ---------------------------------------------------------------------------
+// 6. AC6 - every error response carries the right status and nothing else
+// ---------------------------------------------------------------------------
+
+/**
+ * Every key in a parsed body, at every depth - so the disclosure checks below
+ * walk the whole response rather than only its top-level `error`.
+ * @param {*} value Parsed JSON body
+ * @returns {String[]} Every key name found
+ */
+const allKeys = (value) => {
+  if (Array.isArray(value)) return value.flatMap(allKeys);
+  if (value && typeof value === "object") {
+    return Object.keys(value).concat(Object.values(value).flatMap(allKeys));
+  }
+  return [];
+};
+
+/** Assert an error response is the one shape the API has, and carries nothing more. */
+const assertErrorShape = (res, status, context) => {
+  assert.equal(res.status, status, `expected ${status} for ${context}, got ${res.status}: ${res.raw}`);
+  assert.ok(res.body, `${context} must answer with JSON: ${res.raw}`);
+  assert.equal(typeof res.body.error, "string", `${context} must carry a string error: ${res.raw}`);
+  assert.ok(res.body.error.length > 0, `${context} must carry a message: ${res.raw}`);
+  assert.deepEqual(
+    Object.keys(res.body).filter((key) => key !== "error" && key !== "details"),
+    [],
+    `an error body carries nothing but error and details: ${res.raw}`
+  );
+  assert.ok(
+    !allKeys(res.body).includes("stack"),
+    `${context} must not carry a stack: ${res.raw}`
+  );
+  for (const disclosure of DISCLOSURES) {
+    assert.ok(
+      !res.raw.includes(disclosure),
+      `${context} must not disclose ${disclosure}: ${res.raw}`
+    );
+  }
+};
+
+let errorCtx;
+
+before(async () => {
+  // A small body limit so the 413 costs a kilobyte rather than a megabyte.
+  errorCtx = await startApp({ RATE_LIMIT_MAX: NO_RATE_LIMIT, BODY_LIMIT: "1kb" });
+});
+
+after(async () => {
+  if (errorCtx) {
+    await new Promise((resolve) => errorCtx.server.close(resolve));
+    errorCtx.restore();
+  }
+});
+
+test("a 400, a 401, a 403 and a 404 each carry the right status and no server detail", async () => {
+  const validation = await inProcessRequest(errorCtx.server, "POST", "/api/models", {
+    model: { name: { $ne: null }, devices: [] },
+  });
+  assertErrorShape(validation, 400, "a validation failure");
+  assert.equal(validation.body.error, "Validation failed", validation.raw);
+
+  const anonymous = await inProcessRequest(errorCtx.server, "GET", "/api/models", undefined, {
+    __anonymous: true,
+  });
+  assertErrorShape(anonymous, 401, "an anonymous request");
+  assert.equal(anonymous.body.error, "Authentication required", anonymous.raw);
+
+  const forged = await inProcessRequest(errorCtx.server, "POST", "/api/test-cases", csrfProbeBody, {
+    __anonymous: true,
+    Cookie: errorCtx.cookie,
+  });
+  assertErrorShape(forged, 403, "a request without CSRF protection");
+  assert.equal(forged.body.error, "Invalid CSRF token", forged.raw);
+
+  const unknown = await inProcessRequest(errorCtx.server, "GET", "/api/not-a-real-endpoint");
+  assertErrorShape(unknown, 404, "an authenticated request for an unknown API path");
+  assert.equal(unknown.body.error, "Not found", unknown.raw);
+  assert.ok(
+    !unknown.raw.includes("<!DOCTYPE"),
+    `an unknown API path must not be answered with the dashboard: ${unknown.raw}`
+  );
+
+  const missing = await inProcessRequest(
+    errorCtx.server,
+    "GET",
+    `/api/models/${unique("absent")}.json`
+  );
+  assertErrorShape(missing, 404, "a topology that is not there");
+});
+
+test("an oversized body and an unsupported encoding are refused without server detail", async () => {
+  const oversized = await inProcessRequest(errorCtx.server, "POST", "/api/models", {
+    model: { name: "x".repeat(4096), devices: [] },
+  });
+  assertErrorShape(oversized, 413, "a body past the configured limit");
+  assert.equal(oversized.body.error, "Request entity too large", oversized.raw);
+
+  const encoded = await inProcessRequest(
+    errorCtx.server,
+    "POST",
+    "/api/models",
+    { model: { name: "encoded", devices: [] } },
+    { "Content-Encoding": "not-an-encoding" }
+  );
+  assertErrorShape(encoded, 415, "an unsupported content encoding");
+  assert.equal(encoded.body.error, "Unsupported content encoding", encoded.raw);
+});
+
+test("the database-unavailable refusal is a documented 503 that discloses nothing", async () => {
+  // Only meaningful where no database is reachable, which is the CI case; where
+  // one IS reachable the endpoint answers 200 and there is no error body to
+  // inspect, so the assertion is on whichever of the two arrives.
+  const { bareQuery: res } = await probeDatabaseBackedEndpoints();
+  assert.ok(
+    [200, 503].includes(res.status),
+    `expected 200 or the documented 503, got ${res.status}: ${res.raw}`
+  );
+  if (res.status === 503) {
+    assertErrorShape(res, 503, "an unreachable database");
+    assert.equal(res.body.error, "Database is unavailable", res.raw);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 7. AC7 - the Phase 0 suite is unchanged
+// ---------------------------------------------------------------------------
+
+/**
+ * The Phase 0 end-to-end suite (issue #8) and the helper it is built on.
+ *
+ * The actual proof that Phase 0 still passes is the full `npm test` run, which
+ * executes these files unchanged alongside this one. What is asserted here is
+ * the other half: that they were not quietly edited to make Phase 1 green. A
+ * future change to this suite that weakens the earlier gate fails loudly.
+ */
+const PHASE_0_FILES = [
+  "test/e2e/security-suite.test.js",
+  "test/e2e/limits.test.js",
+  "test/e2e/container-nonroot.test.js",
+  "test/e2e/helpers.js",
+];
+
+test("the Phase 0 end-to-end suite is byte-identical to its committed content", (t) => {
+  let head;
+  try {
+    head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot }).toString().trim();
+  } catch (err) {
+    return t.skip(`git is not available here, so the Phase 0 files cannot be compared: ${err.message}`);
+  }
+  assert.ok(head.length > 0, "HEAD must resolve to a commit");
+
+  for (const file of PHASE_0_FILES) {
+    let committed;
+    try {
+      committed = execFileSync("git", ["show", `HEAD:${file}`], {
+        cwd: repoRoot,
+        maxBuffer: 8 * 1024 * 1024,
+      });
+    } catch (err) {
+      return t.skip(`${file} is not in HEAD yet, so there is nothing to compare: ${err.message}`);
+    }
+    const working = fs.readFileSync(path.resolve(repoRoot, file));
+    assert.ok(
+      Buffer.compare(committed, working) === 0,
+      `${file} differs from its committed content - the Phase 0 gate must not be ` +
+        "weakened to make the Phase 1 suite pass"
+    );
+  }
+});

--- a/test/helpers/route-table.js
+++ b/test/helpers/route-table.js
@@ -1,0 +1,57 @@
+/**
+ * The live Express route-table walker, shared by the suites that have to see
+ * the routes the running application actually mounts.
+ *
+ * Kept in one place because more than one suite depends on it: the CSRF
+ * classification guard (`test/auth-csrf.test.js`) and the anonymous-rejection
+ * enumeration (`test/e2e/auth-journey.test.js`, issue #14). Two copies of a
+ * walker are two chances for one of them to quietly stop finding routes, and a
+ * walker that finds nothing makes every test built on it pass vacuously.
+ */
+
+/**
+ * Recover the path a layer was mounted at from the regexp Express compiled for
+ * it. Express keeps no copy of the original string, and reading the live stack
+ * is the only way to see what the guard actually sees: a source-text scan would
+ * miss a computed path, a `router.route(...)`, a route registered outside
+ * `src/server/routes/`, and every extra mount of a router mounted more than
+ * once — each of which is a way for an unprotected route to ship green.
+ *
+ * @param {Object} layer An Express router-stack layer
+ * @returns {String} The mount path, or "" for a layer that matches everything
+ */
+function layerPath(layer) {
+  if (layer.regexp && layer.regexp.fast_slash) return "";
+  const source = String((layer.regexp && layer.regexp.source) || "");
+  const trimmed = source
+    .replace(/^\^/, "")
+    .replace(/\\\/\?\(\?=\\\/\|\$\)$/, "")
+    .replace(/\\\/\?\$$/, "")
+    .replace(/\$$/, "");
+  return trimmed.replace(/\\(.)/g, "$1");
+}
+
+/**
+ * Walk a mounted Express application and yield every route it can reach.
+ *
+ * @param {Object} stack A router stack
+ * @param {String} prefix The path this stack is mounted at
+ * @returns {Array<{path: String, methods: Object}>} The routes found
+ */
+function collectRoutes(stack, prefix) {
+  const found = [];
+  for (const layer of stack || []) {
+    if (layer.route) {
+      const routePath = layer.route.path === "/" ? "" : layer.route.path;
+      found.push({
+        path: (prefix + routePath).replace(/\/+$/, "") || "/",
+        methods: layer.route.methods || {},
+      });
+    } else if (layer.handle && layer.handle.stack) {
+      found.push(...collectRoutes(layer.handle.stack, prefix + layerPath(layer)));
+    }
+  }
+  return found;
+}
+
+module.exports = { layerPath, collectRoutes };


### PR DESCRIPTION
Closes #14

## Summary

The Phase 1 milestone gate. An API-level end-to-end suite, driven over HTTP against a real running instance, proving that the API is closed to anonymous callers, open to authenticated ones, and that malformed input is rejected with the correct status before it reaches any handler.

No production code changed — this PR is tests only. It verifies the five issues that landed earlier in the milestone (#9 auth/CSRF, #10 request validation, #11 status codes, #13 CSP/helmet) rather than altering them.

## Approach

The load-bearing design decision is that **criterion 1 is structural, not a hand-written list**. The suite walks the *live* Express route table at runtime — the same technique `test/http-status.test.js` and the #9 CSRF guard already use — expands every route into its declared methods, and issues a real anonymous HTTP request for each. A newly added endpoint is therefore covered automatically and cannot silently ship unprotected. A hardcoded list of paths would have rotted on the next router.

To make that walker reusable, `layerPath()` / `collectRoutes()` were lifted verbatim out of `test/auth-csrf.test.js` into `test/helpers/route-table.js`; that file now imports them. The move is strictly behaviour-preserving — no assertion, test name, or other line in `auth-csrf.test.js` was touched, and it still passes 13/13.

The suite extends the existing `test/e2e/` layout and reuses the existing harnesses (`test/helpers/start-app.js` for the in-process route walk, `test/e2e/helpers.js` for the real child-process journey, `test/_http.js` for anonymous probes) rather than inventing a parallel structure.

This is an **API-level** suite, not a browser one: the committed client bundle in `src/public/` has not been rebuilt, so the served dashboard cannot log in (tracked separately as #65). The journey is driven over HTTP.

## Decision Record

**Selected option — balanced.** Promote the route-table walker into a shared helper, then add one new e2e suite covering all seven criteria, organised into seven numbered sections so a reviewer can map tests to criteria 1:1.

**Options rejected**

| Option | Why not |
| --- | --- |
| Minimal — `require()` the walker straight out of `test/auth-csrf.test.js` | Requiring a `*.test.js` module for its exports risks double-registering that file's own tests under `node:test`, and leaves the reusable walker permanently misplaced. |
| Comprehensive — split across four themed files plus a new shared rate-limit helper | Exceeds the issue's M effort band for marginal benefit; all seven criteria are already traceable in one organised file, and four files means four copies of the server-startup boilerplate. |

**Notable in-review decisions**

- The Phase 0 integrity guard was first written against `git merge-base` + `git show`. Review found it vacuous in CI — the repo checks out at depth 1, so no base ref resolves and the test skipped green; on `master` it degraded to comparing HEAD against itself. It was replaced with a **git-free SHA-256 content pin** over LF-normalised bytes, which runs identically on a shallow CI checkout, on `master`, and on a developer clone, and can never skip. Verified by tampering: appending a newline to `test/e2e/limits.test.js` turns the gate red naming the file and both digests.
- The anti-vacuity floor for the route walk was raised from `> 20` to `>= 55` against a real table of 62, plus a per-mount anchor asserted present — a bare count could not catch a whole router silently unmounting. Review found the anchor set covered only 8 of the 15 `/api` mounts, so unmounting e.g. `data-sets` left 57 of 62 — above the floor and named by nothing. **All fifteen** mounts are now anchored, including the three separate `logs/*` registrations; verified by unmounting `data-sets`.
- Review proved the AC2 simulation step vacuous by mutation: making `startSimulation` answer 503 unconditionally left the suite at 26/26. `[200, 409, 503]`, `assert.ok(status.body.simulationStatus)` (`{}` is truthy) and a bare `stop -> 200` (the route answers 200 whether or not a run exists) were each absorbing the failure. Replaced with registry-level assertions; re-verified red under the same mutation.
- The idle-expiry test was moved from `SESSION_TTL_MS=60` / 250 ms to 500 ms / 1200 ms so the pre-expiry assertion stops racing child-process startup on a loaded runner. The property under test is unchanged.

## Changes

| File | Change |
| --- | --- |
| `test/e2e/auth-journey.test.js` | **New.** 26 tests in seven sections, one per acceptance criterion. |
| `test/helpers/route-table.js` | **New.** Shared live Express route-table walker (`layerPath`, `collectRoutes`), moved verbatim. |
| `test/auth-csrf.test.js` | Imports the shared walker instead of defining it locally. Behaviour-preserving; no assertion changed. |

## Test Results

Full suite, locally, `npm test`:

```
ℹ tests 286
ℹ pass 285
ℹ fail 0
ℹ skipped 1
ℹ duration_ms 102809
```

Baseline before this PR was 260 tests / 259 pass / 1 skip. The one skip is the pre-existing `TAS_IMAGE`-gated Docker assertion in `test/e2e/container-nonroot.test.js` — unchanged. The new file is 26/26 with **zero** skips, in ~62 s.

`test/auth-csrf.test.js` holds at 13/13, confirming the walker refactor is faithful.

`git status --porcelain` is clean after the run: nothing is left behind under `src/server/data/**` or `src/server/logs/**`, and cleanup lives in `after` so it covers the failure path too.

> **CI note:** GitHub Actions is currently failing to provision runners repo-wide (jobs terminate with zero steps executed). This PR was verified locally, in full, as recorded above.

### MongoDB availability

No MongoDB is reachable in this environment. Rather than fake a pass, the DB-backed step asserts the **documented** contract: `GET /api/reports` must never answer 401 or 403 to an authenticated caller, and must answer either 200 or exactly `503 {"error":"Database is unavailable"}`. The limitation is named in the test title and in a `CONSTRAINT` comment, so nobody mistakes it for coverage of the report body.

Every other journey step ran for real against a spawned server: login, topology creation (200, file on disk), read-back (200, name round-trips), `POST /api/simulation/start` (200 — the route reads `data-storage.json` and starts without a live DB), `GET /api/simulation/status` (200), `GET /api/simulation/stop/:file` with the CSRF header (200), topology deletion (200, file gone), logout (200), and cookie replay after logout (401).

## Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
| --- | --- | --- | --- |
| 1 | Every API endpoint enumerated and asserted to reject anonymous requests, only the documented allowlist exempt | ✅ Met | Live walk of `app._router` finds **62 `/api` routes → 62 (method, path) pairs**; each gets a real anonymous request and must answer `401 {"error":"Authentication required"}`. Violations are collected and reported as one set. `PUBLIC_API_ROUTES` is `deepEqual`-ed against the three documented entries, and the observed anonymously-answering set is `deepEqual`-ed to exactly those three — widening the allowlist forces a deliberate test edit. An unknown `/api` path also returns 401, so path existence is not probeable. |
| 2 | Full authenticated journey asserted to succeed | ✅ Met (report step degraded, honestly) | Seven per-step tests against a real child-process instance. All steps real except report-reading, which asserts the documented 503 contract because no MongoDB is present — see above. The simulation step requires the run to have **started**, not merely to have been authorised: exactly 200, the run present in the registry the response carries (right topology file, `isRunning: true`), reported by `GET /api/simulation/status`, and back as `isRunning: false` with an end time after the stop. |
| 3 | Expired or invalidated session rejected | ✅ Met | Idle expiry (`SESSION_TTL_MS=500`, sleep 1200, replay → 401) and explicit invalidation (logout, then cookie replay → 401). |
| 4 | State-changing request without valid CSRF rejected | ✅ Met | Session cookie with no `X-CSRF-Token` → 403; wrong token → 403; and the mutating **safe-method** routes (`GET /api/simulation/stop/...`, `/api/devops/start`) without the token → 403, proving the safe-method skip opens no hole. |
| 5 | Structured values where a string is expected rejected before the database | ✅ Met | Object where a string is declared → 400 `Validation failed`; array where a string is declared → 400; a Mongo operator cannot even be expressed in the query string (`query parser: simple`). Short-circuiting is proven positively: a *valid* query on the same route reaches `dbConnector` and returns 503, while the malformed one returns 400 — so the schema decided first. |
| 6 | Error responses carry the correct status and disclose no server paths | ✅ Met | 400 / 401 / 403 / 404 / 413 / 415 / 503 each asserted for exact status; the whole serialised body is scanned at every depth against the 15-entry `DISCLOSURES` canary — the filesystem eight (repo root, its parent, `ENOENT`, `no such file`, `at Object.`, `at Function.`, `node_modules`, `node:internal`) plus five for the database layer this suite newly exercises (`mongodb://`, `mongodb+srv://`, `Mongoose`, `MongoServerError`, `EAI_AGAIN`, `ECONNREFUSED`, `27017` — both shapes an unreachable connector fails with), since a leaked connector cause discloses the connection string and driver class names that no fs canary matches, body keys are asserted ⊆ `{error, details}`, and no `stack` key may appear at any depth. |
| 7 | Phase 0 suite still passes unchanged | ✅ Met | The full `npm test` run above is the proof it still passes. A guard test additionally pins all four Phase 0 files (`security-suite.test.js`, `limits.test.js`, `container-nonroot.test.js`, `helpers.js`) by SHA-256 over LF-normalised bytes, so a future edit to the Phase 1 suite cannot silently weaken the Phase 0 one. Never skips; verified red under tampering. |


