### PR TITLE
fix(server): report the model filename actually written (#70)

### DIFF
--- a/src/server/routes/model.js
+++ b/src/server/routes/model.js
@@ -1,6 +1,7 @@
 /* Working with Data Generator */
 var express = require('express');
 var path = require('path');
+var fs = require('fs');
 const Joi = require('joi');
 
 const { readJSONFile, writeToFile, readDir, deleteFile } = require('../../core/utils');
@@ -12,7 +13,7 @@ const {
   fileNameParam,
   simulationRunFields,
 } = require('../middleware/validate');
-const { errorHandler, fileError, internal } = require('../middleware/errors');
+const { errorHandler, fileError, internal, conflict } = require('../middleware/errors');
 const modelsPath = `${__dirname}/../data/models/`;
 let router = express.Router();
 
@@ -90,6 +91,29 @@ router.get(
   }
 );
 
+// Bound the search for a free "[Duplicated]" name so a pathological
+// directory cannot spin the event loop (issue #70).
+const MAX_DUPLICATE_CANDIDATES = 1000;
+
+/**
+ * Derive the first available "<name> [Duplicated]" filename for a duplicate.
+ * Every candidate is re-checked against the name allowlist, because the
+ * suffix grows the name and the length cap may cut the search short.
+ * @param {String} sourceName The stored model name being duplicated
+ * @returns {{name: String, path: String}|null} A free candidate, or null
+ */
+const findFreeDuplicate = (sourceName) => {
+  for (let i = 1; i <= MAX_DUPLICATE_CANDIDATES; i++) {
+    const candidate = i === 1 ? `${sourceName} [Duplicated]` : `${sourceName} [Duplicated] ${i}`;
+    if (!isValidName(candidate)) continue;
+    const candidatePath = resolveWithin(modelsPath, `${candidate}.json`);
+    if (candidatePath && !fs.existsSync(candidatePath)) {
+      return { name: candidate, path: candidatePath };
+    }
+  }
+  return null;
+};
+
 const duplicateModel = (fileName, res, next) => {
   const modelFile = resolveWithin(modelsPath, fileName);
   if (!modelFile) {
@@ -99,22 +123,20 @@ const duplicateModel = (fileName, res, next) => {
     if (err) {
       next(fileError(err, 'Model not found', 'Cannot read the model file'));
     } else {
-      const newName = `${data.name} [Duplicated]`;
-      const newModel = { ...data, name: newName };
-      if (!isValidName(newName)) {
-        return sendBadRequest(res, 'Invalid model name');
+      // Collision policy (issue #70): duplicating must never overwrite an
+      // earlier copy, so write to a name proven free and report exactly it.
+      const free = findFreeDuplicate(data.name);
+      if (!free) {
+        return next(conflict('Cannot derive a free name for the duplicated model'));
       }
-      const newFileName = `${newName}.json`;
-      const newFile = resolveWithin(modelsPath, newFileName);
-      if (!newFile) {
-        return sendBadRequest(res, 'Invalid model name');
-      }
+      const newModel = { ...data, name: free.name };
+      const newFileName = `${free.name}.json`;
       writeToFile(
-        newFile,
+        free.path,
         JSON.stringify(newModel),
-        (err, dupModel) => {
-          if (err) {
-            next(internal('Cannot save the duplicated model', err));
+        (err2) => {
+          if (err2) {
+            next(internal('Cannot save the duplicated model', err2));
           } else {
             res.send({
               modelFileName: newFileName,
@@ -218,15 +240,26 @@ router.post('/', validate({ body: modelCreateBody }), function (req, res, next) 
   if (!modelFilePath) {
     return sendBadRequest(res, 'Invalid model name');
   }
-  writeToFile(modelFilePath, JSON.stringify(model), (err, data) => {
-    if (err) {
-      next(internal('Cannot save the new configuration', err));
-    } else {
-      res.send({
-        modelFileName,
-      });
-    }
-  });
+  // Collision policy (issue #70): refuse a duplicate name instead of letting
+  // writeToFile silently rename the target — the filename this handler returns
+  // must always be the exact file that was written.
+  if (fs.existsSync(modelFilePath)) {
+    return next(conflict('A model with this name already exists'));
+  }
+  writeToFile(
+    modelFilePath,
+    JSON.stringify(model),
+    (err, data) => {
+      if (err) {
+        next(internal('Cannot save the new configuration', err));
+      } else {
+        res.send({
+          modelFileName,
+        });
+      }
+    },
+    true
+  );
 });
 
 // Delete a model

--- a/test/model-collision.test.js
+++ b/test/model-collision.test.js
@@ -1,0 +1,117 @@
+const { test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const express = require('express');
+const { request } = require('./_http');
+
+const modelRouter = require('../src/server/routes/model');
+
+const modelsDir = path.resolve(__dirname, '../src/server/data/models');
+
+let server;
+let app;
+
+before(() => {
+  app = express();
+  app.use(express.json());
+  app.use('/api/models', modelRouter);
+  server = app.listen(0);
+});
+
+after(() => {
+  server.close();
+});
+
+const unique = (prefix) => `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+const inModelsDir = (fileName) => path.join(modelsDir, fileName);
+
+test('models POST refuses an existing name with 409 and reports only written files', async () => {
+  const name = unique('collision-create');
+  const fileName = `${name}.json`;
+  const body = { model: { name, devices: [] } };
+
+  try {
+    const create = await request(server, 'POST', '/api/models', body);
+    assert.equal(create.status, 200);
+    assert.equal(create.body.modelFileName, fileName);
+
+    const again = await request(server, 'POST', '/api/models', body);
+    assert.equal(
+      again.status,
+      409,
+      `expected 409 for duplicate name, got ${again.status} (${again.raw})`
+    );
+
+    // The reported filename must always be readable afterwards, and the
+    // refused create must leave the original untouched with no stray
+    // timestamped copies behind.
+    const read = await request(server, 'GET', `/api/models/${encodeURIComponent(fileName)}`);
+    assert.equal(read.status, 200);
+    assert.equal(read.body.model.name, name);
+
+    const leftovers = fs
+      .readdirSync(modelsDir)
+      .filter((f) => f.startsWith(`${name}-`) && f.endsWith('.json'));
+    assert.deepEqual(leftovers, [], 'no renamed leftover files may be created');
+  } finally {
+    fs.rmSync(inModelsDir(fileName), { force: true });
+  }
+});
+
+test('models POST duplicate twice yields two distinct readable files', async () => {
+  const name = unique('collision-dup');
+  const fileName = `${name}.json`;
+
+  try {
+    const create = await request(server, 'POST', '/api/models', {
+      model: { name, devices: [] },
+    });
+    assert.equal(create.status, 200);
+
+    const first = await request(server, 'POST', `/api/models/${encodeURIComponent(fileName)}`, {
+      isDuplicated: true,
+    });
+    assert.equal(first.status, 200);
+    const firstDupName = first.body.modelFileName;
+    assert.ok(firstDupName.includes('[Duplicated]'), `expected [Duplicated] in ${firstDupName}`);
+    assert.ok(fs.existsSync(inModelsDir(firstDupName)));
+
+    const second = await request(server, 'POST', `/api/models/${encodeURIComponent(fileName)}`, {
+      isDuplicated: true,
+    });
+    assert.equal(second.status, 200);
+    const secondDupName = second.body.modelFileName;
+    assert.notEqual(
+      secondDupName,
+      firstDupName,
+      'the second duplicate must target a different file'
+    );
+    assert.ok(fs.existsSync(inModelsDir(secondDupName)), 'second duplicate must exist');
+    assert.ok(
+      fs.existsSync(inModelsDir(firstDupName)),
+      'first duplicate must not be overwritten by the second'
+    );
+
+    const readFirst = await request(
+      server,
+      'GET',
+      `/api/models/${encodeURIComponent(firstDupName)}`
+    );
+    assert.equal(readFirst.status, 200);
+    assert.equal(readFirst.body.model.name, firstDupName.replace(/\.json$/, ''));
+
+    const readSecond = await request(
+      server,
+      'GET',
+      `/api/models/${encodeURIComponent(secondDupName)}`
+    );
+    assert.equal(readSecond.status, 200);
+    assert.equal(readSecond.body.model.name, secondDupName.replace(/\.json$/, ''));
+  } finally {
+    fs.rmSync(inModelsDir(fileName), { force: true });
+    for (const f of fs.readdirSync(modelsDir)) {
+      if (f.startsWith(`${name} [Duplicated]`)) fs.rmSync(inModelsDir(f), { force: true });
+    }
+  }
+});


### PR DESCRIPTION
Closes #70

## Summary

`POST /api/models` returned `<name>.json` while `writeToFile` silently renamed the target to `<name>-<timestamp>.json` on a name collision, so the client was handed a path that 404s on the next read (F-BUG-003). Separately, `duplicateModel` always derived `<name> [Duplicated].json` and wrote it with overwrite enabled, so duplicating the same model twice destroyed the first copy (F-BUG-007). One collision policy now applies consistently: create refuses a duplicate name with 409, duplicate derives the first free `[Duplicated]` name, and both report exactly the filename that was written.

## Approach

Explicit collision policy at the route layer (minimal/balanced). The create route pre-checks existence and answers 409 via the existing `conflict()` helper, then writes with `isOverwrite=true`, so the silent-rename path is eliminated and the reported `modelFileName` is always the exact file written. `duplicateModel` derives candidates `<name> [Duplicated]`, `<name> [Duplicated] 2`, … through a bounded search (1000), re-validating each against the name allowlist and containment check, writes to the first proven-free name with `isOverwrite=true`, and reports it.

## Decision Record

- **Root cause:** The create route called `writeToFile` without `isOverwrite`, and that helper renames an existing target to `<name>-<timestamp>.json` without reporting the new path — the handler then returned the original name regardless. `duplicateModel` hardcoded one target name and passed `isOverwrite=true`, making the second duplicate clobber the first.
- **Options considered:** Option 1 — explicit collision policy at the route layer (409 on create, free-name search on duplicate); Option 2 — make `writeToFile` report its renamed path through the callback; Option 3 — refuse duplicates with 409 on both endpoints
- **Options rejected:** Option 2 — changes the core-utils callback contract used by many routes and leaves `-<timestamp>` files whose internal `name` no longer matches the filename; Option 3 — violates the acceptance criterion that duplicating twice yields two distinct files
- **Selected option:** Option 1 — explicit collision policy at the route layer
- **Residual risk:** A theoretical existsSync→write TOCTOU window remains under concurrent writers; the reported==written invariant holds by construction because the write uses `isOverwrite=true`. Rename-overwrite in `updateModel` (renaming onto an existing name replaces it) is adjacent behavior with no finding against it and is left unchanged. `data-recorders.js:320` shares the old duplicate pattern but is outside this issue's findings.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle
- **Reproduction:** `node --test test/model-collision.test.js` confirmed red for the stated reasons (duplicate create answered 200 after silently writing `collision-create-…-….json`; second duplicate targeted the identical `[Duplicated].json`) → regression test `test/model-collision.test.js`

Analyzed at: `fix/70-report-the-model-filename-that-was @ 6aac365` (2026-08-21)

## Changes

| File | Change |
|------|--------|
| `src/server/routes/model.js` | Create route refuses an existing name with 409 and writes with overwrite enabled; `duplicateModel` derives the first free bounded `[Duplicated]` name instead of overwriting; both return exactly the filename written |
| `test/model-collision.test.js` | Regression suite: duplicate-name create returns 409 leaving no stray timestamped copies and the reported name readable; duplicating twice yields two distinct readable files with neither overwritten |

## Test Results

- Unit tests: 289 passed (`npm test`, 293 total)
- Integration tests: included above (route-level suites)
- E2e tests: 0 added
- Build: passed (pre-commit eslint + prettier hooks green)
- QA cycles: 1 (clean, no blocking findings)

The 3 remaining failures are pre-existing on `master` (MongoDB-dependent suites; verified by stash-running `master` before and after building the dashboard bundle) and are untouched by this change.

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Creating a model with an existing name either returns 409 or returns the exact filename written, and a subsequent read of the returned name succeeds | pass | Verified red: `node --test test/model-collision.test.js` → fixed → `models POST refuses an existing name with 409 and reports only written files` (src/server/routes/model.js:247) |
| Duplicating the same model twice yields two distinct files and neither is overwritten | pass | Verified red: same command → fixed → `models POST duplicate twice yields two distinct readable files` (src/server/routes/model.js:94) |
| Both behaviours are covered by tests | pass | `test/model-collision.test.js` (2 tests, red→green demonstrated) |
| `npm test` passes at ≥ 285/286 (baseline-green holds) | pass | 289/293 passing; the 3 failures reproduce identically on pristine `master` (DB-environment), baseline-green holds |

<!-- gitissue:qa v1 head=6aac365dbcef8d077e9b2aaf3d11723f1a29f13c profile=light cycles=1 review=clean tests=289@6aac365dbcef8d077e9b2aaf3d11723f1a29f13c ui=none -->
