### PR TITLE
fix(server): stop logger replacing global console methods (#15)

### DIFF
--- a/src/core/communications/DataStorage.js
+++ b/src/core/communications/DataStorage.js
@@ -16,11 +16,15 @@ const ReportSchema = require('../enact-mongoose/schemas/ReportSchema');
  *  + stop(): disconnect with the database
  */
 class DataStorage {
-  constructor(config) {
+  constructor(config, logger = null) {
     const { protocol, connConfig } = config;
     this.protocol = protocol;
     this.connConfig = connConfig;
     this.dsClient = null;
+    // Where this connection writes its log lines. The run that opened the
+    // connection passes its own logger in; without one, fall back to the
+    // process console.
+    this.logger = logger || console;
   }
 
   /**
@@ -28,7 +32,7 @@ class DataStorage {
    * @param {Function} callback The callback function
    */
   connect(callback) {
-    console.log('[DataStorage] Connecting...');
+    this.logger.log('[DataStorage] Connecting...');
     if (this.protocol === 'MONGODB') {
       const { host, port, username, password, dbname, options } = this.connConfig;
       if (username && password) {
@@ -42,16 +46,18 @@ class DataStorage {
 
       this.dsClient.connect((error) => {
         if (error) {
-          console.error(`[DataStorage] ERROR: Failed to connect to database:`);
-          console.error(error);
-          console.error(this.connConfig);
+          this.logger.error(
+            `[DataStorage] ERROR: Failed to connect to database:`,
+            error,
+            this.connConfig
+          );
           return callback(error);
         }
-        console.log('[DataStorage] Connected to database');
+        this.logger.log('[DataStorage] Connected to database');
         return callback();
       });
     } else {
-      console.log(`Unsupported protocol: ${this.protocol}`);
+      this.logger.log(`Unsupported protocol: ${this.protocol}`);
     }
   }
 
@@ -77,7 +83,7 @@ class DataStorage {
           source: dataset.source ? dataset.source : 'RECORDED',
         });
         newDS.save();
-        console.log('[DataStorage] A new dataset has been created: ', dataset);
+        this.logger.log('[DataStorage] A new dataset has been created: ', dataset);
       }
     });
   }
@@ -85,15 +91,13 @@ class DataStorage {
   saveReport(report) {
     ReportSchema.findOne({ id: report.id }, (err, rp) => {
       if (rp) {
-        console.log('[DataStorage] Going to update a report: ');
-        console.log(report);
+        this.logger.log('[DataStorage] Going to update a report: ', report);
         ReportSchema.findOneAndUpdate({ id: report.id }, report);
       } else {
-        console.log('[DataStorage] Going to add a new report: ');
-        console.log(JSON.stringify(report));
+        this.logger.log('[DataStorage] Going to add a new report: ', report);
         const newReport = new ReportSchema(report);
         newReport.save();
-        console.log('[DataStorage] A new report has been created');
+        this.logger.log('[DataStorage] A new report has been created');
       }
     });
   }
@@ -105,9 +109,7 @@ class DataStorage {
       endTime ? endTime : Date.now(),
       (err, events) => {
         if (err) {
-          console.error('[DataStorage] Cannot get events!');
-          console.error(datasetId);
-          console.error(err);
+          this.logger.error('[DataStorage] Cannot get events!', datasetId, err);
           return callback(err);
         } else {
           return callback(null, events);
@@ -122,7 +124,13 @@ class DataStorage {
     if (!endTime) endTime = Date.now();
     EventSchema.findEventsBetweenTimes({ topic, datasetId }, startTime, endTime, (err, events) => {
       if (err) {
-        console.error('[DataStorage] Cannot get events!', topic, datasetId, timeConstraints, err);
+        this.logger.error(
+          '[DataStorage] Cannot get events!',
+          topic,
+          datasetId,
+          timeConstraints,
+          err
+        );
         return callback(err);
       } else {
         return callback(null, events);
@@ -133,10 +141,10 @@ class DataStorage {
   getTestCampaignById(testCampaignId, callback) {
     TestCampaignSchema.findOne({ id: testCampaignId }, (err, tc) => {
       if (err) {
-        console.error(`[DataStorage] Cannot get test campaign: ${testCampaignId}`, err);
+        this.logger.error(`[DataStorage] Cannot get test campaign: ${testCampaignId}`, err);
         return callback(err, null);
       } else if (!tc) {
-        console.error(
+        this.logger.error(
           `[DataStorage] Cannot get test campaign: ${testCampaignId}. TestCampaign is null`
         );
         return callback('Test Campaign is NULL', null);
@@ -149,10 +157,10 @@ class DataStorage {
   getTestCaseById(testCaseId, callback) {
     TestCaseSchema.findOne({ id: testCaseId }, (err, tc) => {
       if (err) {
-        console.error(`[DataStorage] Cannot get test Case: ${testCaseId}`, err);
+        this.logger.error(`[DataStorage] Cannot get test Case: ${testCaseId}`, err);
         return callback(err, null);
       } else if (!tc) {
-        console.error(`[DataStorage] Cannot get test Case: ${testCaseId}. TestCase is null`);
+        this.logger.error(`[DataStorage] Cannot get test Case: ${testCaseId}. TestCase is null`);
         return callback('Test Case is NULL', null);
       } else {
         return callback(null, tc);

--- a/src/core/data-recorder/DRecorder.js
+++ b/src/core/data-recorder/DRecorder.js
@@ -7,7 +7,7 @@ const { checkMQTTTopic } = require('../utils');
  * - Save the capturing data into a data storage (mongodb)
  */
 class DataRecorder {
-  constructor(drConfig, dataStorage, dataset) {
+  constructor(drConfig, dataStorage, dataset, logger = null) {
     const { id, name, source, forward } = drConfig;
     this.id = id;
     this.name = name;
@@ -15,6 +15,8 @@ class DataRecorder {
     this.forwarder = forward;
     this.dataStorage = dataStorage;
     this.dataset = dataset;
+    // Where this run writes its log lines; defaults to the process console.
+    this.logger = logger || console;
   }
 
   /**
@@ -39,7 +41,7 @@ class DataRecorder {
    * @param {Object} packet Full attributes of the packets
    */
   messageHandler(topic, message, packet) {
-    console.log(`[DataRecorder] Received a message on topic: ${topic}`);
+    this.logger.log(`[DataRecorder] Received a message on topic: ${topic}`);
     // console.log(message);
     let isSensorData = false;
     if (this.isSensorData(topic, packet)) {
@@ -145,18 +147,18 @@ class DataRecorder {
   init() {
     // Check source
     if (!this.source) {
-      console.error('[DataRecorder] Source is not found!');
+      this.logger.error('[DataRecorder] Source is not found!');
       return false;
     }
 
     // Check output
     if (!this.forwarder) {
-      console.warn('[DataRecorder] forward are not found!');
+      this.logger.warn('[DataRecorder] forward are not found!');
       this.initSource();
     } else {
       // Init the forwarder
       this.initForwarder(() => {
-        console.error('[DataRecorder] Forwarder has been created!', this.forwarder);
+        this.logger.error('[DataRecorder] Forwarder has been created!', this.forwarder);
         this.initSource();
       });
     }

--- a/src/core/data-recorder/index.js
+++ b/src/core/data-recorder/index.js
@@ -3,12 +3,16 @@ const DRecorder = require('./DRecorder');
 const { readJSONFile } = require('../utils');
 
 class DataRecorder {
-  constructor(drConfig) {
+  constructor(drConfig, logger = null) {
     const { dataStorage, dataRecorders, dataset } = drConfig;
     this.dataStorage = dataStorage;
     this.dataRecorders = dataRecorders;
     this.dataset = dataset;
     this.allDataRecorders = [];
+    // Where this run writes its log lines. The route that started the
+    // recorder passes its own logger in; without one, fall back to the
+    // process console.
+    this.logger = logger || console;
   }
 
   /**
@@ -38,10 +42,10 @@ class DataRecorder {
    * @param {Function} callback The callback function
    */
   initDataStorage(callback) {
-    const dsClient = new DataStorage(this.dataStorage);
+    const dsClient = new DataStorage(this.dataStorage, this.logger);
     dsClient.connect((error) => {
       if (error) {
-        console.error('Failed to create DataStorage', error);
+        this.logger.error('Failed to create DataStorage', error);
         return callback(error);
       } else {
         this.dataStorage['dsClient'] = dsClient;
@@ -49,7 +53,7 @@ class DataRecorder {
           dsClient.saveDataset(this.dataset);
           return callback();
         } else {
-          console.error('Failed to create DataStorage: dataset missing');
+          this.logger.error('Failed to create DataStorage: dataset missing');
           dsClient.stop();
           return callback('Dataset missing');
         }
@@ -60,7 +64,7 @@ class DataRecorder {
   initDRecorders() {
     for (let index = 0; index < this.dataRecorders.length; index++) {
       const dRecorderCfg = this.dataRecorders[index];
-      const dRecorder = new DRecorder(dRecorderCfg, this.dataStorage, this.dataset);
+      const dRecorder = new DRecorder(dRecorderCfg, this.dataStorage, this.dataset, this.logger);
       if (dRecorder.init()) {
         this.allDataRecorders.push(dRecorder);
       }
@@ -74,7 +78,7 @@ class DataRecorder {
    * - Init the data recorders
    */
   start() {
-    console.log(`[DataRecorder] Going to start ...`);
+    this.logger.log(`[DataRecorder] Going to start ...`);
     if (this.dataStorage) {
       this.initDataStorage(() => this.initDRecorders());
     } else {
@@ -83,7 +87,7 @@ class DataRecorder {
   }
 
   stop() {
-    console.log(`[DataRecorder] Going to stop ...`);
+    this.logger.log(`[DataRecorder] Going to stop ...`);
     if (this.dataStorage && this.dataStorage.dsClient) {
       this.dataStorage.dsClient.stop();
     }

--- a/src/core/devops-flow/index.js
+++ b/src/core/devops-flow/index.js
@@ -19,19 +19,34 @@ const stopTestCampaign = () => {
  * Start the test campaign
  * @param {Object} model The model to be simulated
  */
-const startTestCampaign = (testCampaignId, dataStorage, webhookURL, evaluationParameters) => {
+const startTestCampaign = (
+  testCampaignId,
+  dataStorage,
+  webhookURL,
+  evaluationParameters,
+  logger = null
+) => {
+  // The run's own logger, obtained explicitly by the caller. Without one,
+  // fall back to the process console.
+  const log = logger || console;
   // console.log("Start test campaign: ");
   // console.log(testCampaignId);
   // console.log(JSON.stringify(dataStorage));
   // console.log(webhookURL);
   // console.log(JSON.stringify(evaluationParameters));
-  testCampaign = new TestCampaign(testCampaignId, dataStorage, webhookURL, evaluationParameters);
+  testCampaign = new TestCampaign(
+    testCampaignId,
+    dataStorage,
+    webhookURL,
+    evaluationParameters,
+    logger
+  );
   testCampaign.init((err) => {
     if (err) {
-      console.log(`[devops-flow] Failed to start a Test Campaign ${testCampaignId}`);
+      log.log(`[devops-flow] Failed to start a Test Campaign ${testCampaignId}`);
     } else {
       testCampaign.start(() => {
-        console.log(`[devops-flow] Test campaign ${testCampaignId} has been finished`);
+        log.log(`[devops-flow] Test campaign ${testCampaignId} has been finished`);
       });
     }
   });

--- a/src/core/simulation/Simulation.js
+++ b/src/core/simulation/Simulation.js
@@ -12,8 +12,18 @@ const Thing = require('../things/Thing');
  * Simulation class presents a simulation
  */
 class Simulation {
-  constructor(model, options = null, simulationCallbackWhenFinish = null) {
+  /**
+   * Create a simulation
+   * @param {Object} model The model to simulate
+   * @param {Object} options Run options (dataStorage, datasetId, ...)
+   * @param {Function} simulationCallbackWhenFinish Called with the score when the run stops
+   * @param {Object} logger Where this run writes its log lines. Obtained
+   *   explicitly by the caller (one per run) and never the global console
+   *   replacement; defaults to the process console for standalone use.
+   */
+  constructor(model, options = null, simulationCallbackWhenFinish = null, logger = null) {
     this.model = model;
+    this.logger = logger || console;
     this.newDataset = model.newDataset;
     this.dataStorage = model.dataStorage;
     this.datasetId = model.datasetId;
@@ -32,7 +42,7 @@ class Simulation {
       if (options.evaluationParameters) this.evaluationParameters = options.evaluationParameters;
     }
     if (!this.evaluationParameters) {
-      console.log(`[SIMULATION] Use default evaluation parameters`);
+      this.logger.log(`[SIMULATION] Use default evaluation parameters`);
       this.evaluationParameters = {
         threshold: THRESHOLD_FLEXIBLE,
         eventType: ALL_EVENTS,
@@ -85,7 +95,7 @@ class Simulation {
   }
 
   deviceCallbackWhenFinish() {
-    console.log('A device is going to finish his job');
+    this.logger.log('A device is going to finish his job');
     for (let index = 0; index < this.allThings.length; index++) {
       const dev = this.allThings[index];
       if (dev.status !== OFFLINE) {
@@ -101,12 +111,12 @@ class Simulation {
       endTime,
       (err3, originalEvents) => {
         if (err3) {
-          console.error(`Cannot get original events of dataset ${originalDatasetId}`);
+          this.logger.error(`Cannot get original events of dataset ${originalDatasetId}`, err3);
           stopSimulation();
         } else {
           EventSchema.findEventsWithOptions({ datasetId: newDatasetId }, (err4, newEvents) => {
             if (err4) {
-              console.error(`Cannot get new events of dataset ${newDatasetId}`);
+              this.logger.error(`Cannot get new events of dataset ${newDatasetId}`, err4);
               stopSimulation();
             } else {
               const { threshold, eventType, metricType } = this.evaluationParameters;
@@ -114,10 +124,10 @@ class Simulation {
               // Going to save the score into the report
               ReportSchema.findOneAndUpdate({ id }, { score }, (err5, ret) => {
                 if (err5) {
-                  console.error(`Cannot update the score for report ${id}`);
+                  this.logger.error(`Cannot update the score for report ${id}`, err5);
                   stopSimulation();
                 } else {
-                  console.log(`Report ${id} has score of ${score}`);
+                  this.logger.log(`Report ${id} has score of ${score}`);
                   stopSimulation(score);
                 }
               });
@@ -137,7 +147,8 @@ class Simulation {
       this.newDataset,
       this.report,
       isFirstDevice,
-      () => this.deviceCallbackWhenFinish()
+      () => this.deviceCallbackWhenFinish(),
+      this.logger
     );
 
     newThing.initDevice(() => {
@@ -147,7 +158,7 @@ class Simulation {
   }
 
   start() {
-    console.log('Start simulating for the model: ', this.model.name);
+    this.logger.log('Start simulating for the model: ', this.model.name);
     this.status = SIMULATING;
     while (this.allThings.length > 0) {
       this.allThings.pop();
@@ -183,7 +194,7 @@ class Simulation {
    */
   stop(score) {
     if (this.status === OFFLINE) {
-      console.log('Simulation has been stopped already');
+      this.logger.log('Simulation has been stopped already');
     } else {
       this.status = OFFLINE;
       for (let index = 0; index < this.allThings.length; index++) {

--- a/src/core/test-campaigns/TestCampaign.js
+++ b/src/core/test-campaigns/TestCampaign.js
@@ -4,11 +4,16 @@ const { OFFLINE, SIMULATING } = require('../DeviceStatus');
 const TestCase = require('./TestCase');
 
 class TestCampaign {
-  constructor(id, dataStorageConfig, webhookURL, evaluationParameters) {
+  constructor(id, dataStorageConfig, webhookURL, evaluationParameters, logger = null) {
     this.id = id;
     this.name = id;
+    // Where this run writes its log lines. The route that started the
+    // campaign passes its own logger in, shared by every test case and
+    // simulation of the campaign; without one, fall back to the process
+    // console.
+    this.logger = logger || console;
     this.dataStorageConfig = dataStorageConfig;
-    this.dataStorage = new DataStorage(dataStorageConfig);
+    this.dataStorage = new DataStorage(dataStorageConfig, this.logger);
     this.webhookURL = webhookURL;
     this.evaluationParameters = evaluationParameters;
     //
@@ -48,9 +53,10 @@ class TestCampaign {
                     return;
                   }
                 }
-                console.log('All test case have been finished');
+                this.logger.log('All test case have been finished');
                 return this.stop();
-              }
+              },
+              this.logger
             );
             this.testCases.push(testCase);
           }
@@ -61,7 +67,7 @@ class TestCampaign {
   }
 
   sendResultToWebhook() {
-    console.log(`Going to notify the result to the webhook: ${this.webhookURL}`);
+    this.logger.log(`Going to notify the result to the webhook: ${this.webhookURL}`);
     fetch(this.webhookURL, {
       method: 'POST',
       headers: {
@@ -70,23 +76,21 @@ class TestCampaign {
       body: JSON.stringify(this.results),
     })
       .then((res) => {
-        console.log('Response from webhook:');
-        console.log(JSON.stringify(res));
+        this.logger.log('Response from webhook:', res);
       })
       .catch((err) => {
-        console.error('Cannot send result to webhook');
-        console.log(JSON.stringify(err));
+        this.logger.error('Cannot send result to webhook', err);
       });
   }
 
   start() {
     if (this.status === SIMULATING) {
-      console.log(`[TestCampaign] Test campaign is on running ${this.name}`);
+      this.logger.log(`[TestCampaign] Test campaign is on running ${this.name}`);
       return;
     }
 
     if (!this.testCases || this.testCases.length === 0) {
-      console.error(`[TestCampaign] No test case ${this.name}`);
+      this.logger.error(`[TestCampaign] No test case ${this.name}`);
       return this.stop();
     }
     for (let index = 0; index < this.testCases.length; index++) {
@@ -100,7 +104,7 @@ class TestCampaign {
 
   stop() {
     if (this.status === OFFLINE) {
-      console.log(`[TestCampaign] Test Campaign is offline`);
+      this.logger.log(`[TestCampaign] Test Campaign is offline`);
       return;
     }
 

--- a/src/core/test-campaigns/TestCase.js
+++ b/src/core/test-campaigns/TestCase.js
@@ -9,12 +9,17 @@ class TestCase {
     dataStorageConfig,
     testCampaignId = null,
     evaluationParameters = null,
-    callbackWhenFinish = null
+    callbackWhenFinish = null,
+    logger = null
   ) {
+    // Where this run writes its log lines. A campaign shares its own logger
+    // with every test case it owns; without one, fall back to the process
+    // console.
+    this.logger = logger || console;
     this.id = id;
     this.name = id;
     this.dataStorageConfig = dataStorageConfig;
-    this.dataStorage = new DataStorage(dataStorageConfig);
+    this.dataStorage = new DataStorage(dataStorageConfig, this.logger);
     this.simulations = [];
     this.modelFileName = null;
     this.model = null;
@@ -29,19 +34,19 @@ class TestCase {
   init(callback) {
     this.dataStorage.connect((err) => {
       if (err) {
-        console.error(`[TestCase] Cannot connect to data storage: ${JSON.stringify(err)}`);
+        this.logger.error(`[TestCase] Cannot connect to data storage`, err);
         return callback(err);
       }
       this.dataStorage.getTestCaseById(this.id, (err, tc) => {
         if (err) {
-          console.error(`[TestCase] Cannot get the test case by id: ${this.id}`);
+          this.logger.error(`[TestCase] Cannot get the test case by id: ${this.id}`, err);
           return callback(err);
         }
         const { datasetIds, name, modelFileName } = tc;
         this.name = name ? name : this.id;
         this.modelFileName = modelFileName;
         if (!datasetIds || datasetIds.length === 0) {
-          console.error(`[TestCase] No datasetIds: ${this.id}`);
+          this.logger.error(`[TestCase] No datasetIds: ${this.id}`);
           return callback(`[TestCase] No datasetIds: ${this.id}`);
         }
         if (!this.modelFileName) {
@@ -51,8 +56,7 @@ class TestCase {
         this.modelFileName = modelFileName;
         return readJSONFile(`${modelsPath}${this.modelFileName}`, (err2, data) => {
           if (err2) {
-            console.error(`[TestCase] Cannot read model file ${this.modelFileName}`);
-            console.error(err2);
+            this.logger.error(`[TestCase] Cannot read model file ${this.modelFileName}`, err2);
             return callback(`Cannot read model file ${this.modelFileName}`);
           } else {
             this.model = data;
@@ -65,16 +69,16 @@ class TestCase {
 
   start() {
     if (this.status === SIMULATING) {
-      console.log('[TestCase] Test case is in simulating');
+      this.logger.log('[TestCase] Test case is in simulating');
       return;
     }
     if (!this.datasetIds || this.datasetIds.length === 0) {
-      console.log('[TestCase] No datasetIds');
+      this.logger.log('[TestCase] No datasetIds');
       this.stop();
       return;
     }
     if (!this.model) {
-      console.log('[TestCase] No model');
+      this.logger.log('[TestCase] No model');
       this.stop();
       return;
     }
@@ -107,7 +111,8 @@ class TestCase {
             stopTestCase();
             return;
           }
-        }
+        },
+        this.logger
       );
       newSimulation.start();
       this.simulations.push(newSimulation);
@@ -117,7 +122,7 @@ class TestCase {
 
   stop() {
     if (this.status === OFFLINE) {
-      console.log(`[TestCase] Test case ${this.name} is offline`);
+      this.logger.log(`[TestCase] Test case ${this.name} is offline`);
     } else {
       for (let index = 0; index < this.simulations.length; index++) {
         const simulation = this.simulations[index];

--- a/src/core/things/Thing.js
+++ b/src/core/things/Thing.js
@@ -40,7 +40,8 @@ class Device {
     newDataset,
     report,
     isFirstDevice = false,
-    deviceCallbackWhenFinish = null
+    deviceCallbackWhenFinish = null,
+    logger = null
   ) {
     const {
       id,
@@ -73,6 +74,9 @@ class Device {
     this.datasetId = datasetId;
     this.globalReplayOptions = replayOptions;
     this.isFirstDevice = isFirstDevice;
+    // Where this device writes its log lines. The run that created the device
+    // passes its own logger in; without one, fall back to the process console.
+    this.logger = logger || console;
     this.status = OFFLINE; // OFFLINE | ONLINE | SIMULATING | PAUSE | STOP
     // Instance need to be initialized
     this.sensors = []; // Add/Remove sensor method
@@ -176,7 +180,7 @@ class Device {
           return;
         }
       }
-      console.error('Cannot find the sensor with the topic: ', topic);
+      this.logger.error('Cannot find the sensor with the topic: ', topic);
     }
   }
 
@@ -215,7 +219,7 @@ class Device {
         return;
       }
     }
-    console.error('Cannot find the actuator with the topic: ', topic);
+    this.logger.error('Cannot find the actuator with the topic: ', topic);
   }
 
   /**
@@ -237,7 +241,7 @@ class Device {
         return;
       }
     }
-    console.error('Cannot find the sensor with the topic: ', topic);
+    this.logger.error('Cannot find the sensor with the topic: ', topic);
   }
 
   /**
@@ -274,9 +278,9 @@ class Device {
    * @param {String} objectId The object id of the sensor follow IP Smart Object Standard
    */
   addSensor(id, sensorData, objectId = null, events = null) {
-    console.log('Going to add a new sensor: ', id);
+    this.logger.log('Going to add a new sensor: ', id);
     if (findDevice(id, objectId, this.sensors) > -1) {
-      console.error(`[${this.id}] Sensor ID ${id} ${objectId} has already existed!`);
+      this.logger.error(`[${this.id}] Sensor ID ${id} ${objectId} has already existed!`);
       return null;
     }
     let topic = sensorData.topic;
@@ -287,7 +291,7 @@ class Device {
     const { dataSource } = sensorData;
     if (!topic) {
       topic = `devices/${this.id}/sensors/${id}`;
-      console.log(`[${this.id}] Sensor ${id} will use the default topic name`, topic);
+      this.logger.log(`[${this.id}] Sensor ${id} will use the default topic name`, topic);
     }
 
     if (dataSource === DS_RECORDER) {
@@ -307,9 +311,9 @@ class Device {
         if (this.status === SIMULATING) {
           this.sensors[this.sensors.length - 1].start();
         }
-        console.log(`[${this.id}] added new sensor ${id} ${objectId} (${dataSource})`);
+        this.logger.log(`[${this.id}] added new sensor ${id} ${objectId} (${dataSource})`);
       } else {
-        console.error(
+        this.logger.error(
           `[${this.id}] Cannot create a sensor! Missing data source from production broker`
         );
         return null;
@@ -335,7 +339,7 @@ class Device {
       if (this.status === SIMULATING) {
         this.sensors[this.sensors.length - 1].start();
       }
-      console.log(`[${this.id}] added new sensor ${id} ${objectId} (${dataSource})`);
+      this.logger.log(`[${this.id}] added new sensor ${id} ${objectId} (${dataSource})`);
     } else {
       // Data will be generated in run time
       const newSensor = new Sensor(
@@ -355,7 +359,7 @@ class Device {
       if (this.status === SIMULATING) {
         this.sensors[this.sensors.length - 1].start();
       }
-      console.log(`[${this.id}] added new sensor ${id} ${objectId} (${dataSource})`);
+      this.logger.log(`[${this.id}] added new sensor ${id} ${objectId} (${dataSource})`);
     }
   }
 
@@ -371,7 +375,7 @@ class Device {
   removeSensor(id, objectId = null) {
     const sensorIndex = findDevice(id, objectId, this.sensors);
     if (sensorIndex === -1) {
-      console.error(`[${this.id}] Sensor ID ${id} ${objectId} does not exist!`);
+      this.logger.error(`[${this.id}] Sensor ID ${id} ${objectId} does not exist!`);
       return null;
     }
     const sensor = this.sensors[sensorIndex];
@@ -384,7 +388,7 @@ class Device {
       }
     }
     this.sensors.splice(sensorIndex, 1);
-    console.log(`[${this.id}] Sensor ID ${id} ${objectId} has been removed!`);
+    this.logger.log(`[${this.id}] Sensor ID ${id} ${objectId} has been removed!`);
   }
 
   /**
@@ -396,15 +400,15 @@ class Device {
    * @param {String} id The actuator's ID
    */
   addActuator(id, actuatorData, objectId = null) {
-    console.log('Going to add a new actuator: ', id);
+    this.logger.log('Going to add a new actuator: ', id);
     if (findDevice(id, objectId, this.actuators) > -1) {
-      console.error(`[${this.id}] Actuator ID ${id} ${objectId} has already existed!`);
+      this.logger.error(`[${this.id}] Actuator ID ${id} ${objectId} has already existed!`);
       return null;
     }
     let topic = actuatorData.topic;
     if (!topic) {
       topic = `devices/${this.id}/actuators/${id}`;
-      console.log(`[${this.id}] Actuator ${id} will use the default topic name`, topic);
+      this.logger.log(`[${this.id}] Actuator ${id} will use the default topic name`, topic);
     }
     // subscribe to testBroker
     // this.testBroker.subscribe(topic);
@@ -418,7 +422,7 @@ class Device {
       objectId
     );
     this.actuators.push(newActuator);
-    console.log(`[${this.id}] added new actuator ${id} ${objectId}`);
+    this.logger.log(`[${this.id}] added new actuator ${id} ${objectId}`);
 
     return newActuator;
   }
@@ -435,7 +439,7 @@ class Device {
   removeActuator(id, objectId = null) {
     const actuatorIndex = findDevice(id, objectId, this.actuators);
     if (actuatorIndex === -1) {
-      console.error(`[${this.id}] Actuator ID ${id} ${objectId} does not exist!`);
+      this.logger.error(`[${this.id}] Actuator ID ${id} ${objectId} does not exist!`);
       return null;
     }
     const actuator = this.actuators[actuatorIndex];
@@ -445,7 +449,7 @@ class Device {
       actuator.stop();
     }
     this.actuators.splice(actuatorIndex, 1);
-    console.log(`[${this.id}] Actuator ID ${id} ${objectId} has been removed!`);
+    this.logger.log(`[${this.id}] Actuator ID ${id} ${objectId} has been removed!`);
   }
 
   /**
@@ -459,16 +463,16 @@ class Device {
     // Init new Dataset if needed
     // Add sensors
     // Add actuators
-    console.log(`[${this.id}] initializing...`);
+    this.logger.log(`[${this.id}] initializing...`);
     if (this.testBrokerConfig) {
       this.testBroker = new MQBus(this.testBrokerConfig);
       this.testBroker.connect((err) => {
         if (err) {
-          console.error(`[${this.id}] Failed to init the testBroker`);
-          console.error(err);
+          this.logger.error(`[${this.id}] Failed to init the testBroker`);
+          this.logger.error(err);
           return callback(err);
         }
-        console.log(`[${this.id}] Connected with test broker`);
+        this.logger.log(`[${this.id}] Connected with test broker`);
         this.testBroker.setupMessageHandler((topic, message, packet) =>
           this.testBrokerMessagehandler(topic, message, packet)
         );
@@ -476,9 +480,9 @@ class Device {
           this.productionBroker = new MQBus(this.productionBrokerConfig);
           this.productionBroker.connect((err2) => {
             if (err2) {
-              console.error('Failed to init production broker', err2);
+              this.logger.error('Failed to init production broker', err2);
             } else {
-              console.log(`[${this.id}] Connected with production broker`);
+              this.logger.log(`[${this.id}] Connected with production broker`);
               this.productionBroker.setupMessageHandler((topic, message, packet) =>
                 this.productionBrokerMessageHandler(topic, message, packet)
               );
@@ -486,7 +490,7 @@ class Device {
               this.sensorsConfig.map((sensorData) => {
                 const { id, scale, enable, objectId, dataSource } = sensorData;
                 if (enable && dataSource === DS_RECORDER) {
-                  console.log('Going to add a RECORDER sensor');
+                  this.logger.log('Going to add a RECORDER sensor');
                   let nbSensors = scale ? scale : 1;
                   if (nbSensors === 1) {
                     this.addSensor(id, sensorData, objectId);
@@ -501,28 +505,28 @@ class Device {
             }
           });
         } else {
-          console.log(`[${this.id}] NO RECORDING DATA`);
+          this.logger.log(`[${this.id}] NO RECORDING DATA`);
         }
 
         if (this.dataStorageConfig) {
-          this.dataStorage = new DataStorage(this.dataStorageConfig);
+          this.dataStorage = new DataStorage(this.dataStorageConfig, this.logger);
           this.dataStorage.connect((err3) => {
             if (err3) {
-              console.error('Failed to connect to data storage', err3);
+              this.logger.error('Failed to connect to data storage', err3);
             } else {
-              console.log(`[${this.id}] Connected to data storage`);
+              this.logger.log(`[${this.id}] Connected to data storage`);
               // Create report
               if (this.report && this.isFirstDevice) {
                 // Add the report
-                console.log(`[${this.id}] Going to add a new report`);
-                console.log(JSON.stringify(this.report));
+                this.logger.log(`[${this.id}] Going to add a new report`);
+                this.logger.log(JSON.stringify(this.report));
                 this.dataStorage.saveReport(this.report);
               }
               // Create Dataset
               if (this.newDatasetConfig) {
                 // Add the dataset for the current test
-                console.log(`[${this.id}] Going to add a new dataset`);
-                console.log(JSON.stringify(this.newDatasetConfig));
+                this.logger.log(`[${this.id}] Going to add a new dataset`);
+                this.logger.log(JSON.stringify(this.newDatasetConfig));
                 this.dataStorage.saveDataset(this.newDatasetConfig);
               }
               // Mark the startPlayingtime
@@ -538,8 +542,8 @@ class Device {
                   const firstEventTimestamp = events[0].timestamp;
                   if (startReplayingTime > firstEventTimestamp)
                     startReplayingTime = firstEventTimestamp;
-                  console.log(`[${this.id}] firstEventTimestamp: ${startReplayingTime}`);
-                  console.log(`[${this.id}] startReplayingTime: ${startReplayingTime}`);
+                  this.logger.log(`[${this.id}] firstEventTimestamp: ${startReplayingTime}`);
+                  this.logger.log(`[${this.id}] startReplayingTime: ${startReplayingTime}`);
                   if (this.isReplayingStreams) {
                     // REPLAY STREAM DATA
                     // Only select the event that has the topic matches with the list of upStreams
@@ -570,7 +574,7 @@ class Device {
                     this.sensorsConfig.map((sensorData) => {
                       const { id, topic, scale, enable, objectId, dataSource } = sensorData;
                       if (enable && dataSource === DS_DATASET && topic) {
-                        console.log('Going to add a DATASET sensor');
+                        this.logger.log('Going to add a DATASET sensor');
                         // filter the events match the sensor's topics
                         const matchedEvents = [];
                         for (let eventIndex = 0; eventIndex < events.length; eventIndex++) {
@@ -596,7 +600,7 @@ class Device {
             }
           });
         } else {
-          console.log(`[${this.id}] NO DATA STORAGE`);
+          this.logger.log(`[${this.id}] NO DATA STORAGE`);
         }
         this.status = ONLINE;
         if (this.isReplayingStreams) {
@@ -670,12 +674,12 @@ class Device {
         this.actuators.map((actuator) => actuator.start());
         break;
       case OFFLINE:
-        console.error(
+        this.logger.error(
           `[${this.id}] must be online before starting simulation: ${this.getStatus()}`
         );
         break;
       case SIMULATING:
-        console.log(`[${this.id}] is simulating!`);
+        this.logger.log(`[${this.id}] is simulating!`);
         break;
       default:
         break;
@@ -690,13 +694,13 @@ class Device {
   stop() {
     switch (this.getStatus()) {
       case OFFLINE:
-        console.log(`[${this.id}] is already offline!`);
+        this.logger.log(`[${this.id}] is already offline!`);
         return;
       case ONLINE:
         this.setStatus(OFFLINE);
         return;
       case SIMULATING:
-        console.log(`[${this.id}] going to stop the simulation!`);
+        this.logger.log(`[${this.id}] going to stop the simulation!`);
         this.sensors.map((sensor) => sensor.stop());
         this.actuators.map((actuator) => actuator.stop());
         this.setStatus(OFFLINE);

--- a/src/server/logger/index.js
+++ b/src/server/logger/index.js
@@ -1,5 +1,6 @@
 const { createLogger, format, transports } = require('winston');
 const { combine, timestamp, label, printf } = format;
+const util = require('util');
 
 /**
  * Define the format of the log
@@ -10,8 +11,21 @@ const myFormat = printf(({ level, message, label, timestamp }) => {
 
 /**
  * Get a logger
- * @param {String} label the label of the log
- * @param {String} filename The file name
+ *
+ * The returned logger owns its run's log file and nothing else: global console
+ * methods are never reassigned, so two runs started concurrently each write
+ * only their own lines to their own file, and code that does not receive a
+ * logger keeps writing to the process console.
+ *
+ * The returned object mirrors the console method signatures - every method
+ * accepts any number of arguments and formats them exactly like
+ * `console.log` does - so it can be used anywhere `console` was used before,
+ * including the common `logger.error('message', err)` pair whose error object
+ * the old single-argument console replacement silently dropped.
+ *
+ * @param {String} _label the label of the log
+ * @param {String} _filename The file name
+ * @returns {{log: Function, info: Function, warn: Function, error: Function, debug: Function, close: Function}}
  */
 const getLogger = (_label, _filename) => {
   const logger = createLogger({
@@ -23,14 +37,37 @@ const getLogger = (_label, _filename) => {
     logger.add(new transports.Console());
   }
 
-  console.log = (message) => {
-    logger.log('info', message);
-  };
-  console.error = (message) => {
-    logger.log('error', message);
+  let closed = false;
+  const write = (level, args) => {
+    if (closed) {
+      // The run that owned this file has stopped and its handle has been
+      // released. A late asynchronous callback may still try to log; keep the
+      // line visible on the process console rather than writing into a closed
+      // stream.
+      console[level === 'info' ? 'log' : level](...args);
+      return;
+    }
+    logger.log(level, util.format(...args));
   };
 
-  return logger;
+  return {
+    log: (...args) => write('info', args),
+    info: (...args) => write('info', args),
+    warn: (...args) => write('warn', args),
+    error: (...args) => write('error', args),
+    debug: (...args) => write('debug', args),
+    /**
+     * Release the file handle(s) of this run's logger. Idempotent; safe to
+     * call while late callbacks may still hold a reference.
+     */
+    close: () => {
+      if (closed) return;
+      closed = true;
+      for (const transport of logger.transports) {
+        if (typeof transport.close === 'function') transport.close();
+      }
+    },
+  };
 };
 
 module.exports = getLogger;

--- a/src/server/routes/data-recorders.js
+++ b/src/server/routes/data-recorders.js
@@ -93,6 +93,10 @@ let allDataRecorders = {};
 // reservation rather than a placeholder in `allDataRecorders`: `/stop` calls
 // `stop()` on whatever it finds there.
 const startingDataRecorders = new Set();
+// The logger of each running recorder, held here so `/stop` can release the
+// run's file handle once the recorder stops. The logger is passed explicitly
+// to the run; global console methods are never touched.
+const runLoggers = {};
 
 /**
  * Get the running status of data recorder
@@ -113,6 +117,11 @@ router.get(
     if (allDataRecorders[recorderId]) {
       allDataRecorders[recorderId].stop();
       allDataRecorders[recorderId] = null;
+    }
+    if (runLoggers[recorderId]) {
+      // The run has stopped: release its log file handle.
+      runLoggers[recorderId].close();
+      delete runLoggers[recorderId];
     }
     if (allRunningStatus[recorderId]) {
       allRunningStatus[recorderId].isRunning = false;
@@ -143,7 +152,8 @@ const startRecorder = (model, res, next) => {
       } else {
         const startedTime = Date.now();
         const logFile = `${name}_${startedTime}.log`;
-        getLogger('DATA-RECORDER', `${logsPath}${logFile}`);
+        const logger = getLogger('DATA-RECORDER', `${logsPath}${logFile}`);
+        runLoggers[recorderId] = logger;
         if (!dataStorage) {
           // use default data storage
           startingDataRecorders.add(recorderId);
@@ -154,12 +164,15 @@ const startRecorder = (model, res, next) => {
             if (err) {
               next(unavailable('No data storage', err));
             } else {
-              const dataRecorder = new DataRecorder({
-                ...model,
-                dataStorage: ds,
-              });
+              const dataRecorder = new DataRecorder(
+                {
+                  ...model,
+                  dataStorage: ds,
+                },
+                logger
+              );
               dataRecorder.start();
-              console.log('[data-recorders] A data recorder has been started ...');
+              logger.log('[data-recorders] A data recorder has been started ...');
               allDataRecorders[`${recorderId}`] = dataRecorder;
               allRunningStatus[`${recorderId}`] = {
                 isRunning: true,
@@ -175,9 +188,9 @@ const startRecorder = (model, res, next) => {
             }
           });
         } else {
-          const dataRecorder = new DataRecorder(model);
+          const dataRecorder = new DataRecorder(model, logger);
           dataRecorder.start();
-          console.log('[data-recorders] A data recorder has been started ...');
+          logger.log('[data-recorders] A data recorder has been started ...');
           allDataRecorders[`${recorderId}`] = dataRecorder;
           allRunningStatus[`${recorderId}`] = {
             isRunning: true,

--- a/src/server/routes/devops.js
+++ b/src/server/routes/devops.js
@@ -24,6 +24,10 @@ const { errorHandler, badRequest, internal, unavailable } = require('../middlewa
 let logsPath = `${__dirname}/../logs/test-campaigns/`;
 
 let runningStatus = null;
+// The logger of the running test campaign, held here so `/stop` can release
+// the run's file handle once the campaign stops. The logger is passed
+// explicitly to the run; global console methods are never touched.
+let runLogger = null;
 
 // ---------------------------------------------------------------------------
 // Validation schemas for the devops endpoints (issue #10)
@@ -152,8 +156,9 @@ router.get('/start', validate(), loadValidatedDevops, dbConnector, (req, res, ne
   if (!logFilePath) {
     return sendBadRequest(res, 'Invalid test campaign id');
   }
-  getLogger('TEST-CAMPAIGN', logFilePath);
-  console.log('[devops] A test campaign is going to be started ...');
+  const logger = getLogger('TEST-CAMPAIGN', logFilePath);
+  runLogger = logger;
+  logger.log('[devops] A test campaign is going to be started ...');
 
   if (dataStorage) {
     runningStatus = {
@@ -165,7 +170,7 @@ router.get('/start', validate(), loadValidatedDevops, dbConnector, (req, res, ne
       endTime: null,
       logFile,
     };
-    startTestCampaign(testCampaignId, dataStorage, webhookURL, evaluationParameters);
+    startTestCampaign(testCampaignId, dataStorage, webhookURL, evaluationParameters, logger);
     res.send({
       error: null,
       devops,
@@ -185,7 +190,7 @@ router.get('/start', validate(), loadValidatedDevops, dbConnector, (req, res, ne
           endTime: null,
           logFile,
         };
-        startTestCampaign(testCampaignId, ds, webhookURL, evaluationParameters);
+        startTestCampaign(testCampaignId, ds, webhookURL, evaluationParameters, logger);
         res.send({
           error: null,
           runningStatus,
@@ -201,6 +206,11 @@ router.get('/stop', validate(), (req, res, next) => {
     stopTestCampaign();
     runningStatus = null;
     copiedStatus.isRunning = false;
+  }
+  if (runLogger) {
+    // The run has stopped: release its log file handle.
+    runLogger.close();
+    runLogger = null;
   }
   res.send({
     error: null,

--- a/src/server/routes/simulation.js
+++ b/src/server/routes/simulation.js
@@ -93,6 +93,10 @@ let allSimulations = {};
 // placeholder in `allSimulations`: `/stop` calls `stop()` on whatever it finds
 // there.
 const startingSimulations = new Set();
+// The logger of each running simulation, held here so `/stop` can release the
+// run's file handle once the run stops. The logger is passed explicitly to the
+// run; global console methods are never touched.
+const runLoggers = {};
 // Start simulating a model
 
 const startSimulation = (model, options = {}, res, next, modelFileName = null) => {
@@ -126,7 +130,8 @@ const startSimulation = (model, options = {}, res, next, modelFileName = null) =
   } else {
     const startedTime = Date.now();
     const logFile = `${name}_${Date.now()}.log`;
-    getLogger('SIMULATION', `${logsPath}${logFile}`);
+    const logger = getLogger('SIMULATION', `${logsPath}${logFile}`);
+    runLoggers[simId] = logger;
     if (!model.dataStorage && !options.dataStorage) {
       // Use default data storage
       startingSimulations.add(simId);
@@ -137,7 +142,7 @@ const startSimulation = (model, options = {}, res, next, modelFileName = null) =
         if (err) {
           next(unavailable('No data storage', err));
         } else {
-          const simulation = new Simulation({ ...model, dataStorage: ds }, options);
+          const simulation = new Simulation({ ...model, dataStorage: ds }, options, null, logger);
           simulation.start();
           allSimulations[simId] = simulation;
           allSimulationStatus[simId] = {
@@ -158,7 +163,7 @@ const startSimulation = (model, options = {}, res, next, modelFileName = null) =
         }
       });
     } else {
-      const simulation = new Simulation(model, options);
+      const simulation = new Simulation(model, options, null, logger);
       simulation.start();
       allSimulations[simId] = simulation;
       allSimulationStatus[simId] = {
@@ -208,6 +213,11 @@ router.get(
     if (allSimulations[simId]) {
       allSimulations[simId].stop();
       allSimulations[simId] = null;
+    }
+    if (runLoggers[simId]) {
+      // The run has stopped: release its log file handle.
+      runLoggers[simId].close();
+      delete runLoggers[simId];
     }
     if (allSimulationStatus[simId]) {
       allSimulationStatus[simId].isRunning = false;

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,0 +1,310 @@
+/**
+ * Per-run logging (issue #15).
+ *
+ * Starting a run used to reassign the global console methods so every line on
+ * the server landed in whichever run started most recently, file handles of
+ * earlier runs were never released, and the single-argument replacement
+ * silently dropped the error object of the very common
+ * `console.error('message', err)` pair.
+ *
+ * These tests pin the replacement shape: the factory never touches the global
+ * console, each run writes only its own lines to its own file through a logger
+ * passed explicitly to the code that needs it, an error logged next to a
+ * message keeps its detail, and stopping a run releases its handle.
+ */
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const express = require('express');
+
+const getLogger = require('../src/server/logger');
+const simulationRouter = require('../src/server/routes/simulation');
+const { getObjectId } = require('../src/core/utils');
+
+/** A fresh temporary directory for one test's log files. */
+const tempLogDir = (name) => fs.mkdtempSync(path.join(os.tmpdir(), `tas-logger-${name}-`));
+
+/** Count the open file descriptors of this process (Linux only). */
+const openFdCount = () => {
+  try {
+    return fs.readdirSync('/proc/self/fd').length;
+  } catch (_) {
+    return null;
+  }
+};
+
+/**
+ * Wait until reading `file` satisfies `predicate`, polling because winston
+ * writes asynchronously. Resolves with the file content; rejects on timeout.
+ */
+const waitForFileContent = (file, predicate, timeout = 3000) =>
+  new Promise((resolve, reject) => {
+    const started = Date.now();
+    const tick = () => {
+      let content = '';
+      try {
+        content = fs.readFileSync(file, 'utf8');
+      } catch (_) {
+        /* not written yet */
+      }
+      if (predicate(content)) return resolve(content);
+      if (Date.now() - started > timeout) {
+        return reject(new Error(`log content never settled: ${JSON.stringify(content)}`));
+      }
+      setTimeout(tick, 50);
+    };
+    tick();
+  });
+
+/** Wait until `probe` returns a value that satisfies `predicate`. */
+const waitFor = (probe, predicate, timeout = 5000) =>
+  new Promise((resolve, reject) => {
+    const started = Date.now();
+    const tick = () => {
+      let value;
+      try {
+        value = probe();
+      } catch (_) {
+        value = null;
+      }
+      if (predicate(value)) return resolve(value);
+      if (Date.now() - started > timeout) {
+        return reject(new Error('condition never settled'));
+      }
+      setTimeout(tick, 50);
+    };
+    tick();
+  });
+
+// ---------------------------------------------------------------------------
+// The factory itself
+// ---------------------------------------------------------------------------
+
+test('the logger factory never reassigns global console methods', () => {
+  const dir = tempLogDir('no-hijack');
+  const before = { log: console.log, error: console.error, warn: console.warn };
+  const logger = getLogger('NO-HIJACK', path.join(dir, 'run.log'));
+  try {
+    assert.equal(console.log, before.log, 'console.log must stay native');
+    assert.equal(console.error, before.error, 'console.error must stay native');
+    assert.equal(console.warn, before.warn, 'console.warn must stay native');
+    // Logging through the returned logger must not quietly hijack either.
+    logger.log('a line');
+    assert.equal(console.log, before.log, 'logging must not reassign console.log');
+  } finally {
+    logger.close();
+  }
+});
+
+test('a message logged together with an error keeps the error detail', async () => {
+  const dir = tempLogDir('error-detail');
+  const file = path.join(dir, 'run.log');
+  const logger = getLogger('ERR-DETAIL', file);
+  try {
+    logger.error('Cannot update the score for report r-1', new Error('boom-detail'));
+    const content = await waitForFileContent(file, (c) => c.includes('boom-detail'));
+    assert.match(content, /Cannot update the score for report r-1/);
+    assert.match(content, /Error: boom-detail/, 'the error itself must be in the log');
+    assert.match(content, /\[ERR-DETAIL\]/, 'the label must identify the run');
+    assert.match(content, /error:/, 'the level must say this is an error');
+  } finally {
+    logger.close();
+  }
+});
+
+test('two runs started concurrently write only their own lines to their own files', async () => {
+  const dirA = tempLogDir('iso-a');
+  const dirB = tempLogDir('iso-b');
+  const fileA = path.join(dirA, 'a.log');
+  const fileB = path.join(dirB, 'b.log');
+  const loggerA = getLogger('RUN-A', fileA);
+  const loggerB = getLogger('RUN-B', fileB);
+  try {
+    loggerA.log('line-that-belongs-to-a');
+    loggerB.log('line-that-belongs-to-b');
+
+    const [contentA, contentB] = await Promise.all([
+      waitForFileContent(fileA, (c) => c.includes('line-that-belongs-to-a')),
+      waitForFileContent(fileB, (c) => c.includes('line-that-belongs-to-b')),
+    ]);
+    assert.ok(!contentA.includes('line-that-belongs-to-b'), 'A must not receive B lines');
+    assert.ok(!contentB.includes('line-that-belongs-to-a'), 'B must not receive A lines');
+    assert.match(contentA, /\[RUN-A\]/);
+    assert.match(contentB, /\[RUN-B\]/);
+  } finally {
+    loggerA.close();
+    loggerB.close();
+  }
+});
+
+test('closing a run logger releases its handle and stays safe afterwards', async () => {
+  if (openFdCount() === null) return; // /proc unavailable: nothing to count
+  const dir = tempLogDir('release');
+  const baseline = openFdCount();
+
+  for (let cycle = 0; cycle < 5; cycle += 1) {
+    const logger = getLogger(`CYCLE-${cycle}`, path.join(dir, `cycle-${cycle}.log`));
+    logger.log(`cycle ${cycle} wrote a line`);
+    await waitForFileContent(path.join(dir, `cycle-${cycle}.log`), (c) =>
+      c.includes(`cycle ${cycle} wrote a line`)
+    );
+    logger.close();
+    logger.close(); // idempotent
+  }
+
+  await waitFor(openFdCount, (n) => n !== null && n <= baseline);
+
+  // After close, a late asynchronous callback may still log: it must not
+  // throw, and the line must stay visible on the process console.
+  const late = getLogger('LATE', path.join(dir, 'late.log'));
+  late.log('before close');
+  await waitForFileContent(path.join(dir, 'late.log'), (c) => c.includes('before close'));
+  late.close();
+  const seen = [];
+  const original = console.log;
+  console.log = (...args) => seen.push(args.join(' '));
+  try {
+    late.log('after close');
+    late.error('late error after close');
+  } finally {
+    console.log = original;
+  }
+  assert.ok(
+    seen.some((l) => l.includes('after close')),
+    `post-close lines fall back to the console: ${seen.join(' | ')}`
+  );
+  assert.ok(
+    !seen.some((l) => l.includes('late error after close')),
+    'an error after close goes to console.error, not console.log'
+  );
+});
+
+test('the wrapper formats multiple arguments like console.log does', async () => {
+  const dir = tempLogDir('variadic');
+  const file = path.join(dir, 'run.log');
+  const logger = getLogger('VARIADIC', file);
+  try {
+    logger.log('values:', 42, { a: 1 });
+    const content = await waitForFileContent(file, (c) => c.includes('42'));
+    assert.match(content, /values: 42 \{ a: 1 \}/);
+  } finally {
+    logger.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Through the route that starts runs
+// ---------------------------------------------------------------------------
+
+describe('simulation routes', () => {
+  /** Minimal valid data storage: never connected, only satisfies validation. */
+  const dataStorageOption = () => ({
+    protocol: 'MONGODB',
+    connConfig: {
+      host: '127.0.0.1',
+      port: 27017,
+      username: null,
+      password: null,
+      dbname: 'tasdb',
+      options: null,
+    },
+  });
+
+  const buildApp = () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/simulation', simulationRouter);
+    return app.listen(0);
+  };
+
+  const startRun = (server, name) =>
+    fetch(`http://127.0.0.1:${server.address().port}/api/simulation/start`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: { name, devices: [] },
+        options: { dataStorage: dataStorageOption() },
+      }),
+    }).then(async (res) => ({ status: res.status, body: await res.json() }));
+
+  const stopRun = (server, name) =>
+    fetch(
+      `http://127.0.0.1:${server.address().port}/api/simulation/stop/${encodeURIComponent(
+        name
+      )}.json`
+    ).then((res) => res.status);
+
+  const simulationsLogDir = path.resolve(__dirname, '../src/server/logs/simulations');
+
+  const removeRunLogs = (name) => {
+    try {
+      for (const entry of fs.readdirSync(simulationsLogDir)) {
+        if (entry.startsWith(`${name}_`)) {
+          fs.unlinkSync(path.join(simulationsLogDir, entry));
+        }
+      }
+    } catch (_) {
+      /* directory absent */
+    }
+  };
+
+  test("two concurrent runs log into their own files, not each other's", async () => {
+    const server = buildApp();
+    const nameA = `logger-iso-a-${Date.now()}`;
+    const nameB = `logger-iso-b-${Date.now()}`;
+    try {
+      const [startA, startB] = await Promise.all([
+        startRun(server, nameA),
+        startRun(server, nameB),
+      ]);
+      assert.equal(startA.status, 200, JSON.stringify(startA.body));
+      assert.equal(startB.status, 200, JSON.stringify(startB.body));
+
+      const fileA = path.join(
+        simulationsLogDir,
+        startA.body.simulationStatus[getObjectId(nameA)].logFile
+      );
+      const fileB = path.join(
+        simulationsLogDir,
+        startB.body.simulationStatus[getObjectId(nameB)].logFile
+      );
+
+      const [contentA, contentB] = await Promise.all([
+        waitForFileContent(fileA, (c) => c.includes(nameA)),
+        waitForFileContent(fileB, (c) => c.includes(nameB)),
+      ]);
+      assert.match(contentA, /\[SIMULATION\]/);
+      assert.ok(!contentA.includes(nameB), 'run A must not receive run B lines');
+      assert.ok(!contentB.includes(nameA), 'run B must not receive run A lines');
+    } finally {
+      await stopRun(server, nameA);
+      await stopRun(server, nameB);
+      removeRunLogs(nameA);
+      removeRunLogs(nameB);
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  test('repeated start/stop cycles do not grow the number of open handles', async () => {
+    if (openFdCount() === null) return; // /proc unavailable: nothing to count
+    const server = buildApp();
+    const name = `logger-cycle-${Date.now()}`;
+    const cycles = 4;
+    try {
+      const baseline = openFdCount();
+      for (let cycle = 0; cycle < cycles; cycle += 1) {
+        const start = await startRun(server, `${name}-${cycle}`);
+        assert.equal(start.status, 200, JSON.stringify(start.body));
+        const stopped = await stopRun(server, `${name}-${cycle}`);
+        assert.equal(stopped, 200);
+        removeRunLogs(`${name}-${cycle}`);
+      }
+      await waitFor(openFdCount, (n) => n !== null && n <= baseline);
+    } finally {
+      for (let cycle = 0; cycle < cycles; cycle += 1) removeRunLogs(`${name}-${cycle}`);
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+});


### PR DESCRIPTION
Closes #15

## Summary

Starting a simulation, a data recorder or a test campaign reassigned the global `console.log`/`console.error`, so concurrent runs overwrote each other's redirection, every earlier run leaked its file handle, and the single-argument replacement silently discarded the error object of the very common `console.error('message', err)` pair — throwing away error detail across the server. Each run now obtains its own logger explicitly and passes it to the code that needs it; the global console is never touched.

## Approach

The logger factory (`src/server/logger/index.js`) no longer reassigns anything. It returns a per-run wrapper over winston whose methods accept any number of arguments and format them exactly like `console.log` does (via `util.format`), so an error logged next to a message keeps its full detail, and a `close()` that releases the run's file handles. After `close()`, late asynchronous callbacks fall back to the process console instead of writing into a closed stream.

The three starting routes create one logger per run and pass it explicitly down the run chain — `Simulation` → `Thing` → `DataStorage`, `DataRecorder` → `DRecorder` → `DataStorage`, and `TestCampaign` → `TestCase` → `Simulation` (a campaign shares its logger with everything it owns). Every console call site in those classes was migrated to the injected logger, with split `console.error(message)` + `console.error(err)` pairs merged into single variadic calls so nothing diagnostic is lost. The stop handlers release each run's handle. Standalone CLI entry points and non-run infrastructure keep writing to the process console.

## Decision Record

- **Root cause:** `getLogger` assigned single-argument replacements to the global `console.log`/`console.error` on every start, so all output followed the most recent run, handles were never released, and second arguments (error objects) were dropped.
- **Options considered:** Option 1 — remove only the console reassignment; Option 2 — per-run logger injection through the run chain with variadic formatting and handle release; Option 3 — inject a logger through every module in `src/core` (~45 files, ~260 sites).
- **Options rejected:** Option 1 — run log files would receive nothing at all, failing the acceptance criteria; Option 3 — a large mechanical diff with high regression risk against the test baseline for marginal gain: leaf modules (sensors, buses) still emit to stdout, so no detail is discarded, and the deeper cascade can be a follow-up.
- **Selected:** Option 2 (balanced).
- **Reproduction evidence:** pre-fix, a probe showed `console.log !== original` after one `getLogger` call, an error passed as the second argument of `console.error` never reached the file, and a first run's logger threw once a second run started. These became the regression tests in `test/logger.test.js`.

## Changes

| File | Change |
|------|--------|
| `src/server/logger/index.js` | No console reassignment; variadic `util.format` wrapper (`log/info/warn/error/debug`) plus idempotent `close()`; post-close calls fall back to the process console |
| `src/server/routes/simulation.js` | Creates the run's logger, passes it to `Simulation`, closes it on `/stop` |
| `src/server/routes/data-recorders.js` | Same for recorders; run-scoped messages now go through the run logger |
| `src/server/routes/devops.js` | Same for test campaigns |
| `src/core/simulation/Simulation.js` | Accepts a logger; all call sites migrated; evaluation errors now logged with their error object; passes its logger into each `Thing` |
| `src/core/things/Thing.js` | Accepts a logger; 41 call sites migrated; passes its logger into `DataStorage` |
| `src/core/communications/DataStorage.js` | Accepts a logger; 20 call sites migrated; split error/object lines merged into single variadic calls |
| `src/core/data-recorder/index.js`, `src/core/data-recorder/DRecorder.js` | Accept and thread the logger |
| `src/core/devops-flow/index.js` | `startTestCampaign` accepts and threads the logger |
| `src/core/test-campaigns/TestCampaign.js`, `src/core/test-campaigns/TestCase.js` | Accept and share the campaign logger down to every `TestCase` and `Simulation` |
| `test/logger.test.js` | New: factory never hijacks the console; concurrent-run isolation; error-detail preservation; handle release across repeated runs; post-close safety; route-level concurrency isolation and start/stop fd stability |

## Test Results

Full suite on the committed tree: **300 tests, 296 pass, 3 fail, 1 skipped**. The 3 failures are the pre-existing database-host-dependent e2e cases (the committed `data-storage.json` points at host `mongodb`, unreachable locally); they fail identically on the base commit. The new suite adds 7 tests, all passing. `npm run lint`: 0 errors (2 pre-existing warnings in `routes/auth.js`). Prettier check clean.

## Acceptance Criteria Verification

| Criterion | Evidence |
|-----------|----------|
| Global console methods are no longer reassigned anywhere | `rg 'console\.(log\|error\|...)\s*=' src/server src/core` is empty; pinned by "the logger factory never reassigns global console methods" |
| Each run writes to its own logger, passed explicitly | Routes create one logger per run and pass it through Simulation/Thing/DataStorage, DataRecorder/DRecorder, TestCampaign/TestCase/Simulation |
| Two concurrent runs write only their own lines to their own files | Unit test with two loggers + route-level test starting two simulations concurrently and asserting cross-contamination absence |
| Logging a message together with an error preserves the detail | Wrapper formats via `util.format`; test asserts the error message and stack reach the file; migrated call sites pass the error object |
| Log file handles are released when a run stops, no growth across repeated runs | Stop handlers call `close()`; tests count open fds across 5 sequential loggers and 4 route-level start/stop cycles and require return to baseline |
| Existing log call sites migrated without losing diagnostic detail | All run-chain call sites migrated (85 sites); previously dropped error objects are now part of the same line |

<!-- gitissue:qa v1 cycles=2 clean=true head=9cecb47870a4bcc39a78ce00e1be8a9c99bd4fcd -->