### PR TITLE
fix(ci): strip release tag prefix exactly and modernise image publish workflow (#19)

### DIFF
--- a/.github/workflows/build-docker-container.yml
+++ b/.github/workflows/build-docker-container.yml
@@ -4,13 +4,46 @@ on:
   push:
     tags: ['v*'] # Push events to matching v*, i.e. v1.0, v20.15.10
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
-  build:
+  test:
+    name: Test suite gate
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          # Match the runtime the shipped container image uses.
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The compiled client bundle is not committed (issue #42); build it
+      # before the suite, mirroring e2e-security.yml.
+      - name: Build the dashboard client
+        run: cd src/client && npm install && npm run build
+
+      # A failing suite aborts the workflow here — nothing is published.
+      - name: Run the full test suite
+        run: npm test
+
+  publish:
+    name: Build, scan and publish the image
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
 
       - name: Login to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -19,15 +52,45 @@ jobs:
         env:
           GITHUB_REF: ${{ github.ref }}
         run: |
-          cat <<EOF >> $GITHUB_ENV
-          PACKAGE_VERSION=$(echo $GITHUB_REF | tr -d 'refs/tags/' )
-          EOF
+          # Strip the refs/tags/ prefix exactly. Never delete characters:
+          # the old `tr -d 'refs/tags/'` mangled any tag containing
+          # r, e, f, s, t, a or g (issue #19).
+          PACKAGE_VERSION="${GITHUB_REF#refs/tags/}"
+          if [ -z "$PACKAGE_VERSION" ] || [ "$PACKAGE_VERSION" = "$GITHUB_REF" ]; then
+            echo "Could not derive PACKAGE_VERSION from GITHUB_REF='$GITHUB_REF'" >&2
+            exit 1
+          fi
+          # Only a stable vX.Y.Z — no pre-release suffix — may move the
+          # floating latest tag.
+          if [[ "$PACKAGE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            IS_STABLE=true
+          else
+            IS_STABLE=false
+          fi
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
+          echo "IS_STABLE=$IS_STABLE" >> "$GITHUB_ENV"
 
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v2
+      - name: Build Docker image
+        run: |
+          docker build \
+            -t "ghcr.io/montimage/tas:${PACKAGE_VERSION}" \
+            -t "tas:release-scan" \
+            .
+
+      - name: Scan the built image for known vulnerabilities
+        uses: aquasecurity/trivy-action@0.36.0
         with:
-          context: .
-          push: true
-          tags: |
-            ghcr.io/montimage/tas:${{ env.PACKAGE_VERSION }}
-            ghcr.io/montimage/tas:latest
+          image-ref: 'tas:release-scan'
+          format: table
+          exit-code: '0'
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+
+      - name: Push version tag
+        run: docker push "ghcr.io/montimage/tas:${PACKAGE_VERSION}"
+
+      # Pre-releases publish under their exact tag only; latest keeps
+      # pointing at the newest stable release.
+      - name: Push latest tag
+        if: env.IS_STABLE == 'true'
+        run: docker push "ghcr.io/montimage/tas:latest"

--- a/test/release-workflow.test.js
+++ b/test/release-workflow.test.js
@@ -1,0 +1,111 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const { execFileSync } = require('node:child_process');
+
+const REPO = `${__dirname}/..`;
+const WORKFLOW_PATH = `${REPO}/.github/workflows/build-docker-container.yml`;
+const rawWorkflow = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+// Executable content only — comments may document the old bug.
+const workflow = rawWorkflow
+  .split('\n')
+  .map((l) => l.replace(/(^|\s)#.*$/, '$1'))
+  .join('\n');
+
+// The publish job must be gated on the test job.
+test('publishing is gated on a passing test suite', () => {
+  const lines = workflow.split('\n');
+  const start = lines.findIndex((l) => l.trim() === 'publish:');
+  assert.ok(start !== -1, 'workflow must define a publish job');
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^ {2}\S+:\s*$/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  const publish = lines.slice(start + 1, end).join('\n');
+  assert.match(
+    publish,
+    /^ {4}needs:\s*test\s*$/m,
+    'publish job must declare needs: test so a failing suite blocks the release'
+  );
+  assert.match(workflow, /run:\s*npm test/, 'the gate must run the full test suite');
+});
+
+// Issue #19: the old extraction was `tr -d 'refs/tags/'`, which deletes every
+// occurrence of those characters instead of stripping the prefix.
+test('version extraction strips the refs/tags/ prefix and never deletes characters', () => {
+  assert.ok(!/tr -d/.test(workflow), 'character-deletion extraction must be gone');
+  const line = workflow
+    .split('\n')
+    .find((l) => l.includes('PACKAGE_VERSION=') && l.includes('#refs/tags/'));
+  assert.ok(line, 'extraction must use the ${GITHUB_REF#refs/tags/} prefix strip');
+
+  // Behavioural check: run the exact expression from the workflow against
+  // tags the old code mangled.
+  const samples = [
+    ['refs/tags/v1.0.2', 'v1.0.2'],
+    ['refs/tags/v1.2.0-beta.1', 'v1.2.0-beta.1'],
+    ['refs/tags/v3.0.0-greatest', 'v3.0.0-greatest'],
+    ['refs/tags/v0.9.9-restfest-agate', 'v0.9.9-restfest-agate'],
+  ];
+  for (const [ref, expected] of samples) {
+    const got = execFileSync('bash', ['-c', `${line.trim()}; echo "$PACKAGE_VERSION"`], {
+      env: { ...process.env, GITHUB_REF: ref },
+    })
+      .toString()
+      .trim();
+    assert.strictEqual(got, expected, `${ref} must extract to ${expected}, got ${got}`);
+  }
+});
+
+// Only stable vX.Y.Z releases may move the floating latest tag.
+test('floating latest tag moves only for stable releases', () => {
+  const m =
+    workflow.match(/"\$PACKAGE_VERSION"=~(\/\^[^\s/]+\/)/) || workflow.match(/=~\s*(\^\S+)/);
+  assert.ok(m, 'a stable-release regex must guard the latest tag');
+  const stable = new RegExp(m[1].replace(/^\/\^/, '^').replace(/\/$/, ''), '');
+  assert.match(stable.source, /\^v\\?\[\d/, 'regex must anchor on vX.Y.Z');
+  for (const [version, expectStable] of [
+    ['v1.0.2', true],
+    ['v10.20.30', true],
+    ['v1.2.0-beta.1', false],
+    ['v2.0.0-rc.1', false],
+    ['v3.0.0-greatest', false],
+  ]) {
+    assert.strictEqual(
+      stable.test(version),
+      expectStable,
+      `${version} must ${expectStable ? '' : 'not '}count as stable`
+    );
+  }
+  const latestStep = workflow.split('\n').findIndex((l) => l.trim() === '- name: Push latest tag');
+  assert.ok(latestStep !== -1, 'latest push must be its own step');
+  const stepBody = workflow
+    .split('\n')
+    .slice(latestStep, latestStep + 5)
+    .join('\n');
+  assert.match(stepBody, /if:.*IS_STABLE/, 'latest push must be guarded by IS_STABLE');
+});
+
+test('actions are pinned to current major versions, never floating or ancient refs', () => {
+  const uses = [...workflow.matchAll(/^\s*uses:\s*(\S+)\s*$/gm)].map((m) => m[1]);
+  assert.ok(uses.length >= 3, 'expected at least three action references');
+  for (const ref of uses) {
+    assert.doesNotMatch(ref, /@(v?[0-5]|master|main)$/, `${ref} is not a current pin`);
+  }
+  assert.ok(
+    !uses.some((r) => r.startsWith('docker/build-push-action@')),
+    'plain docker CLI is used for build/push'
+  );
+});
+
+test('the built image is scanned for known vulnerabilities', () => {
+  assert.match(workflow, /aquasecurity\/trivy-action@\d/, 'Trivy scan must run in the workflow');
+  assert.match(
+    workflow,
+    /image-ref:\s*['"]?tas:release-scan/,
+    'the scan must target the built image'
+  );
+});


### PR DESCRIPTION
## Summary

The release workflow derived the image version with `tr -d 'refs/tags/'` — a
character-deletion that removes *every* `r`, `e`, `f`, `s`, `t`, `a`, `g` from
the ref, not the prefix. It happened to work for tags like `v1.0.2` but silently
mangles any tag containing those characters (`v1.2.0-beta.1` → `v1.2.0-b.1`,
`v3.0.0-greatest` → `v3.0.0-`), publishing images under wrong versions.
The workflow also pinned actions several majors behind, published with no test
gate, and moved the floating `latest` tag on every release including
pre-releases.

Closes #19

## Approach

Rewrote `.github/workflows/build-docker-container.yml` as a two-job pipeline:

1. **`test`** — checkout, Node 22 (matching the image runtime), `npm ci`,
   dashboard client build, full `npm test`. Mirrors `e2e-security.yml`.
2. **`publish`** (`needs: test`) — version derived by exact prefix strip
   `${GITHUB_REF#refs/tags/}`; stable check via `^v[0-9]+\.[0-9]+\.[0-9]+$`;
   build once with two local tags, Trivy scan of the built image, push the
   version tag always and `latest` only when `IS_STABLE == 'true'`.

Actions pinned to current majors verified against the GitHub API at
implementation time: `actions/checkout@v7`, `actions/setup-node@v7`,
`aquasecurity/trivy-action@0.36.0`. Build/push uses the plain Docker CLI
(the pattern already proven in this repo by `e2e-security.yml`), which also
retires the 2024-era `docker/build-push-action@v2` pin.

## Decision Record

- **Selected option:** single-workflow modernisation (minimal/balanced). A
  split reusable-workflow design adds surface area with no benefit for one
  release pipeline; rejected.
- **Bug reproduction (red):** `echo refs/tags/v1.2.0-beta.1 | tr -d 'refs/tags/'`
  → `v1.2.0-b.1`; `refs/tags/v3.0.0-greatest` → `v3.0.0-`. Prefix strip returns
  both exactly. Converted into regression tests that execute the expression
  pulled from the workflow file itself.
- **CVE scan is non-blocking** (`exit-code: '0'`, `ignore-unfixed: true`,
  CRITICAL/HIGH): the issue requires scanning to be *part of the workflow*
  (medium priority), while the hard publish gate is the test suite (high).
  Gating releases on unfixed base-image CVEs would brick all releases on
  findings outside this repo's control; results are printed in the job log for
  triage. Revisit as a follow-up if maintainers want an enforced threshold.
- **Pre-existing test failures:** 3 server-side e2e tests fail identically on
  the clean `master` baseline (session logout, validation short-circuit,
  DB-unavailable 503) — environment-dependent, unrelated to this CI change,
  left untouched per atomic-PR scope.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/build-docker-container.yml` | Exact prefix-strip extraction; `test` job gating publish; stable-only `latest`; current action pins; Trivy scan; least-privilege `permissions` |
| `test/release-workflow.test.js` | New: 5 regression tests (extraction behaviour executed in bash, stable/pre-release classification, needs-gate, pin hygiene, scan presence) |

## Test Results

- New suite `node --test test/release-workflow.test.js`: **5/5 pass**, verified
  red (5/5 fail) against the pre-fix workflow.
- Full suite at HEAD `956a473`: **307 pass / 3 fail / 1 skipped** of 311 — the
  same 3 failures as the untouched `master` baseline (302/306), i.e. no
  regressions introduced.

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Published version equals the tag with its prefix stripped, incl. pre-release suffixes | ✅ | `${GITHUB_REF#refs/tags/}` + `test/release-workflow.test.js` "version extraction strips…" executing the workflow's own expression on `v1.0.2`, `v1.2.0-beta.1`, `v3.0.0-greatest`, `v0.9.9-restfest-agate` |
| Workflow actions pinned to currently-supported major versions | ✅ | `checkout@v7`, `setup-node@v7`, `trivy-action@0.36.0` (current majors confirmed via GitHub API); test asserts no ancient/floating pins |
| A failing test suite prevents publishing | ✅ | `publish` job declares `needs: test`; suite runs before any build/push step |
| Floating `latest` moved only by stable releases | ✅ | `IS_STABLE` regex guard `^v[0-9]+\.[0-9]+\.[0-9]+$`; `Push latest tag` step has `if: env.IS_STABLE == 'true'`; classification covered by tests |
| Built image scanned for known vulnerabilities in the workflow | ✅ | `aquasecurity/trivy-action@0.36.0` scans `tas:release-scan` (the just-built image), CRITICAL/HIGH, table output |

<!-- gitissue:qa v1 head=956a473b6c025ff90211eea89a64e5bbf82abcf3 profile=light cycles=1 review=clean tests=307@956a473b6c025ff90211eea89a64e5bbf82abcf3 ui=none -->
