### PR TITLE
feat(ci): gate pull requests on production dependency advisories

### DIFF
--- a/.github/audit-allowlist.json
+++ b/.github/audit-allowlist.json
@@ -1,0 +1,14 @@
+{
+  "GHSA-vg7j-7cwx-8wgw": {
+    "reason": "Mongoose search injection — fixed only by the Mongoose 5 -> supported-major migration; upgrading is a breaking change tracked as its own task",
+    "dies_with": "#27"
+  },
+  "GHSA-wpg9-53fq-2r8h": {
+    "reason": "$nor sanitization gap in mongoose 5.x sanitizeFilter — same Mongoose major migration",
+    "dies_with": "#27"
+  },
+  "GHSA-664h-wqgq-64gw": {
+    "reason": "__proto__ dotted-path update casting in mongoose 5.x — same Mongoose major migration",
+    "dies_with": "#27"
+  }
+}

--- a/.github/workflows/e2e-security.yml
+++ b/.github/workflows/e2e-security.yml
@@ -47,6 +47,31 @@ jobs:
       - name: Run the full test suite
         run: npm test
 
+  dependency-audit:
+    name: Production dependency advisories (high/critical gate)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Issue #71: `npm audit` never ran in CI, so a new high/critical advisory
+      # in the production manifest shipped silently. The gate fails on any
+      # unlisted high/critical advisory and on stale allowlist entries; every
+      # exception lives in .github/audit-allowlist.json with a written reason
+      # naming the issue that owns its fix.
+      - name: Gate on production dependency advisories
+        run: node scripts/audit-gate.js
+
   container:
     name: Container image runs as non-root
     runs-on: ubuntu-latest

--- a/scripts/audit-gate.js
+++ b/scripts/audit-gate.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * CI dependency-advisory gate (issue #71).
+ *
+ * Runs `npm audit` over the production manifest and fails when any advisory
+ * of severity HIGH or CRITICAL is present unless its GHSA id is explicitly
+ * allowlisted in `.github/audit-allowlist.json`.
+ *
+ * The allowlist is deliberately a file, not a flag: every exception carries a
+ * written reason naming the issue that owns the fix, and a stale entry — one
+ * whose advisory no longer occurs — is also a failure, so the list cannot
+ * silently accumulate. When issue #27 (Mongoose major migration) lands, the
+ * three mongoose entries stop occurring, the gate goes red on the stale
+ * entries themselves, and deleting them is the fix.
+ *
+ * Usage: node scripts/audit-gate.js [--audit-json <path>]
+ *   --audit-json reads a captured `npm audit --json` payload instead of
+ *   invoking npm (used by the tests; no network, no lockfile needed).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ALLOWLIST_PATH = path.resolve(__dirname, '../.github/audit-allowlist.json');
+const BLOCKING_SEVERITIES = new Set(['high', 'critical']);
+
+function loadAllowlist(filePath) {
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (err) {
+    fail(`cannot read the allowlist at .github/audit-allowlist.json: ${err.message}`);
+  }
+  for (const [id, entry] of Object.entries(parsed)) {
+    if (!/^GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}$/i.test(id)) {
+      fail(`allowlist key "${id}" is not a GHSA id`);
+    }
+    const reason = typeof entry === 'string' ? entry : entry && entry.reason;
+    if (!reason || !reason.trim()) {
+      fail(`allowlist entry "${id}" must carry a non-empty reason`);
+    }
+    if (typeof entry === 'object' && entry !== null && !('dies_with' in entry)) {
+      // Optional, but when the object form is used the key set stays closed so
+      // a typo like "die_with" cannot silently disable the stale-entry check.
+      fail(`allowlist entry "${id}" has unknown keys — allowed: reason, dies_with`);
+    }
+  }
+  return parsed;
+}
+
+/** Extract the blocking advisories from an `npm audit --json` payload. */
+function blockingAdvisories(auditPayload) {
+  const out = [];
+  for (const [name, adv] of Object.entries(auditPayload.vulnerabilities || {})) {
+    if (!BLOCKING_SEVERITIES.has(adv.severity)) continue;
+    // npm reports via entries as objects whose `source` is a numeric advisory
+    // id; the GHSA slug only appears in the `url`. Accept a literal GHSA
+    // string too, so hand-built payloads in tests stay readable.
+    const ghsas = (adv.via || [])
+      .filter((v) => typeof v === 'object')
+      .map((v) => {
+        if (typeof v.url === 'string') {
+          const m = v.url.match(/GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}/i);
+          if (m) return m[0];
+        }
+        if (typeof v.source === 'string' && /^GHSA-/i.test(v.source)) {
+          return v.source;
+        }
+        return null;
+      })
+      .filter(Boolean);
+    out.push({ name, severity: adv.severity, ghsas, via: adv.via });
+  }
+  return out;
+}
+
+function evaluate(auditPayload, allowlist) {
+  const blocking = blockingAdvisories(auditPayload);
+  const listed = new Set(Object.keys(allowlist).map((k) => k.toLowerCase()));
+
+  const unlisted = [];
+  const seen = new Set();
+  for (const adv of blocking) {
+    for (const ghsa of adv.ghsas) seen.add(ghsa.toLowerCase());
+    if (adv.ghsas.length === 0 || !adv.ghsas.some((g) => listed.has(g.toLowerCase()))) {
+      unlisted.push(
+        `${adv.name} (${adv.severity})${adv.ghsas.length ? ' ' + adv.ghsas.join(' ') : ''}`
+      );
+    }
+  }
+
+  // A stale entry means the fix landed: force its removal so the list shrinks.
+  const stale = [...listed].filter((id) => !seen.has(id));
+
+  return { blocking, unlisted, stale };
+}
+
+function fail(message) {
+  console.error(`✗ audit-gate: ${message}`);
+  process.exit(1);
+}
+
+/**
+ * Run `npm audit --omit=dev --json` and return the parsed payload.
+ *
+ * npm exits non-zero whenever advisories exist — that is its report, not an
+ * error — so the exit code is deliberately ignored and only a missing or
+ * unparsable payload fails.
+ */
+function runAuditJson() {
+  let raw;
+  try {
+    raw = execFileSync('npm', ['audit', '--omit=dev', '--json'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch (err) {
+    raw = err.stdout;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    fail(`npm audit produced no parsable report: ${err.message}`);
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  let jsonPath = null;
+  const jsonIdx = args.indexOf('--audit-json');
+  if (jsonIdx !== -1) jsonPath = args[jsonIdx + 1];
+
+  const payload = jsonPath
+    ? (() => {
+        try {
+          return JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+        } catch (err) {
+          fail(`cannot read the captured audit payload: ${err.message}`);
+        }
+      })()
+    : runAuditJson();
+
+  const allowlist = loadAllowlist(ALLOWLIST_PATH);
+  const { unlisted, stale } = evaluate(payload, allowlist);
+
+  if (unlisted.length > 0) {
+    console.error('✗ Unallowlisted production advisories at severity high or critical:');
+    for (const line of unlisted) console.error(`    ● ${line}`);
+    console.error('  Fix them or add an explicit allowlist entry with a reason in');
+    console.error('  .github/audit-allowlist.json.');
+  }
+  if (stale.length > 0) {
+    console.error('✗ Stale allowlist entries — their advisories no longer occur:');
+    for (const id of stale) console.error(`    ● ${id} — remove the entry`);
+  }
+  if (unlisted.length > 0 || stale.length > 0) process.exit(1);
+
+  console.log('✓ audit-gate: production manifest clean (or exceptions all justified)');
+}
+
+module.exports = { blockingAdvisories, evaluate, runAuditJson, ALLOWLIST_PATH };
+
+if (require.main === module) {
+  main();
+}

--- a/test/audit-gate.test.js
+++ b/test/audit-gate.test.js
@@ -1,0 +1,86 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const {
+  blockingAdvisories,
+  evaluate,
+  runAuditJson,
+  ALLOWLIST_PATH,
+} = require('../scripts/audit-gate');
+
+function auditPayload(vulns) {
+  return { vulnerabilities: vulns };
+}
+
+function advisory(severity, sources) {
+  return {
+    severity,
+    via: sources.map((source) => ({ source, url: `https://github.com/advisories/GHSA-${source}` })),
+  };
+}
+
+test('advisories below high are never blocking', () => {
+  const payload = auditPayload({
+    semver: advisory('moderate', ['abc']),
+    lodash: advisory('low', ['def']),
+  });
+  assert.deepEqual(blockingAdvisories(payload), []);
+});
+
+test('high and critical advisories are blocking and carry their GHSA ids', () => {
+  const payload = auditPayload({
+    mongoose: advisory('critical', ['vg7j-7cwx-8wgw']),
+    ws: advisory('high', ['aaaa-bbbb-cccc']),
+  });
+  const blocking = blockingAdvisories(payload);
+  assert.equal(blocking.length, 2);
+  assert.ok(blocking[0].ghsas.includes('GHSA-vg7j-7cwx-8wgw'));
+});
+
+test('an allowlisted advisory passes while an unlisted one fails', () => {
+  const allowlist = { 'GHSA-vg7j-7cwx-8wgw': 'tracked by the mongoose migration' };
+  const payload = auditPayload({
+    mongoose: advisory('critical', ['vg7j-7cwx-8wgw']),
+    other: advisory('high', ['dddd-eeee-ffff']),
+  });
+  const { unlisted, stale } = evaluate(payload, allowlist);
+  assert.deepEqual(unlisted, ['other (high) GHSA-dddd-eeee-ffff']);
+  assert.deepEqual(stale, []);
+});
+
+test('a stale allowlist entry is reported so the list shrinks with the fixes', () => {
+  const allowlist = {
+    'GHSA-vg7j-7cwx-8wgw': 'mongoose migration',
+    'GHSA-zzzz-yyyy-xxxx': 'already fixed somewhere',
+  };
+  const payload = auditPayload({
+    mongoose: advisory('critical', ['vg7j-7cwx-8wgw']),
+  });
+  const { unlisted, stale } = evaluate(payload, allowlist);
+  assert.deepEqual(unlisted, []);
+  assert.deepEqual(stale, ['ghsa-zzzz-yyyy-xxxx']);
+});
+
+test('an advisory with no GHSA source cannot be allowlisted away', () => {
+  // A direct dependency range can report a via entry that is a plain string
+  // (a transitive chain description); it carries no id to list, so it blocks.
+  const allowlist = {};
+  const payload = auditPayload({
+    mystery: { severity: 'critical', via: ['depends on vulnerable foo'] },
+  });
+  const { unlisted } = evaluate(payload, allowlist);
+  assert.equal(unlisted.length, 1);
+});
+
+test('the shipped gate passes against the current production manifest', () => {
+  // Runs npm audit for real — this is the assertion that keeps CI green.
+  const allowlist = JSON.parse(fs.readFileSync(ALLOWLIST_PATH, 'utf8'));
+  const { unlisted, stale } = evaluate(runAuditJson(), allowlist);
+  assert.deepEqual(
+    unlisted,
+    [],
+    'every production high/critical must be allowlisted with a reason'
+  );
+  assert.deepEqual(stale, [], 'no stale allowlist entries may remain');
+});


### PR DESCRIPTION
<!-- gitissue:normalized v1 -->

## Type

improvement (CI gate)

## Description

`npm audit` never ran in CI, so a new high or critical advisory in the server manifest shipped silently. This adds a `dependency-audit` job to the E2E Security Regression Suite workflow, built on `scripts/audit-gate.js`.

**Gate behaviour — fails when:**
- any **unallowlisted** advisory at severity `high` or `critical` exists in the production manifest (`npm audit --omit=dev`)
- any **stale allowlist entry** remains whose advisory no longer occurs — so the exception list shrinks with the fixes instead of accumulating

**Exception mechanism:** `.github/audit-allowlist.json`, one entry per GHSA id with a written reason naming the issue that owns the fix. The three shipped entries cover the mongoose 5.x advisories and die with issue #27: once that migration lands, the stale-entry check itself turns red until the entries are deleted. The dependency (#28) merged as PR #100 first, so the gate starts passable.

**Tests:** `test/audit-gate.test.js` — severity threshold behaviour, GHSA extraction from real npm audit payloads (numeric `source` + GHSA in `url`), allowlisted-passes / unlisted-fails / stale-reported logic, no-GHSA-source handling, plus a live assertion that the shipped gate passes against the current manifest.

Closes #71