### PR TITLE
feat(ci): run lint on pull requests and enable dependabot (#24)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Issue #24 (AC5): automated dependency update proposals for both manifests.
+version: 2
+updates:
+  # Root manifest — the server runtime and its dev tooling.
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  # Dashboard client manifest (src/client/package.json).
+  - package-ecosystem: 'npm'
+    directory: '/src/client'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/.github/workflows/e2e-security.yml
+++ b/.github/workflows/e2e-security.yml
@@ -62,3 +62,26 @@ jobs:
         run: node --test test/e2e/container-nonroot.test.js
         env:
           TAS_IMAGE: montimage/tas:e2e
+
+  lint:
+    name: Lint (eslint)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Issue #24: the suite gate exercised behaviour, but nothing ran static
+      # analysis on a pull request. A dedicated job rather than a step of the
+      # suite job, so lint reports independently of the database-backed suites.
+      - name: Run eslint
+        run: npm run lint

--- a/README.md
+++ b/README.md
@@ -221,7 +221,9 @@ TAS_IMAGE=montimage/tas:e2e node --test test/e2e/container-nonroot.test.js
 These assertions require the security fixes (path containment, CORS allowlist,
 body-size and rate limits, non-root image) to be present, and are enforced in
 CI on every push to `master` and every pull request via
-`.github/workflows/e2e-security.yml`.
+`.github/workflows/e2e-security.yml`, which also runs `npm run lint`. Updates
+for both dependency manifests (the server root and the dashboard client) are
+proposed weekly by Dependabot via `.github/dependabot.yml`.
 
 `npm test` runs everything under `test/`, including the end-to-end files, and
 is serialised with the same `--test-concurrency=1` for the same reason. Some

--- a/test/ci-gate.test.js
+++ b/test/ci-gate.test.js
@@ -1,0 +1,91 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+
+const REPO = `${__dirname}/..`;
+
+// Executable content only — comments may document history or old behaviour.
+const stripComments = (raw) =>
+  raw
+    .split('\n')
+    .map((l) => l.replace(/(^|\s)#.*$/, '$1'))
+    .join('\n');
+
+const readWorkflow = (name) => fs.readFileSync(`${REPO}/.github/workflows/${name}`, 'utf8');
+
+const ciWorkflow = stripComments(readWorkflow('e2e-security.yml'));
+const ciLines = ciWorkflow.split('\n');
+
+/** Slice the body of a top-level YAML key (lines up to the next unindented key). */
+const topLevelBlock = (lines, key) => {
+  const start = lines.findIndex((l) => l === `${key}:`);
+  if (start === -1) return '';
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^\S/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start + 1, end).join('\n');
+};
+
+// --- Issue #24: lint and the full test suite run on every pull request -------
+
+test('the CI gate workflow triggers on pull requests aimed at master', () => {
+  const onBlock = topLevelBlock(ciLines, 'on');
+  assert.match(onBlock, /^ {2}pull_request:\s*$/m, 'must declare a pull_request trigger');
+  assert.match(
+    onBlock,
+    /^ {4}branches:\s*\['master'\]\s*$/m,
+    'the pull_request trigger must target master'
+  );
+});
+
+test('the same checks run on pushes to the default branch', () => {
+  const onBlock = topLevelBlock(ciLines, 'on');
+  assert.match(onBlock, /^ {2}push:\s*$/m, 'must declare a push trigger');
+  // Both triggers must scope to master: exactly two branch pins, one per trigger.
+  const pins = onBlock.match(/branches:\s*\['master'\]/g) || [];
+  assert.ok(pins.length >= 2, 'both push and pull_request must target master');
+});
+
+test('lint runs on every pull request', () => {
+  assert.match(ciWorkflow, /run:\s*npm run lint\s*$/m, 'the workflow must run eslint');
+});
+
+test('the full test suite runs on every pull request', () => {
+  assert.match(ciWorkflow, /run:\s*npm test\s*$/m, 'the workflow must run the full suite');
+});
+
+// --- Issue #24 (AC5): dependabot proposals cover both manifests --------------
+
+const dependabotPath = `${REPO}/.github/dependabot.yml`;
+const dependabot = fs.readFileSync(dependabotPath, 'utf8');
+
+test('dependabot is configured at schema version 2', () => {
+  assert.match(dependabot, /^version:\s*['"]?2['"]?\s*$/m, 'dependabot.yml must set version: 2');
+});
+
+test('dependabot proposes npm updates for both manifests, weekly', () => {
+  const dirs = [...dependabot.matchAll(/directory:\s*['"]?(\S+?)['"]?\s*$/gm)].map((m) => m[1]);
+  assert.deepEqual(dirs.sort(), ['/', '/src/client'], 'both manifests must be covered');
+
+  const ecosystems = [...dependabot.matchAll(/package-ecosystem:\s*['"]?(\S+?)['"]?\s*$/gm)].map(
+    (m) => m[1]
+  );
+  assert.deepEqual(ecosystems, ['npm', 'npm'], 'each entry must target the npm ecosystem');
+
+  const intervals = [...dependabot.matchAll(/interval:\s*['"]?(\S+?)['"]?\s*$/gm)].map((m) => m[1]);
+  assert.deepEqual(intervals, ['weekly', 'weekly'], 'each manifest must be scanned weekly');
+});
+
+// --- Issue #24 (AC3): a failing check blocks the image publish ---------------
+// The deep guards live in release-workflow.test.js; this records the parity
+// invariant: what gates a PR is the same suite command that gates publishing.
+
+test('the image publish is gated by the same suite command the PR gate runs', () => {
+  const release = stripComments(readWorkflow('build-docker-container.yml'));
+  assert.match(release, /^ {4}needs:\s*test\s*$/m, 'publish must need the test job');
+  assert.match(release, /run:\s*npm test\s*$/m, 'the release gate must run the full suite');
+});

--- a/test/ci-gate.test.js
+++ b/test/ci-gate.test.js
@@ -30,14 +30,36 @@ const topLevelBlock = (lines, key) => {
   return lines.slice(start + 1, end).join('\n');
 };
 
+/**
+ * Slice the body of a key nested inside a parent block (e.g. `push:` within
+ * `on:`), so an assertion about one trigger cannot be satisfied by another.
+ */
+const nestedBlock = (parentLines, key) => {
+  const start = parentLines.findIndex((l) => l.trim() === `${key}:`);
+  if (start === -1) return '';
+  const childIndent = parentLines[start].match(/^ */)[0].length;
+  let end = parentLines.length;
+  for (let i = start + 1; i < parentLines.length; i++) {
+    const line = parentLines[i];
+    if (line.trim() === '') continue;
+    if (/^\S/.test(line)) break;
+    if (line.match(/^ */)[0].length <= childIndent) {
+      end = i;
+      break;
+    }
+  }
+  return parentLines.slice(start + 1, end).join('\n');
+};
+
 // --- Issue #24: lint and the full test suite run on every pull request -------
 
 test('the CI gate workflow triggers on pull requests aimed at master', () => {
   const onBlock = topLevelBlock(ciLines, 'on');
   assert.match(onBlock, /^ {2}pull_request:\s*$/m, 'must declare a pull_request trigger');
+  const prBlock = nestedBlock(onBlock.split('\n'), 'pull_request');
   assert.match(
-    onBlock,
-    /^ {4}branches:\s*\['master'\]\s*$/m,
+    prBlock,
+    /branches:\s*\['master'\]\s*$/m,
     'the pull_request trigger must target master'
   );
 });
@@ -45,9 +67,10 @@ test('the CI gate workflow triggers on pull requests aimed at master', () => {
 test('the same checks run on pushes to the default branch', () => {
   const onBlock = topLevelBlock(ciLines, 'on');
   assert.match(onBlock, /^ {2}push:\s*$/m, 'must declare a push trigger');
-  // Both triggers must scope to master: exactly two branch pins, one per trigger.
-  const pins = onBlock.match(/branches:\s*\['master'\]/g) || [];
-  assert.ok(pins.length >= 2, 'both push and pull_request must target master');
+  // Scoped to the push sub-block: another trigger gaining a master pin must
+  // not satisfy this assertion while push itself lost its scoping.
+  const pushBlock = nestedBlock(onBlock.split('\n'), 'push');
+  assert.match(pushBlock, /^ {4}branches:\s*\['master'\]\s*$/m, 'push must target master');
 });
 
 test('lint runs on every pull request', () => {


### PR DESCRIPTION
Closes #24

## Summary

The pull-request gate verified behaviour but never ran static analysis, and no automated dependency-update proposals existed for either manifest. This PR completes the CI gate: `npm run lint` now runs on every pull request and every push to `master` as its own job in `.github/workflows/e2e-security.yml`, and a new `.github/dependabot.yml` proposes weekly npm updates for both manifests (server root `/` and dashboard client `/src/client`). Static regression guards pin the whole arrangement so it cannot silently regress.

## Approach

Additive-only edits to the existing gate. A standalone `lint` job was appended after the `container` job — deliberately away from the region where open PR #101 inserts its `dependency-audit` job — rather than a step inside `http-suite`, so lint reports independently of the database-backed suites and merge-conflict risk stays minimal. Dependabot groups minor/patch updates to keep proposal volume low. Guards follow the repo's static-workflow-guard pattern (`test/release-workflow.test.js`, `test/dockerfile.test.js`): read the YAML, strip comments, assert structure, plus behavioural checks where cheap. AC3's substance already exists (`build-docker-container.yml` gates `publish` on a `test` job running the same suite) and is verified/documented here rather than duplicated; the deep guards remain in `test/release-workflow.test.js`.

## Decision Record

- **Root cause:** the only PR-facing workflow exercised runtime behaviour via `npm test`; nothing ran `npm run lint`, and neither `package.json` manifest had dependency-update automation, leaving style/static regressions invisible before merge and dependency currency manual.
- **Options considered:** Option 1 — add a lint step inside the existing `http-suite` job; Option 2 — standalone `lint` job appended to `e2e-security.yml` + new `.github/dependabot.yml` + static guards; Option 3 — replace both workflows with one new combined CI workflow.
- **Options rejected:** Option 1 — sits exactly where open PR #101's diff hunk lands (merge-conflict risk) and couples lint greenness to the MongoDB-environmental suite reds; Option 3 — duplicates working gates (suite, container, publish), non-atomic.
- **Selected option:** Option 2 — additive lint job + dependabot + guards.
- **Residual risk:** none identified in the change. Two pre-existing MongoDB-environmental suite failures on master (`test/e2e/auth-journey.test.js` answering 500 instead of the documented 503 when Mongo is unreachable) are unchanged by this PR — identical locally and in CI run 32546252720 on untouched master.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `feat/24-run-lint-and-tests-in-ci-on-every-pull-requ @ 3016928` (2026-08-22)

## Changes

| File | Change |
|------|--------|
| `.github/workflows/e2e-security.yml` | New `lint` job (checkout → Node 22 → `npm ci` → `npm run lint`) appended after `container` |
| `.github/dependabot.yml` | New config: weekly npm update proposals for `/` and `/src/client`, minor+patch grouped, limit 5 each |
| `test/ci-gate.test.js` | New static guards: `pull_request`/`push`→master triggers asserted per sub-block, lint step present, full suite present, dependabot covers both manifests weekly, release-gate parity (`needs: test` + same suite command) |
| `README.md` | Documents the lint gate and Dependabot coverage next to the existing CI paragraph |

## Test Results

- Unit/static guard tests: 331 passed of 336 (7 new in `test/ci-gate.test.js`); the 2 failures are the pre-existing MongoDB-environmental reds byte-identical on untouched master (locally and in CI run 32546252720), out of scope here; 3 skipped unchanged
- Lint: exit 0 (2 pre-existing warnings in `src/server/config.js`, `src/server/routes/auth.js`)
- Workflow YAML validated; guard mutation-checked (fails red when the push trigger loses its master scoping)
- QA cycles: 1 (one blocking finding — trigger assertions scoped too loosely — fixed and mutation-verified)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Lint and the full test suite run on every pull request | pass | `lint` job + `http-suite` (`npm test`) in `.github/workflows/e2e-security.yml`; guarded by `test/ci-gate.test.js` ("lint runs on every pull request", "the full test suite runs on every pull request") |
| The same checks run on pushes to the default branch | pass | `push:` trigger scoped to `['master']` asserted inside its own sub-block (`test/ci-gate.test.js`) |
| A failing check blocks the image publish workflow | pass | Pre-existing substance verified: `build-docker-container.yml` `publish` has `needs: test` running the same `npm test`; guarded by `test/release-workflow.test.js` and the parity guard in `test/ci-gate.test.js` |
| Check results are visible on the pull request without opening the logs | pass | Both jobs report as named GitHub checks via the workflow's `pull_request` trigger (existing behaviour, now pinned by the trigger guards) |
| Automated dependency update proposals are enabled for both manifests | pass | `.github/dependabot.yml` declares npm ecosystems for `/` and `/src/client`, weekly; guarded by "dependabot proposes npm updates for both manifests, weekly" |

<!-- gitissue:qa v1 head=709502aac7ced9bdba420e52232b955ad47148c7 profile=light cycles=1 review=clean tests=331@14d040f096d5998e648d09c5ec7e234c217dc725 ui=none -->
