### PR TITLE
chore(client): clear jsoneditor advisories on v10 (#77)

### DIFF
--- a/src/client/MIGRATION-jsoneditor-v10.md
+++ b/src/client/MIGRATION-jsoneditor-v10.md
@@ -1,0 +1,74 @@
+# jsoneditor 8 → 10 upgrade — migration guide
+
+Finding `F-DEP-105` (modernization plan task 5.5, issue #77): the dashboard's
+model JSON editor ran on `jsoneditor` 8.6.6 — two majors behind — carrying a
+moderate stored-XSS advisory and a moderate ReDoS advisory against an
+operator-facing surface.
+
+## Advisories closed
+
+| Advisory | CVE | Class | Affected | Fixed | Severity |
+|----------|-----|-------|----------|-------|----------|
+| [GHSA-q854-j362-cfq9](https://github.com/advisories/GHSA-q854-j362-cfq9) | CVE-2020-23849 | Stored XSS in tree mode | < 9.0.2 | 9.0.2 | Moderate 6.1 |
+| [GHSA-hhfg-6hfc-rvxm](https://github.com/advisories/GHSA-hhfg-6hfc-rvxm) | CVE-2021-3822 | ReDoS in `getInnerText` | < 9.5.6 | 9.5.6 | Moderate 5.3 |
+
+Installed version: **10.4.3** (`^10.4.3` in `src/client/package.json`) — clears
+both ranges.
+
+## Migration sources
+
+Upstream publishes its changelog as `HISTORY.md`; the copy shipped inside the
+installed package (`src/client/node_modules/jsoneditor/HISTORY.md`, identical to
+[the upstream file](https://github.com/josdejong/jsoneditor/blob/master/HISTORY.md))
+is the authoritative source for every entry below. API semantics were checked
+against the installed docs (`src/client/node_modules/jsoneditor/docs/api.md`).
+
+## v8 → v9 (relevant entries)
+
+| Version | Change | Impact here |
+|---------|--------|-------------|
+| 9.0.0 | New `limitDragging` option; breaking when a JSON schema is used — dragging becomes more restrictive by default (`limitDragging: false` restores old behaviour) | None — the dashboard never passes `schema` |
+| 9.0.2 | **Fix #1029: XSS vulnerabilities** (upstream fix for GHSA-q854-j362-cfq9) | Primary security driver of this upgrade |
+| 9.5.6 | ReDoS fix in `getInnerText` (fixes GHSA-hhfg-6hfc-rvxm, CVE-2021-3822) | Second security driver |
+| 9.10.x | `showErrorTable` option; Ace/ajv/jsonrepair dependency refreshes | Informational |
+
+## v9 → v10 (relevant entries)
+
+| Version | Change | Impact here |
+|---------|--------|-------------|
+| 10.0.0 | **BREAKING: dropped Internet Explorer 11 support** — the *only* breaking change in v10 | None — Vite-built SPA, browserslist targets evergreen browsers |
+| 10.1.x–10.4.x | Ace/`jsonrepair` upgrades, autocomplete improvements, `.validate()` always returns a Promise | Informational |
+
+## Compatibility audit (installed 10.4.3 `docs/api.md`)
+
+Single integration point: `src/client/src/components/JSONView/`
+(`Editor.jsx` wraps the constructor; `JSONView.js` supplies props; used by
+`ModelPage.js`, `DataRecorderPage.js`, `DataStoragePage.js`).
+
+Every option and method the wrapper uses still exists in v10.4.3:
+
+- Options: `onChange`, `onError`, `onModeChange`, `mode`, `name`, `schema`,
+  `schemaRefs`, `ace`, `theme`, `history`, `navigationBar`, `statusBar`,
+  `search`, `modes` (the wrapper maps React prop `allowedModes` → `modes`,
+  unchanged).
+- Methods: `set`, `get`, `getText`, `updateText`, `setName`/`getName`,
+  `setSchema`, `destroy`, `collapseAll`, `expandAll`, `focus`.
+- Behaviour note: `onChange` fires only on user edits — never on programmatic
+  `set`/`setText`/`update`/`updateText` (api.md, `onChange`). Unchanged from v8,
+  and relied upon by `Editor.handleChange`.
+
+Result: **no production code change required for the bump itself** — the only
+code touch was the React 18 lifecycle rename (`UNSAFE_componentWillReceiveProps`)
+landed by the #35 dependency wave (PR #116), which carried the version bump.
+
+## Verification performed (2026-08-22)
+
+- `npm audit` in `src/client`: neither GHSA appears; remaining findings are the
+  pre-existing low-severity `elliptic` crypto-browserify chain, unrelated to
+  jsoneditor.
+- Round-trip regression test added at
+  `src/client/src/components/JSONView/JSONView.test.js`: loads a topology into a
+  live v10 editor, propagates an edit through the documented change-handler seam
+  into `onChange` (the payload ModelPage persists via export), and verifies
+  teardown destroys the instance.
+- Root suite baseline holds (≥ 285 passing, 0 failures).

--- a/src/client/src/components/JSONView/JSONView.test.js
+++ b/src/client/src/components/JSONView/JSONView.test.js
@@ -1,0 +1,82 @@
+import React, { createRef } from "react";
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import Editor from "./Editor";
+import JSONView from "./JSONView";
+
+// A minimal topology shaped like what the model pages feed the editor.
+const topology = {
+  name: "demo-model",
+  nodes: [{ id: 1, label: "gateway" }],
+  links: [],
+};
+
+const renderEditor = (props = {}) => {
+  const ref = createRef();
+  const onChange = vi.fn();
+  const utils = render(
+    <Editor ref={ref} value={topology} onChange={onChange} {...props} />
+  );
+  return {
+    ...utils,
+    wrapper: () => ref.current,
+    editor: () => ref.current.jsonEditor,
+    onChange,
+  };
+};
+
+describe("JSONView / jsoneditor v10", () => {
+  afterEach(cleanup);
+
+  test("loads a topology into a live v10 editor", () => {
+    const { container, editor } = renderEditor();
+    expect(container.querySelector(".jsoneditor")).toBeInTheDocument();
+    // The document really made it through the constructor + set() path.
+    expect(editor().get()).toEqual(topology);
+    expect(editor().getText()).toContain('"demo-model"');
+    expect(screen.getAllByText("demo-model").length).toBeGreaterThan(0);
+  });
+
+  test("propagates an edited topology through onChange", () => {
+    const { editor, wrapper, onChange } = renderEditor();
+    expect(onChange).not.toHaveBeenCalled();
+
+    const edited = { ...topology, name: "renamed-model" };
+    // updateText is programmatic, so per the v10 API it does not fire onChange;
+    // handleChange is the exact handler user edits invoke, and it must read
+    // the edited document back out (the payload ModelPage saves).
+    editor().updateText(JSON.stringify(edited));
+    wrapper().handleChange();
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(edited);
+  });
+
+  test("reports an emptied document to onChange as null", () => {
+    const { editor, wrapper, onChange } = renderEditor();
+    // Clearing is only legal in text mode; tree mode rejects an empty document.
+    editor().setMode("text");
+    editor().setText("");
+    wrapper().handleChange();
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  test("destroys the editor instance on unmount", () => {
+    const { editor, unmount } = renderEditor();
+    const destroy = vi.spyOn(editor(), "destroy");
+    unmount();
+    expect(destroy).toHaveBeenCalled();
+  });
+
+  test("JSONView wires value and onChange through to the editor", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <JSONView value={topology} onChange={onChange} />
+    );
+    expect(container.querySelector(".jsoneditor")).toBeInTheDocument();
+    expect(screen.getAllByText("demo-model").length).toBeGreaterThan(0);
+    // Programmatic load alone must not look like a user edit.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #77

## Summary

Closes finding `F-DEP-105` (modernization plan task 5.5): the dashboard's model
JSON editor dependency, `jsoneditor`, carried a moderate stored-XSS advisory
([GHSA-q854-j362-cfq9](https://github.com/advisories/GHSA-q854-j362-cfq9), fixed
9.0.2) and a moderate ReDoS advisory
([GHSA-hhfg-6hfc-rvxm](https://github.com/advisories/GHSA-hhfg-6hfc-rvxm),
fixed 9.5.6) while two majors behind. The version bump itself (`^10.4.3`) landed
with the #35 dependency wave (PR #116); this PR closes the acceptance criteria
that remained open against this issue: the migration-guide spike, live audit
clearance evidence, and automated proof that the editor still loads, edits and
saves a topology on v10.

## Approach

Migration guide produced first from the upstream v9/v10 changelogs (the
`HISTORY.md` shipped inside installed 10.4.3, identical to upstream), then an
API compatibility audit of the single integration point
(`src/client/src/components/JSONView/`) against installed 10.4.3 `docs/api.md`,
then a vitest round-trip suite driving a real v10 instance under jsdom. No
production code change was required: every option and method the wrapper uses
still exists in v10, and the only v10 breaking change (IE11 drop) is inert for
this evergreen-targeted Vite SPA.

## Decision Record

- **Root cause / current reality:** verified live — `jsoneditor@10.4.3` is
  installed and both GHSAs are absent from the client audit (remaining findings:
  pre-existing low-severity `elliptic` chain, unrelated); what remained open was
  documentation and behavioral verification, not the bump itself.
- **Options considered:** (1) migration guide only; (2) **guide + round-trip
  verification tests** — selected; (3) also refactor the wrapper to hooks /
  drop brace / adopt svelte-jsoneditor — rejected as high-churn out-of-scope
  churn (upstream README warns its successor library is not a drop-in
  replacement).
- **Options rejected:** (1) leaves the loads/edits/saves criterion resting on
  nothing testable; (3) no behavior gain proportional to the risk on a core
  operator workflow.
- **Selected option:** guide + tests — smallest diff that evidences all four
  acceptance criteria; risk Low (additive files only).
- **Residual risk:** the empty-document contract test exercises text-mode Ace
  under jsdom; deterministic locally, would surface as CI flake if environment-
  dependent.

## Changes

| File | Change |
|------|--------|
| `src/client/MIGRATION-jsoneditor-v10.md` | Migration guide: both advisories with affected/fixed ranges, v8→v9 and v9→v10 changelog-derived impact analysis, option/method compatibility audit vs installed 10.4.3, verification record |
| `src/client/src/components/JSONView/JSONView.test.js` | New: loads a topology into a live v10 editor, propagates an edited topology through `onChange` (the payload ModelPage persists), null-contract for emptied documents, destroy-on-unmount teardown guard, JSONView wiring smoke |

## Test Results

- Client (`vitest`): **17 passed / 0 failed** across 7 files (was 12/12 — +5 new)
- Root (`npm test`): **364 passed / 0 failed / 3 skipped** of 367 — baseline
  ≥ 285 holds
- `npm audit` in `src/client`: GHSA-q854-j362-cfq9 and GHSA-hhfg-6hfc-rvxm
  absent (verified live 2026-08-22)
- Lint: 0 errors (2 pre-existing server warnings, untouched)

## Acceptance Criteria Verification

| Criterion | Evidence | Result |
|-----------|----------|--------|
| Migration guide produced first from upstream v9/v10 changelogs, linked in PR | `src/client/MIGRATION-jsoneditor-v10.md` (this PR links it) | ✓ |
| GHSA-q854-j362-cfq9 and GHSA-hhfg-6hfc-rvxm absent from the client audit | Live `npm audit --json` in `src/client`, 2026-08-22; recorded in the guide's verification section | ✓ |
| Model JSON editor loads, edits and saves a topology | `JSONView.test.js` round-trip suite against a real v10 instance: load (`get()` equals topology), edit→`onChange` propagation (save payload), emptied-document null contract | ✓ |
| `npm test` passes at ≥ 285/286 | Final run on HEAD: 364 passed / 0 failed / 3 skipped of 367 | ✓ |

<!-- gitissue:qa v1 head=776620217aad46d76462bc291e0261bfbd2a4c43 profile=full cycles=1 review=clean tests=364@776620217aad46d76462bc291e0261bfbd2a4c43 ui=none -->
