### PR TITLE
refactor(build): remove vestigial babel configuration (#82)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "plugins": [["@babel/plugin-proposal-class-properties", { "loose": true }]],
-  "presets": ["@babel/env", "@babel/preset-react"]
-}


### PR DESCRIPTION
Closes #82

## Summary

Deletes the vestigial `.babelrc` at the repository root (modernization finding F-DEAD-002, plan task 7.2). It configured `@babel/plugin-proposal-class-properties`, `@babel/env` and `@babel/preset-react`, none of which appears in either manifest — leftovers from the webpack setup removed by the Vite migration (#34).

## Approach

Direct deletion. Nothing consumes the file: the client build is Vite/esbuild (`src/client/vite.config.js`), the container build runs that same Vite build (`Dockerfile:23`), no CI workflow or npm script invokes Babel, and Babel's `.babelrc` lookup for files under `src/client/` terminates at the `src/client/package.json` package boundary anyway.

## Decision Record

- **Root cause:** `.babelrc` is unreachable dead configuration from a pre-Vite webpack setup — its three configured plugins/presets are absent from both `package.json` manifests and nothing in the repo references `.babelrc` any more.
- **Options considered:** Option 1 — delete `.babelrc`; Option 2 — reinstate the Babel toolchain as a real dependency with a build consuming it
- **Options rejected:** n/a — trivial change, direct plan (light profile)
- **Selected option:** Option 1 — delete the vestigial configuration
- **Residual risk:** none identified
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `refactor/82-delete-the-vestigial-babel @ 57c424d` (2026-08-22)

## Changes

| File | Change |
|------|--------|
| `.babelrc` | Deleted — vestigial webpack-era config (F-DEAD-002) |

## Test Results

- Unit tests: 368 passed
- Integration tests: same `node:test` suite — 3 skipped / 0 failed of 371 total
- E2e tests: none in suite (unchanged by this PR)
- Build: passed — client `vite build` (✓ built in 15.73s) and full Docker image build (✓ DONE) both green
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `.babelrc` is deleted, or the toolchain it configures is reinstated as a real dependency with a build that uses it | pass | File deleted in commit 51fca01; `git grep babelrc HEAD -- . ':!*.lock*'` empty |
| The client build and the container build both still succeed | pass | `npm run build` in `src/client/` → ✓ built in 15.73s; `docker build` → DONE |
| `npm test` passes at ≥ 285/286 (baseline-green holds) | pass | 368 pass / 0 fail / 3 skipped of 371 on commit 51fca01 |

<!-- gitissue:qa v1 head=51fca015a4c45491ec27565d34fd89e2f5c234b9 profile=light cycles=1 review=clean tests=368@51fca015a4c45491ec27565d34fd89e2f5c234b9 ui=none -->
