### PR TITLE
fix(server): make the log router kind explicit and required (#84)

### DIFF
--- a/src/server/routes/logs.js
+++ b/src/server/routes/logs.js
@@ -8,6 +8,12 @@ const { errorHandler, fileError, internal } = require('../middleware/errors');
 
 const _logsPath = `${__dirname}/../logs/`;
 
+// The log root has one subdirectory per kind of log the server writes, and
+// each mounted instance reads exactly one of them (issue #84). Keeping the
+// list here means a misspelled or defaulted kind fails at mount time instead
+// of silently serving a directory that can never exist.
+const LOG_KINDS = ['data-recorders', 'simulations', 'test-campaigns'];
+
 // ---------------------------------------------------------------------------
 // Validation schemas for the log endpoints (issue #10)
 // ---------------------------------------------------------------------------
@@ -18,7 +24,12 @@ const _logsPath = `${__dirname}/../logs/`;
 // delete the logs the product itself writes.
 const logFileNameParam = fileNameParam('.log', generatedFileNameMaxLength('.log'));
 
-const createRouter = (appLog = true) => {
+const createRouter = (appLog) => {
+  if (!LOG_KINDS.includes(appLog)) {
+    throw new TypeError(
+      `Unknown log kind: ${String(appLog)}. Expected one of: ${LOG_KINDS.join(', ')}`
+    );
+  }
   let router = express.Router();
   let logsPath = `${_logsPath}${appLog}/`;
 

--- a/test/log-router-kind.test.js
+++ b/test/log-router-kind.test.js
@@ -1,0 +1,31 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const createLogRouter = require('../src/server/routes/logs');
+
+// Issue #84: the factory used to default its kind to a boolean that was then
+// interpolated into a directory path, so a caller forgetting the argument got
+// a router serving a literal `true` directory instead of failing loudly.
+
+test('mounting with no argument throws loudly', () => {
+  assert.throws(() => createLogRouter(), TypeError);
+});
+
+test('mounting with the retired boolean default throws', () => {
+  assert.throws(() => createLogRouter(true), /Unknown log kind: true/);
+});
+
+test('mounting with an unknown kind throws naming the kind', () => {
+  assert.throws(() => createLogRouter('simulation'), /Unknown log kind: simulation/);
+});
+
+test('the thrown message lists every known log kind', () => {
+  assert.throws(() => createLogRouter(), /data-recorders, simulations, test-campaigns/);
+});
+
+test('each of the three known kinds mounts without throwing', () => {
+  for (const kind of ['data-recorders', 'simulations', 'test-campaigns']) {
+    const router = createLogRouter(kind);
+    assert.equal(typeof router, 'function');
+  }
+});


### PR DESCRIPTION
Closes #84

## Summary

The log router factory (`src/server/routes/logs.js`) defaulted its kind parameter to a boolean `true`, which was interpolated into a directory path — a caller forgetting the argument silently got a router serving a literal `logs/true/` directory. The parameter is now required and validated against the three known log kinds, failing loudly at mount time otherwise.

## Approach

Required kind parameter with mount-time allowlist validation: an explicit `LOG_KINDS` list (`data-recorders`, `simulations`, `test-campaigns`) guards the factory entry; any other value — including the retired boolean default and misspellings — throws a `TypeError` naming the bad kind and the valid ones.

## Decision Record

- **Root cause:** the factory signature `(appLog = true)` made the kind optional with a boolean default that was then interpolated into `${_logsPath}${appLog}/`, so the default resolved to a path segment `true`; all existing callers passed a string, leaving the trap armed for the next caller (finding F-BUG-008).
- **Options considered:** Option 1 — remove the default and throw on any falsy value; Option 2 — required parameter validated against an explicit `LOG_KINDS` allowlist; Option 3 — per-kind router registry module owning kind-to-path mapping
- **Options rejected:** Option 1 — accepts any truthy string, so misspellings stay silent; Option 3 — over-engineered for a three-value enum used by one factory
- **Selected option:** Option 2 — required parameter with mount-time allowlist validation
- **Residual risk:** none identified
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle
- **Reproduction:** `node -e "require('./src/server/routes/logs')()"` confirmed red (mounted silently, served `src/server/logs/true/`) → fixed → regression test `test/log-router-kind.test.js`

Analyzed at: `fix/84-make-the-log-router-s-kind-explicit @ 39730cb` (2026-08-22)

## Changes

| File | Change |
|------|--------|
| `src/server/routes/logs.js` | Added `LOG_KINDS` allowlist; kind parameter is now required and throws a `TypeError` at mount time on unknown values; removed the boolean default |
| `test/log-router-kind.test.js` | New regression tests: no-argument mount throws, retired boolean default throws, unknown kind throws naming it, message lists all valid kinds, each valid kind mounts |

## Test Results

- Unit tests: 373 passed (full suite: 376 tests, 0 failed, 3 skipped)
- Integration tests: included in suite pass count
- E2e tests: unchanged
- Build: passed (lint clean, pre-existing warnings only)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| The parameter is required and validated against the three known log kinds, throwing at mount time otherwise | pass | `src/server/routes/logs.js:27-32` — `LOG_KINDS.includes` guard throwing `TypeError` before any path interpolation |
| A test asserts that mounting with no argument fails loudly | pass | Verified red: `node -e "require('./src/server/routes/logs')()"` mounted silently → fixed → `test/log-router-kind.test.js` ("mounting with no argument throws loudly") |
| `npm test` passes at ≥ 285/286 (baseline-green holds) | pass | Full suite after fix: 373 passed / 0 failed / 3 skipped of 376 (baseline before change: 368/0/3) |

<!-- gitissue:qa v1 head=39730cbf98e0d202afd9345095f2abea0b89ef8d profile=light cycles=1 review=clean tests=376@39730cbf98e0d202afd9345095f2abea0b89ef8d ui=none -->
