### PR TITLE
fix(client): add confirm gates and list request states (#37)

### DIFF
--- a/src/client/src/components/ListStates/ListStates.js
+++ b/src/client/src/components/ListStates/ListStates.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { Button, Empty } from "antd";
+
+/**
+ * Shared list-view states. Every list page renders these through its antd
+ * Table `locale.emptyText` slot so a genuinely empty table is
+ * distinguishable from one still loading (the LayoutPage spinner owns the
+ * in-flight case) and a failed request offers a retry.
+ */
+
+export const ListStateEmpty = ({ description, action }) => (
+  <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={description}>
+    {action}
+  </Empty>
+);
+
+export const ListStateError = ({ message, onRetry }) => (
+  <Empty
+    image={Empty.PRESENTED_IMAGE_SIMPLE}
+    description={
+      <span>
+        Failed to load: {message === null || message === undefined ? "request failed" : String(message)}
+      </span>
+    }
+  >
+    <Button type="primary" onClick={onRetry}>
+      Retry
+    </Button>
+  </Empty>
+);

--- a/src/client/src/components/ListStates/index.js
+++ b/src/client/src/components/ListStates/index.js
@@ -1,0 +1,1 @@
+export { ListStateEmpty, ListStateError } from "./ListStates";

--- a/src/client/src/pages/DataRecorderListPage.js
+++ b/src/client/src/pages/DataRecorderListPage.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from "react";
 import { connect } from "react-redux";
-import { Button, Dropdown, Table } from "antd";
+import { Button, Dropdown, Popconfirm, Table } from "antd";
 import {
   ClearOutlined,
   ImportOutlined,
@@ -11,6 +11,7 @@ import {
   StopOutlined,
 } from "@ant-design/icons";
 import LayoutPage from "./LayoutPage";
+import { ListStateEmpty, ListStateError } from "../components/ListStates";
 import {
   requestAllDataRecorders,
   requestDeleteDataRecorder,
@@ -49,6 +50,9 @@ class DataRecorderListPage extends Component {
       startDataRecorder,
       dataRecorderStatus,
       stopDataRecorder,
+      requesting,
+      requestError,
+      fetchAllDataRecorders,
     } = this.props;
     const dataSource = allDataRecorders.map((model, index) => {
       let recorderId = null;
@@ -84,15 +88,22 @@ class DataRecorderListPage extends Component {
         render: (item) => (
           <Fragment>
             {item.isRunning ? (
-              <Button
-                style={{ marginRight: 10, paddingRight: 10 }}
-                size="small"
-                type="primary"
-                danger
-                onClick={() => stopDataRecorder(item.name)}
+              <Popconfirm
+                title={`Stop data recorder "${item.name}"?`}
+                description="The recorder will stop collecting data."
+                okText="Stop"
+                cancelText="Cancel"
+                onConfirm={() => stopDataRecorder(item.name)}
               >
-                <StopOutlined /> Stop
-              </Button>
+                <Button
+                  style={{ marginRight: 10, paddingRight: 10 }}
+                  size="small"
+                  type="primary"
+                  danger
+                >
+                  <StopOutlined /> Stop
+                </Button>
+              </Popconfirm>
             ) : (
               <Button
                 style={{ marginRight: 10 }}
@@ -110,18 +121,40 @@ class DataRecorderListPage extends Component {
             >
               <CopyOutlined /> Duplicate
             </Button>
-            <Button
-              size="small"
-              onClick={() => deleteDataRecorder(item.name)}
-              danger
+            <Popconfirm
+              title={`Delete data recorder "${item.name}"?`}
+              description="This permanently removes the data recorder. It cannot be undone."
+              okText="Delete"
+              okButtonProps={{ danger: true }}
+              cancelText="Cancel"
+              onConfirm={() => deleteDataRecorder(item.name)}
             >
-              <DeleteOutlined />
-              Delete
-            </Button>
+              <Button size="small" danger>
+                <DeleteOutlined />
+                Delete
+              </Button>
+            </Popconfirm>
           </Fragment>
         ),
       },
     ];
+
+    const emptyState =
+      !requesting && requestError ? (
+        <ListStateError
+          message={requestError.message}
+          onRetry={fetchAllDataRecorders}
+        />
+      ) : (
+        <ListStateEmpty
+          description="No data recorders yet"
+          action={
+            <a href={`/data-recorders/new-DataRecorder-${Date.now()}`}>
+              <Button type="primary">Create New Data Recorder</Button>
+            </a>
+          }
+        />
+      );
 
     return (
       <LayoutPage
@@ -173,7 +206,7 @@ class DataRecorderListPage extends Component {
           </Button>
         </Dropdown>
 
-        <Table columns={columns} dataSource={dataSource} />
+        <Table columns={columns} dataSource={dataSource} locale={{ emptyText: emptyState }} />
         <p></p>
         <a href={`/logs/data-recorders`}>View Logs</a>
       </LayoutPage>
@@ -181,9 +214,16 @@ class DataRecorderListPage extends Component {
   }
 }
 
-const mapPropsToStates = ({ allDataRecorders, dataRecorderStatus }) => ({
+const mapPropsToStates = ({
   allDataRecorders,
   dataRecorderStatus,
+  requesting,
+  requestError,
+}) => ({
+  allDataRecorders,
+  dataRecorderStatus,
+  requesting,
+  requestError,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/client/src/pages/DatasetListPage.js
+++ b/src/client/src/pages/DatasetListPage.js
@@ -1,13 +1,14 @@
 import React, { Component, Fragment } from "react";
 import { connect } from "react-redux";
 import dayjs from "dayjs";
-import { Table, Button } from "antd";
+import { Table, Button, Popconfirm } from "antd";
 import {
   CaretRightOutlined,
   CopyOutlined,
   DeleteOutlined,
 } from "@ant-design/icons";
 import LayoutPage from "./LayoutPage";
+import { ListStateEmpty, ListStateError } from "../components/ListStates";
 import {
   requestAllDatasets,
   requestAddNewDataset,
@@ -47,7 +48,8 @@ class DatasetListPage extends Component {
   }
 
   render() {
-    const { datasets, deleteDataset } = this.props;
+    const { datasets, deleteDataset, requesting, requestError, fetchDatasets } =
+      this.props;
     const dataSource = datasets.map((ds, index) => ({ ...ds, key: index }));
     const columns = [
       {
@@ -80,26 +82,50 @@ class DatasetListPage extends Component {
             >
               <CopyOutlined /> Duplicate
             </Button>
-            <Button size="small" danger onClick={() => deleteDataset(ds.id)}>
-              <DeleteOutlined /> Delete
-            </Button>
+            <Popconfirm
+              title={`Delete dataset "${ds.id}"?`}
+              description="This permanently removes the dataset and its events. It cannot be undone."
+              okText="Delete"
+              okButtonProps={{ danger: true }}
+              cancelText="Cancel"
+              onConfirm={() => deleteDataset(ds.id)}
+            >
+              <Button size="small" danger>
+                <DeleteOutlined /> Delete
+              </Button>
+            </Popconfirm>
           </Fragment>
         ),
       },
     ];
+    const emptyState =
+      !requesting && requestError ? (
+        <ListStateError message={requestError.message} onRetry={fetchDatasets} />
+      ) : (
+        <ListStateEmpty
+          description="No datasets yet"
+          action={
+            <a href={`/data-sets/new-dataset-${Date.now()}`}>
+              <Button type="primary">Add New Dataset</Button>
+            </a>
+          }
+        />
+      );
     return (
       <LayoutPage pageTitle="Dataset" pageSubTitle="All the datasets">
         <a href={`/data-sets/new-dataset-${Date.now()}`}>
           <Button style={{ marginBottom: "10px" }}>Add New Dataset</Button>
         </a>
-        <Table columns={columns} dataSource={dataSource} />
+        <Table columns={columns} dataSource={dataSource} locale={{ emptyText: emptyState }} />
       </LayoutPage>
     );
   }
 }
 
-const mapPropsToStates = ({ datasets }) => ({
+const mapPropsToStates = ({ datasets, requesting, requestError }) => ({
   datasets: datasets.allDatasets,
+  requesting,
+  requestError,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/client/src/pages/DatasetPage.js
+++ b/src/client/src/pages/DatasetPage.js
@@ -249,7 +249,8 @@ class DatasetPage extends Component {
       newEvent,
       isNew,
     } = this.state;
-    const { addNewEvent, updateEvent, requesting, requestError } = this.props;
+    const { addNewEvent, updateEvent, requesting, requestError, totalNbEvents } =
+      this.props;
     const nbEvents = events.length;
     const startTime = events[0] ? events[0].timestamp : 0;
     const endTime = events[nbEvents - 1] ? events[nbEvents - 1].timestamp : 0;
@@ -268,13 +269,17 @@ class DatasetPage extends Component {
 
     // TODO: Make statistic beautiful
     // TODO: implement editting event
-    const datasetMissing = !isNew && !requesting && !id;
+    // A failed dataset fetch leaves the page without data; offer a retry.
+    // Stale errors from other pages are cleared on mount by this page's own
+    // request actions (any request start resets the record), so this banner
+    // only reflects this view's failed fetch.
+    const fetchFailed = !requesting && requestError;
     return (
       <LayoutPage
         pageTitle={name}
         pageSubTitle="View and update a dataset"
       >
-        {datasetMissing && requestError ? (
+        {fetchFailed ? (
           <Button onClick={() => this.refetch()}>Retry loading dataset</Button>
         ) : null}
         <Form labelCol={{ span: 8 }} wrapperCol={{ span: 16 }}>

--- a/src/client/src/pages/DatasetPage.js
+++ b/src/client/src/pages/DatasetPage.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from "react";
 import { connect } from "react-redux";
-import { Button, Tooltip, Form } from "antd";
+import { Button, Tooltip, Form, Modal } from "antd";
 import LayoutPage from "./LayoutPage";
 import {
   requestDataset,
@@ -104,9 +104,28 @@ class DatasetPage extends Component {
   }
 
   componentDidMount() {
+    this.refetch();
+  }
+
+  refetch() {
     const dsId = getLastPath();
     this.props.fetchDataset(dsId);
     this.requestEvents();
+  }
+
+  /**
+   * Event deletion is irreversible, so it is confirmed here before the
+   * callback reaches the event stream; cancelling leaves the event intact.
+   */
+  deleteEventWithConfirmation(eventId) {
+    Modal.confirm({
+      title: `Delete event "${eventId}"?`,
+      content: "This permanently removes the event from the dataset. It cannot be undone.",
+      okText: "Delete",
+      okButtonProps: { danger: true },
+      cancelText: "Cancel",
+      onOk: () => this.props.deleteEvent(eventId),
+    });
   }
 
   UNSAFE_componentWillReceiveProps(newProps) {
@@ -230,7 +249,7 @@ class DatasetPage extends Component {
       newEvent,
       isNew,
     } = this.state;
-    const { deleteEvent, addNewEvent, updateEvent, totalNbEvents } = this.props;
+    const { addNewEvent, updateEvent, requesting, requestError } = this.props;
     const nbEvents = events.length;
     const startTime = events[0] ? events[0].timestamp : 0;
     const endTime = events[nbEvents - 1] ? events[nbEvents - 1].timestamp : 0;
@@ -249,11 +268,15 @@ class DatasetPage extends Component {
 
     // TODO: Make statistic beautiful
     // TODO: implement editting event
+    const datasetMissing = !isNew && !requesting && !id;
     return (
       <LayoutPage
         pageTitle={name}
         pageSubTitle="View and update a dataset"
       >
+        {datasetMissing && requestError ? (
+          <Button onClick={() => this.refetch()}>Retry loading dataset</Button>
+        ) : null}
         <Form labelCol={{ span: 8 }} wrapperCol={{ span: 16 }}>
           {isNew ? (
             <Fragment>
@@ -361,7 +384,7 @@ class DatasetPage extends Component {
         </Tooltip>
         <EventStream
           events={events}
-          deleteEvent={deleteEvent}
+          deleteEvent={(eventId) => this.deleteEventWithConfirmation(eventId)}
           addNewEvent={addNewEvent}
           updateEvent={updateEvent}
         />
@@ -383,10 +406,12 @@ class DatasetPage extends Component {
   }
 }
 
-const mapPropsToStates = ({ datasets }) => ({
+const mapPropsToStates = ({ datasets, requesting, requestError }) => ({
   dataset: datasets.currentDataset.dataset,
   events: datasets.currentDataset.events,
   totalNbEvents: datasets.currentDataset.totalNbEvents,
+  requesting,
+  requestError,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/client/src/pages/DatasetPage.test.js
+++ b/src/client/src/pages/DatasetPage.test.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  act,
+} from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+// DatasetPage runs against the real reducers; the saga layer is absent, so
+// tests settle the store themselves with the same actions the sagas would
+// dispatch.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    onSessionExpired: vi.fn(() => {}),
+  };
+});
+
+import DatasetPage from './DatasetPage';
+import rootReducer from '../reducers';
+import {
+  setCurrentDataset,
+  setEvents,
+  setTotalNumberEvents,
+  setNotification,
+} from '../actions';
+
+const dataset = {
+  id: 'ds-1',
+  name: 'My dataset',
+  description: 'desc',
+  tags: [],
+  source: 'GENERATED',
+};
+
+const renderPage = () => {
+  const store = createStore(rootReducer);
+  render(
+    <Provider store={store}>
+      <DatasetPage />
+    </Provider>
+  );
+  return store;
+};
+
+describe('DatasetPage', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    window.history.pushState({}, '', '/');
+  });
+
+  test('renders the loaded dataset with its event statistics', () => {
+    window.history.pushState({}, '', '/data-sets/ds-1');
+    const store = renderPage();
+    // Mount starts both fetches (requesting=true); settling them reveals
+    // the page content exactly as the sagas would after a successful load.
+    act(() => {
+      store.dispatch(setCurrentDataset(dataset));
+      store.dispatch(setEvents([{ timestamp: 1, isSensorData: true }]));
+      store.dispatch(setTotalNumberEvents(7));
+    });
+    expect(screen.getAllByText('My dataset').length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/number of presented events/i).length
+    ).toBeGreaterThan(0);
+    expect(screen.getByText('Get more events (1/7)')).toBeInTheDocument();
+  });
+
+  test('offers a retry when the dataset request fails and hides it on retry', () => {
+    window.history.pushState({}, '', '/data-sets/ds-1');
+    const store = renderPage();
+    // The failed load settles through an error notification.
+    act(() => {
+      store.dispatch(setNotification({ type: 'error', message: 'boom' }));
+    });
+    expect(
+      screen.getByRole('button', { name: /retry loading dataset/i })
+    ).toBeInTheDocument();
+    // Retrying re-enters the request lifecycle: the banner yields to the
+    // in-flight state instead of stacking on top of it.
+    fireEvent.click(
+      screen.getByRole('button', { name: /retry loading dataset/i })
+    );
+    expect(
+      screen.queryByRole('button', { name: /retry loading dataset/i })
+    ).not.toBeInTheDocument();
+  });
+
+  test('shows no retry banner while the page is simply loading', () => {
+    window.history.pushState({}, '', '/data-sets/ds-1');
+    const store = renderPage();
+    // Mount already dispatched the fetches; the flag is in flight.
+    expect(store.getState().requesting).toBe(true);
+    expect(store.getState().requestError).toBeNull();
+  });
+});

--- a/src/client/src/pages/LogsPage.js
+++ b/src/client/src/pages/LogsPage.js
@@ -4,9 +4,10 @@ import relativeTime from "dayjs/plugin/relativeTime";
 
 dayjs.extend(relativeTime);
 import { connect } from "react-redux";
-import { Table, Button } from "antd";
+import { Table, Button, Popconfirm } from "antd";
 import PageHeader from "../components/PageHeader";
 import { getCreatedTimeFromFileName, getLastPath, getQuery } from "../utils";
+import { ListStateEmpty, ListStateError } from "../components/ListStates";
 
 import {
   requestAllLogFiles,
@@ -40,7 +41,14 @@ class LogsPage extends Component {
   }
 
   render() {
-    const { logFiles, logs, deleteLogFile } = this.props;
+    const {
+      logFiles,
+      logs,
+      deleteLogFile,
+      requesting,
+      requestError,
+      fetchAllLogFiles,
+    } = this.props;
     const { tool, isLogPage, logFile } = this.state;
     if (isLogPage) {
       return <LogFileContent logs={logs} logFile={logFile} />;
@@ -68,31 +76,47 @@ class LogsPage extends Component {
       {
         title: "Action",
         render: (file) => (
-          <Button
-            danger
-            size="small"
-            onClick={() => deleteLogFile(tool, file.name)}
+          <Popconfirm
+            title={`Delete log file "${file.name}"?`}
+            description="This permanently removes the log file. It cannot be undone."
+            okText="Delete"
+            okButtonProps={{ danger: true }}
+            cancelText="Cancel"
+            onConfirm={() => deleteLogFile(tool, file.name)}
           >
-            Delete
-          </Button>
+            <Button danger size="small">
+              Delete
+            </Button>
+          </Popconfirm>
         ),
       },
     ];
+    const emptyState =
+      !requesting && requestError ? (
+        <ListStateError
+          message={requestError.message}
+          onRetry={() => fetchAllLogFiles(tool)}
+        />
+      ) : (
+        <ListStateEmpty description="No log files yet" />
+      );
     return (
       <LayoutPage>
         <PageHeader
           className="site-page-header"
           title={`${logFiles.length} Log Files`}
         />
-        <Table columns={columns} dataSource={dataSource} />
+        <Table columns={columns} dataSource={dataSource} locale={{ emptyText: emptyState }} />
       </LayoutPage>
     );
   }
 }
 
-const mapPropsToStates = ({ logs }) => ({
+const mapPropsToStates = ({ logs, requesting, requestError }) => ({
   logFiles: logs.logFiles,
   logs: logs.logs,
+  requesting,
+  requestError,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/client/src/pages/ModelListPage.js
+++ b/src/client/src/pages/ModelListPage.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from "react";
 import { connect } from "react-redux";
-import { Button, Dropdown, Table } from "antd";
+import { Button, Dropdown, Popconfirm, Table } from "antd";
 import {
   ClearOutlined,
   ImportOutlined,
@@ -11,6 +11,7 @@ import {
   StopOutlined,
 } from "@ant-design/icons";
 import LayoutPage from "./LayoutPage";
+import { ListStateEmpty, ListStateError } from "../components/ListStates";
 import {
   requestAllModels,
   requestDeleteModel,
@@ -49,6 +50,9 @@ class ModelListPage extends Component {
       simulationStatus,
       startSimulation,
       stopSimulation,
+      requesting,
+      requestError,
+      fetchAllModels,
     } = this.props;
     const dataSource = allModels.map((model, index) => {
       const simId = getObjectId(model.replace(".json", ""));
@@ -81,15 +85,22 @@ class ModelListPage extends Component {
         render: (item) => (
           <Fragment>
             {item.isRunning ? (
-              <Button
-                style={{ marginRight: 10, paddingRight: 34 }}
-                size="small"
-                type="primary"
-                danger
-                onClick={() => stopSimulation(item.name)}
+              <Popconfirm
+                title={`Stop the simulation of "${item.name}"?`}
+                description="The running simulation will be stopped."
+                okText="Stop"
+                cancelText="Cancel"
+                onConfirm={() => stopSimulation(item.name)}
               >
-                <StopOutlined /> Stop
-              </Button>
+                <Button
+                  style={{ marginRight: 10, paddingRight: 34 }}
+                  size="small"
+                  type="primary"
+                  danger
+                >
+                  <StopOutlined /> Stop
+                </Button>
+              </Popconfirm>
             ) : (
               <a type="button" href={`/simulation?model=${item.name}`}>
                 <Button
@@ -110,14 +121,37 @@ class ModelListPage extends Component {
             >
               <CopyOutlined /> Duplicate
             </Button>
-            <Button size="small" onClick={() => deleteModel(item.name)} danger>
-              <DeleteOutlined />
-              Delete
-            </Button>
+            <Popconfirm
+              title={`Delete topology "${item.name}"?`}
+              description="This permanently removes the topology file. It cannot be undone."
+              okText="Delete"
+              okButtonProps={{ danger: true }}
+              cancelText="Cancel"
+              onConfirm={() => deleteModel(item.name)}
+            >
+              <Button size="small" danger>
+                <DeleteOutlined />
+                Delete
+              </Button>
+            </Popconfirm>
           </Fragment>
         ),
       },
     ];
+
+    const emptyState =
+      !requesting && requestError ? (
+        <ListStateError message={requestError.message} onRetry={fetchAllModels} />
+      ) : (
+        <ListStateEmpty
+          description="No topologies yet"
+          action={
+            <a href={`/models/new-model-${Date.now()}`}>
+              <Button type="primary">Create New Topology</Button>
+            </a>
+          }
+        />
+      );
 
     return (
       <LayoutPage
@@ -168,15 +202,17 @@ class ModelListPage extends Component {
             Add Model <DownOutlined />
           </Button>
         </Dropdown>
-        <Table columns={columns} dataSource={dataSource} />
+        <Table columns={columns} dataSource={dataSource} locale={{ emptyText: emptyState }} />
       </LayoutPage>
     );
   }
 }
 
-const mapPropsToStates = ({ allModels, simulationStatus }) => ({
+const mapPropsToStates = ({ allModels, simulationStatus, requesting, requestError }) => ({
   allModels,
   simulationStatus,
+  requesting,
+  requestError,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/client/src/pages/ModelListPage.test.js
+++ b/src/client/src/pages/ModelListPage.test.js
@@ -1,0 +1,127 @@
+import React from 'react';
+import { createStore, applyMiddleware } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+import { Provider } from 'react-redux';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// The api layer is the only boundary the dashboard talks to; mocking it lets
+// the real store + sagas run while the network stays out of scope (the same
+// harness App.test.js uses).
+const expiry = vi.hoisted(() => ({ handler: null }));
+
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    requestSession: vi.fn(() => new Promise(() => {})),
+    onSessionExpired: vi.fn((handler) => {
+      expiry.handler = handler;
+    }),
+    requestAllModels: vi.fn(() => Promise.resolve(['topo-a.json'])),
+    requestModel: vi.fn(() => Promise.resolve({})),
+    requestDeleteModel: vi.fn(() => Promise.resolve()),
+    sendRequestSimulationStatus: vi.fn(() => Promise.resolve({})),
+    sendRequestStopSimulation: vi.fn(() => Promise.resolve()),
+  };
+});
+
+import ModelListPage from './ModelListPage';
+import rootReducer from '../reducers';
+import rootSaga from '../sagas';
+import { setSimulationStatus } from '../actions';
+import { getObjectId } from '../utils';
+
+const makeStore = () => {
+  const sagaMiddleware = createSagaMiddleware();
+  const store = createStore(rootReducer, applyMiddleware(sagaMiddleware));
+  sagaMiddleware.run(rootSaga);
+  return store;
+};
+
+const renderPage = () =>
+  render(
+    <Provider store={makeStore()}>
+      <ModelListPage />
+    </Provider>
+  );
+
+describe('ModelListPage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  test('asks for confirmation naming the topology before deleting it', async () => {
+    const { requestDeleteModel } = await import('../api');
+    renderPage();
+    await screen.findByText('topo-a');
+    await userEvent.click(screen.getByRole('button', { name: /delete/i }));
+    // No removal until the user confirms.
+    expect(requestDeleteModel).not.toHaveBeenCalled();
+    // The confirmation names the specific item about to be removed.
+    expect(await screen.findByText(/delete topology "topo-a\.json"/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => expect(requestDeleteModel).toHaveBeenCalledWith('topo-a.json'));
+  });
+
+  test('leaves the topology untouched when the deletion is cancelled', async () => {
+    const { requestDeleteModel } = await import('../api');
+    renderPage();
+    await screen.findByText('topo-a');
+    await userEvent.click(screen.getByRole('button', { name: /delete/i }));
+    await screen.findByText(/delete topology "topo-a\.json"/i);
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(requestDeleteModel).not.toHaveBeenCalled();
+    // The row is still rendered.
+    expect(screen.getByText('topo-a')).toBeInTheDocument();
+  });
+
+  test('confirms stopping a running simulation before stopping it', async () => {
+    const { sendRequestStopSimulation } = await import('../api');
+    const store = makeStore();
+    render(
+      <Provider store={store}>
+        <ModelListPage />
+      </Provider>
+    );
+    await screen.findByText('topo-a');
+    store.dispatch(
+      setSimulationStatus({ [getObjectId('topo-a')]: { isRunning: true } })
+    );
+    const stopButton = await screen.findByRole('button', { name: /stop/i });
+    await userEvent.click(stopButton);
+    expect(sendRequestStopSimulation).not.toHaveBeenCalled();
+    expect(await screen.findByText(/stop.*simulation.*topo-a/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Stop' }));
+    await waitFor(() =>
+      expect(sendRequestStopSimulation).toHaveBeenCalledWith('topo-a.json')
+    );
+  });
+
+  test('shows a distinct empty state with a next action when there are no topologies', async () => {
+    const { requestAllModels } = await import('../api');
+    requestAllModels.mockResolvedValue([]);
+    renderPage();
+    expect(await screen.findByText(/no topologies yet/i)).toBeInTheDocument();
+    expect(screen.queryByText('topo-a')).not.toBeInTheDocument();
+  });
+
+  test('shows an error state with a working retry when loading fails', async () => {
+    const { requestAllModels } = await import('../api');
+    requestAllModels.mockRejectedValueOnce(new Error('boom'));
+    renderPage();
+    expect(await screen.findByText(/failed to load/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    // The retry re-issues the original request.
+    requestAllModels.mockResolvedValue(['topo-a.json']);
+    await userEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(await screen.findByText('topo-a')).toBeInTheDocument();
+    expect(requestAllModels).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/client/src/pages/ReportListPage.js
+++ b/src/client/src/pages/ReportListPage.js
@@ -1,9 +1,10 @@
 import React, { Component, Fragment } from "react";
 import { connect } from "react-redux";
 import dayjs from "dayjs";
-import { Table, Button } from "antd";
+import { Table, Button, Popconfirm } from "antd";
 import { DeleteOutlined } from "@ant-design/icons";
 import LayoutPage from "./LayoutPage";
+import { ListStateEmpty, ListStateError } from "../components/ListStates";
 import { requestAllReports, requestDeleteReport } from "../actions";
 import { getQuery } from "../utils";
 
@@ -15,7 +16,8 @@ class ReportListPage extends Component {
   }
 
   render() {
-    const { reports, deleteReport } = this.props;
+    const { reports, deleteReport, requesting, requestError, fetchReports } =
+      this.props;
     let pageSubTitle = "All reports";
     const topologyFileName = getQuery("topologyFileName");
     if (topologyFileName) {
@@ -78,23 +80,47 @@ class ReportListPage extends Component {
         width: 100,
         render: (ds) => (
           <Fragment>
-            <Button size="small" danger onClick={() => deleteReport(ds._id)}>
-              <DeleteOutlined /> Delete
-            </Button>
+            <Popconfirm
+              title={`Delete report "${ds._id}"?`}
+              description="This permanently removes the report. It cannot be undone."
+              okText="Delete"
+              okButtonProps={{ danger: true }}
+              cancelText="Cancel"
+              onConfirm={() => deleteReport(ds._id)}
+            >
+              <Button size="small" danger>
+                <DeleteOutlined /> Delete
+              </Button>
+            </Popconfirm>
           </Fragment>
         ),
       },
     ];
+    const emptyState =
+      !requesting && requestError ? (
+        <ListStateError message={requestError.message} onRetry={fetchReports} />
+      ) : (
+        <ListStateEmpty
+          description="No reports yet"
+          action={
+            <a href="/test-campaigns">
+              <Button type="primary">Run a Test Campaign</Button>
+            </a>
+          }
+        />
+      );
     return (
       <LayoutPage pageTitle="Reports" pageSubTitle={pageSubTitle}>
-        <Table columns={columns} dataSource={dataSource} />
+        <Table columns={columns} dataSource={dataSource} locale={{ emptyText: emptyState }} />
       </LayoutPage>
     );
   }
 }
 
-const mapPropsToStates = ({ reports }) => ({
+const mapPropsToStates = ({ reports, requesting, requestError }) => ({
   reports: reports.allReports,
+  requesting,
+  requestError,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/client/src/pages/TestCampaignListPage.js
+++ b/src/client/src/pages/TestCampaignListPage.js
@@ -1,8 +1,9 @@
 import React, { Component, Fragment } from "react";
 import { connect } from "react-redux";
-import { Table, Button, Form } from "antd";
+import { Table, Button, Form, Popconfirm } from "antd";
 import { BuildOutlined, CopyOutlined, DeleteOutlined } from "@ant-design/icons";
 import LayoutPage from "./LayoutPage";
+import { ListStateEmpty, ListStateError } from "../components/ListStates";
 import {
   requestAllTestCampaigns,
   requestAddNewTestCampaign,
@@ -78,6 +79,9 @@ class TestCampaignListPage extends Component {
       launchTestCampaign,
       stopTestCampaign,
       runningStatus,
+      requesting,
+      requestError,
+      fetchTestCampaigns,
     } = this.props;
     const { webhookURL, testCampaignId, isChanged, evaluationParameters } = this.state;
     const dataSource = testCampaigns.map((tc) => ({ ...tc, key: tc.id }));
@@ -134,17 +138,38 @@ class TestCampaignListPage extends Component {
                 </a>
               </Button>
             )}
-            <Button
-              size="small"
-              danger
-              onClick={() => deleteTestCampaign(tc.id)}
+            <Popconfirm
+              title={`Delete test campaign "${tc.id}"?`}
+              description="This permanently removes the test campaign. It cannot be undone."
+              okText="Delete"
+              okButtonProps={{ danger: true }}
+              cancelText="Cancel"
+              onConfirm={() => deleteTestCampaign(tc.id)}
             >
-              <DeleteOutlined /> Delete
-            </Button>
+              <Button size="small" danger>
+                <DeleteOutlined /> Delete
+              </Button>
+            </Popconfirm>
           </Fragment>
         ),
       },
     ];
+    const emptyState =
+      !requesting && requestError ? (
+        <ListStateError
+          message={requestError.message}
+          onRetry={fetchTestCampaigns}
+        />
+      ) : (
+        <ListStateEmpty
+          description="No test campaigns yet"
+          action={
+            <a href={`/test-campaigns/new-campaign-${Date.now()}`}>
+              <Button type="primary">Add New Campaign</Button>
+            </a>
+          }
+        />
+      );
     return (
       <LayoutPage
         pageTitle="Test Campaign"
@@ -235,13 +260,17 @@ class TestCampaignListPage extends Component {
               {runningStatus ? (
                 <Fragment>
                   {runningStatus.isRunning ? (
-                    <Button
-                      type="primary"
-                      danger
-                      onClick={() => stopTestCampaign()}
+                    <Popconfirm
+                      title="Stop the running test campaign build?"
+                      description="The running build will be stopped."
+                      okText="Stop"
+                      cancelText="Cancel"
+                      onConfirm={() => stopTestCampaign()}
                     >
-                      Stop
-                    </Button>
+                      <Button type="primary" danger>
+                        Stop
+                      </Button>
+                    </Popconfirm>
                   ) : (
                     <Button
                       type="primary"
@@ -275,7 +304,7 @@ class TestCampaignListPage extends Component {
         <a href={`/test-campaigns/new-campaign-${Date.now()}`}>
           <Button style={{ marginBottom: "10px" }}>Add New Campaign</Button>
         </a>
-        <Table columns={columns} dataSource={dataSource} />
+        <Table columns={columns} dataSource={dataSource} locale={{ emptyText: emptyState }} />
         <p></p>
         <a href={`/logs/test-campaigns`}>View All Campaign Logs</a>
       </LayoutPage>
@@ -283,10 +312,12 @@ class TestCampaignListPage extends Component {
   }
 }
 
-const mapPropsToStates = ({ testCampaigns, devops }) => ({
+const mapPropsToStates = ({ testCampaigns, devops, requesting, requestError }) => ({
   testCampaigns: testCampaigns.allTestCampaigns,
   runningStatus: testCampaigns.runningStatus,
   devops,
+  requesting,
+  requestError,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/client/src/pages/TestCaseListPage.js
+++ b/src/client/src/pages/TestCaseListPage.js
@@ -1,8 +1,9 @@
 import React, { Component, Fragment } from "react";
 import { connect } from "react-redux";
-import { Table, Button } from "antd";
+import { Table, Button, Popconfirm } from "antd";
 import { DeleteOutlined, CopyOutlined } from "@ant-design/icons";
 import LayoutPage from "./LayoutPage";
+import { ListStateEmpty, ListStateError } from "../components/ListStates";
 import {
   requestAllTestCases,
   requestAddNewTestCase,
@@ -26,7 +27,13 @@ class TestCaseListPage extends Component {
   }
 
   render() {
-    const { testCases, deleteTestCase } = this.props;
+    const {
+      testCases,
+      deleteTestCase,
+      requesting,
+      requestError,
+      fetchTestCases,
+    } = this.props;
     const dataSource = testCases.map((tc) => ({ ...tc, key: tc.id }));
     const columns = [
       {
@@ -41,13 +48,38 @@ class TestCaseListPage extends Component {
         render: (tc) => (
           <Fragment>
             <Button size="small" style={{marginRight: 10}} onClick={() => this.duplicateTestCase(tc)}><CopyOutlined/> Duplicate</Button>
-            <Button size="small" danger onClick={() => deleteTestCase(tc.id)}>
-            <DeleteOutlined /> Delete
-            </Button>
+            <Popconfirm
+              title={`Delete test case "${tc.id}"?`}
+              description="This permanently removes the test case. It cannot be undone."
+              okText="Delete"
+              okButtonProps={{ danger: true }}
+              cancelText="Cancel"
+              onConfirm={() => deleteTestCase(tc.id)}
+            >
+              <Button size="small" danger>
+                <DeleteOutlined /> Delete
+              </Button>
+            </Popconfirm>
           </Fragment>
         ),
       },
     ];
+    const emptyState =
+      !requesting && requestError ? (
+        <ListStateError
+          message={requestError.message}
+          onRetry={fetchTestCases}
+        />
+      ) : (
+        <ListStateEmpty
+          description="No test cases yet"
+          action={
+            <a href={`/test-cases/new-case-${Date.now()}`}>
+              <Button type="primary">Add New Case</Button>
+            </a>
+          }
+        />
+      );
     return (
       <LayoutPage
         pageTitle="Test Case"
@@ -56,14 +88,16 @@ class TestCaseListPage extends Component {
         <a href={`/test-cases/new-case-${Date.now()}`}>
           <Button style={{ marginBottom: "10px" }}>Add New Case</Button>
         </a>
-        <Table columns={columns} dataSource={dataSource} />
+        <Table columns={columns} dataSource={dataSource} locale={{ emptyText: emptyState }} />
       </LayoutPage>
     );
   }
 }
 
-const mapPropsToStates = ({ testCases }) => ({
+const mapPropsToStates = ({ testCases, requesting, requestError }) => ({
   testCases: testCases.allTestCases,
+  requesting,
+  requestError,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/client/src/pages/TestCaseListPage.test.js
+++ b/src/client/src/pages/TestCaseListPage.test.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import { createStore, applyMiddleware } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+import { Provider } from 'react-redux';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Same harness as App.test.js: real store + sagas, mocked api boundary.
+const expiry = vi.hoisted(() => ({ handler: null }));
+
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    requestSession: vi.fn(() => new Promise(() => {})),
+    onSessionExpired: vi.fn((handler) => {
+      expiry.handler = handler;
+    }),
+    sendRequestAllTestCases: vi.fn(() =>
+      Promise.resolve([
+        { id: 'case-1', name: 'First case' },
+        { id: 'case-2', name: 'Second case' },
+      ])
+    ),
+    sendRequestTestCase: vi.fn(() => Promise.resolve({})),
+    sendRequestDeleteTestCase: vi.fn(() => Promise.resolve()),
+    sendRequestAddNewTestCase: vi.fn(() => Promise.resolve('case-3')),
+  };
+});
+
+import TestCaseListPage from './TestCaseListPage';
+import rootReducer from '../reducers';
+import rootSaga from '../sagas';
+
+const makeStore = () => {
+  const sagaMiddleware = createSagaMiddleware();
+  const store = createStore(rootReducer, applyMiddleware(sagaMiddleware));
+  sagaMiddleware.run(rootSaga);
+  return store;
+};
+
+const renderPage = () =>
+  render(
+    <Provider store={makeStore()}>
+      <TestCaseListPage />
+    </Provider>
+  );
+
+describe('TestCaseListPage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  test('asks for confirmation naming the test case before deleting it', async () => {
+    const { sendRequestDeleteTestCase } = await import('../api');
+    renderPage();
+    await screen.findByText('First case');
+    await userEvent.click(screen.getAllByRole('button', { name: /delete/i })[0]);
+    expect(sendRequestDeleteTestCase).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText(/delete test case "case-1"\?/i)
+    ).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() =>
+      expect(sendRequestDeleteTestCase).toHaveBeenCalledWith('case-1')
+    );
+  });
+
+  test('leaves the test case untouched when deletion is cancelled', async () => {
+    const { sendRequestDeleteTestCase } = await import('../api');
+    renderPage();
+    await screen.findByText('First case');
+    await userEvent.click(screen.getAllByRole('button', { name: /delete/i })[0]);
+    await screen.findByText(/delete test case "case-1"\?/i);
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(sendRequestDeleteTestCase).not.toHaveBeenCalled();
+    expect(screen.getByText('First case')).toBeInTheDocument();
+  });
+
+  test('shows a distinct empty state with a next action when there are no test cases', async () => {
+    const { sendRequestAllTestCases } = await import('../api');
+    sendRequestAllTestCases.mockResolvedValue([]);
+    renderPage();
+    expect(await screen.findByText(/no test cases yet/i)).toBeInTheDocument();
+    expect(screen.queryByText('First case')).not.toBeInTheDocument();
+  });
+
+  test('shows an error state with a working retry when loading fails', async () => {
+    const { sendRequestAllTestCases } = await import('../api');
+    sendRequestAllTestCases.mockRejectedValueOnce(new Error('offline'));
+    renderPage();
+    expect(await screen.findByText(/failed to load/i)).toBeInTheDocument();
+    sendRequestAllTestCases.mockResolvedValue([]);
+    await userEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(await screen.findByText(/no test cases yet/i)).toBeInTheDocument();
+    expect(sendRequestAllTestCases).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/client/src/reducers/index.js
+++ b/src/client/src/reducers/index.js
@@ -18,7 +18,7 @@ import { reportsSlice } from '../slices/reportsSlice';
 import { authSlice } from '../slices/authSlice';
 import { editingFormSlice } from '../slices/editingFormSlice';
 import { notificationSlice } from '../slices/notificationSlice';
-import { requestingReducer } from '../slices/requestingSlice';
+import { requestingReducer, requestErrorReducer } from '../slices/requestingSlice';
 
 // State keys are the store's public shape - every component selects through
 // them, so they must not change even though the reducers are now slices.
@@ -33,6 +33,7 @@ const rootReducer = combineReducers({
   logs: logsSlice.reducer,
   notify: notificationSlice.reducer,
   requesting: requestingReducer,
+  requestError: requestErrorReducer,
   editingForm: editingFormSlice.reducer,
   simulationStatus: simulationStatusSlice.reducer,
   testCampaigns: testCampaignsSlice.reducer,

--- a/src/client/src/slices/requestingSlice.js
+++ b/src/client/src/slices/requestingSlice.js
@@ -35,12 +35,13 @@ const REQUEST_STARTED = [
   storage.requestDataStorage, storage.requestUpdateDataStorage,
   storage.requestTestDataStorageConnection,
   // Logs / statistics
-  logs.requestLogFile,
+  logs.requestLogFile, logs.requestAllLogFiles, logs.requestDeleteLogFile,
   stats.requestStats,
   // Test campaigns
   campaigns.requestAllTestCampaigns, campaigns.requestDeleteTestCampaign,
   campaigns.requestAddNewTestCampaign, campaigns.requestTestCampaign,
-  campaigns.requestUpdateTestCampaign,
+  campaigns.requestUpdateTestCampaign, campaigns.requestLaunchTestCampaign,
+  campaigns.requestStopTestCampaign,
   // Test cases
   testCases.requestAllTestCases, testCases.requestTestCase,
   testCases.requestDeleteTestCase, testCases.requestAddNewTestCase,
@@ -72,7 +73,7 @@ const REQUEST_FINISHED = [
   // Data storage
   storage.setDataStorage, storage.setDataStorageConnectionStatus,
   // Logs / statistics
-  logs.requestLogFileOK,
+  logs.requestLogFileOK, logs.requestAllLogFilesOK, logs.requestDeleteLogFileOK,
   stats.requestStatsOK,
   // Any notification dismisses the spinner
   notify.setNotification,
@@ -106,3 +107,39 @@ export const requestingReducer = createRequestingReducer(
   REQUEST_STARTED,
   REQUEST_FINISHED
 );
+
+/**
+ * The failure half of the same request lifecycle: sagas surface a failed
+ * request as an error notification, so the flag is set there and cleared
+ * when that request re-enters the lifecycle - either because any new
+ * request starts (a retry, or any other activity superseding the stale
+ * failure) or because the paired settle action for the same resource
+ * arrives. Clearing on *every* settle would let an unrelated background
+ * response (a status poll, say) silently swallow a visible failure, so
+ * only the pairs below clear on settle. List views read this flag to swap
+ * their empty state for an error state with retry instead of tracking a
+ * parallel error flag per page.
+ */
+const FETCH_PAIRS = [
+  [models.requestAllModels, [models.setAllModels]],
+  [recorders.requestAllDataRecorders, [recorders.setAllDataRecorders]],
+  [datasets.requestAllDatasets, [datasets.setAllDatasets]],
+  [reports.requestAllReports, [reports.setAllReports]],
+  [campaigns.requestAllTestCampaigns, [campaigns.setAllTestCampaigns]],
+  [testCases.requestAllTestCases, [testCases.setAllTestCases]],
+  [logs.requestAllLogFiles, [logs.requestAllLogFilesOK]],
+];
+
+export const requestErrorReducer = createReducer(null, (builder) => {
+  // Errors ride the notification action; a non-error notification leaves
+  // the recorded failure untouched.
+  builder.addCase(notify.setNotification, (state, action) =>
+    action.payload.type === "error" ? { message: action.payload.message } : state
+  );
+  // Any new request supersedes the recorded failure.
+  REQUEST_STARTED.forEach((action) => builder.addCase(action, () => null));
+  // A settle paired with the failed fetch replaces it with fresh data.
+  FETCH_PAIRS.forEach(([, settledBy]) =>
+    settledBy.forEach((action) => builder.addCase(action, () => null))
+  );
+});

--- a/src/client/src/slices/requestingSlice.test.js
+++ b/src/client/src/slices/requestingSlice.test.js
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  requestAllModels,
+  setAllModels,
+  setNotification,
+  requestDeleteModel,
+} from '../actions';
+import {
+  requestAllLogFiles,
+  requestAllLogFilesOK,
+  requestDeleteLogFile,
+  requestDeleteLogFileOK,
+  requestLogFile,
+} from '../actions';
+import {
+  requestLaunchTestCampaign,
+  requestStopTestCampaign,
+  setTestCampaignRunningStatus,
+} from '../actions';
+import {
+  requestErrorReducer,
+  requestingReducer,
+} from './requestingSlice';
+
+const dispatchAll = (reducer, actions) =>
+  actions.reduce((state, action) => reducer(state, action), undefined);
+
+describe('requestingReducer', () => {
+  test('flips on for a list fetch and off when its data settles', () => {
+    let state = requestingReducer(undefined, requestAllModels());
+    expect(state).toBe(true);
+    state = requestingReducer(state, setAllModels(['a.json']));
+    expect(state).toBe(false);
+  });
+
+  test('tracks log file requests that were previously unregistered', () => {
+    expect(requestingReducer(false, requestAllLogFiles('models'))).toBe(true);
+    expect(requestingReducer(true, requestAllLogFilesOK([]))).toBe(false);
+    expect(requestingReducer(false, requestDeleteLogFile({ tool: 't', logFile: 'f' }))).toBe(true);
+    expect(requestingReducer(true, requestDeleteLogFileOK('f'))).toBe(false);
+  });
+
+  test('tracks campaign launch and stop as in-flight requests', () => {
+    // Launch settles through its success notification (the status poll that
+    // also reports running state is deliberately not tracked, so the flag
+    // does not flicker on every 3s tick).
+    let state = requestingReducer(false, requestLaunchTestCampaign());
+    expect(state).toBe(true);
+    state = requestingReducer(
+      state,
+      setNotification({ type: 'success', message: 'started' })
+    );
+    expect(state).toBe(false);
+    expect(requestingReducer(false, requestStopTestCampaign())).toBe(true);
+  });
+});
+
+describe('requestErrorReducer', () => {
+  test('is null until a request fails', () => {
+    expect(requestErrorReducer(undefined, { type: '@@INIT' })).toBeNull();
+    const state = requestErrorReducer(
+      null,
+      setNotification({ type: 'error', message: 'boom' })
+    );
+    expect(state).toEqual({ message: 'boom' });
+  });
+
+  test('records an error message from any serializable value', () => {
+    const err = new Error('network down');
+    const state = requestErrorReducer(
+      null,
+      setNotification({ type: 'error', message: err })
+    );
+    expect(state.message).toBe(err);
+  });
+
+  test('a success notification does not clear or set the error', () => {
+    const failure = requestErrorReducer(
+      null,
+      setNotification({ type: 'error', message: 'boom' })
+    );
+    expect(
+      requestErrorReducer(failure, setNotification({ type: 'success', message: 'ok' }))
+    ).toBe(failure);
+    expect(requestErrorReducer(null, setNotification({ type: 'success', message: 'ok' }))).toBeNull();
+  });
+
+  test('any new request start clears the recorded failure (retry re-entry)', () => {
+    const failure = requestErrorReducer(
+      null,
+      setNotification({ type: 'error', message: 'boom' })
+    );
+    expect(requestErrorReducer(failure, requestAllModels())).toBeNull();
+    expect(requestErrorReducer(failure, requestDeleteModel('x.json'))).toBeNull();
+  });
+
+  test('the paired settle clears it but unrelated settles do not', () => {
+    const failure = requestErrorReducer(
+      null,
+      setNotification({ type: 'error', message: 'boom' })
+    );
+    // A background simulation-status settle must not swallow the failure.
+    expect(requestErrorReducer(failure, setTestCampaignRunningStatus({}))).toEqual(failure);
+    // Its own resource settling replaces it with fresh data.
+    expect(requestErrorReducer(failure, setAllModels([]))).toBeNull();
+    // Log files have their own pair too.
+    const logFailure = requestErrorReducer(
+      null,
+      setNotification({ type: 'error', message: 'logs boom' })
+    );
+    expect(requestErrorReducer(logFailure, requestAllLogFilesOK([]))).toBeNull();
+    expect(requestErrorReducer(logFailure, requestLogFile({ tool: 't', logFile: 'f' }))).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #37
Closes #38

## Summary

Every irreversible dashboard action now asks for a keyboard-accessible confirmation naming the specific item before it runs, and every list view drives a distinct loading / empty / error state from the store's existing request lifecycle instead of rendering an empty table that could mean anything. Delete and Stop buttons on all list pages (plus event deletion on the dataset detail page) are gated behind antd `Popconfirm`/`Modal.confirm`; failed list loads render an error state with a working Retry, and genuinely empty ones render an empty state with a next action. The two issues are resolved together in one pass over the shared pages, as planned in the milestone.

## Approach

Balanced unified fix (Option 2): reuse the single global `requesting` flag for in-flight feedback, derive a small `requestError` record from the same request lifecycle rather than adding a parallel error-state layer, and gate destructive actions with antd's accessible confirm components.

## Decision Record

- **Root cause:** the dashboard's list pages dispatched removal/stop actions directly from button clicks and rendered raw tables: the global `requesting` boolean was consumed only by `LayoutPage`, several requests (`requestAllLogFiles`, `requestDeleteLogFile`, campaign launch/stop) were never registered in the lifecycle lists at all, and saga failures surfaced only as transient toasts - leaving no confirmation step, no not-yet-loaded distinction, and no retry affordance.
- **Options considered:** Option 1 — Minimal (confirm gates only); Option 2 — Balanced unified fix (confirms + request-driven states); Option 3 — Comprehensive overhaul (all detail pages, granular per-request loading map)
- **Options rejected:** Option 1 — leaves issue #38's error/retry and empty-state gaps unresolved; Option 3 — exceeds the minimum change set this batch calls for
- **Selected option:** Option 2 — Balanced unified fix
- **Residual risk:** LogsPage's genuinely-empty state offers guidance instead of a create action (log files have no user-facing create flow); error states are only shown while the table is empty so unrelated background poll failures cannot masquerade as load failures.
- **Design-confirm:** auto-selected Option 2 (complexity: medium)
- **Reproduction:** `npm --prefix src/client test -- ModelListPage` confirmed red for the stated reason (the delete fired on first click - the red run's DOM shows "SUCCESS: Model topo-a.json has been deleted!" with no confirmation) → regression tests `src/client/src/pages/ModelListPage.test.js`

Analyzed at: `fix/37-confirm-destructive-actions-before-they @ 9e3f5d8` (2026-08-23)

## Changes

| File | Change |
|------|--------|
| `src/client/src/slices/requestingSlice.js` | Register log-file and campaign launch/stop actions in the request lifecycle; add `requestErrorReducer` recording the last failure, cleared by any new request or its paired settle (immune to unrelated background settles) |
| `src/client/src/reducers/index.js` | Mount the new `requestError` state key |
| `src/client/src/components/ListStates/` | New shared `ListStateEmpty` / `ListStateError` presentational components |
| `src/client/src/pages/ModelListPage.js` | Confirm-gated Delete topology + Stop simulation; empty/error table states with retry |
| `src/client/src/pages/DataRecorderListPage.js` | Confirm-gated Delete recorder + Stop recorder; empty/error table states |
| `src/client/src/pages/DatasetListPage.js` | Confirm-gated Delete dataset; empty/error table states |
| `src/client/src/pages/DatasetPage.js` | Confirm-gated event deletion (`Modal.confirm` naming the event); retry banner for a failed dataset fetch; restored `totalNbEvents` wiring caught in review |
| `src/client/src/pages/ReportListPage.js` | Confirm-gated Delete report; empty/error table states |
| `src/client/src/pages/LogsPage.js` | Confirm-gated Delete log file; empty/error table states (loading now tracked for this page too) |
| `src/client/src/pages/TestCampaignListPage.js` | Confirm-gated Delete campaign + Stop running build; empty/error table states |
| `src/client/src/pages/TestCaseListPage.js` | Confirm-gated Delete test case; empty/error table states |
| `src/client/src/pages/ModelListPage.test.js` | Red-first regression coverage: no API call until confirmed, cancel leaves intact, stop confirms, empty CTA, error retry re-issues |
| `src/client/src/pages/TestCaseListPage.test.js` | Same gates on a second resource family |
| `src/client/src/pages/DatasetPage.test.js` | Statistics render path + retry banner lifecycle |
| `src/client/src/slices/requestingSlice.test.js` | Lifecycle unit tests incl. newly tracked actions and paired-settle clearing |

## Test Results

- Unit tests: 8 passed (`requestingSlice.test.js`)
- Component/integration tests: 12 passed (ModelListPage 5, TestCaseListPage 4, DatasetPage 3; vitest + Testing Library, real store + sagas, mocked api)
- E2e tests: none (no e2e framework in the repo)
- Build: `vite build` passed
- Regression guard: root suite `npm test` 432 passed / 0 failed (baseline ≥285 intact)
- QA cycles: 2

## Acceptance Criteria Verification

**Issue #37**

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Every irreversible action asks for confirmation before proceeding | pass | Popconfirm wraps every Delete/Stop in the 7 list pages; Modal.confirm gates event deletion (`DatasetPage.deleteEventWithConfirmation`) |
| The confirmation names the specific item being affected | pass | Titles interpolate the item, e.g. `Delete topology "${item.name}"?`; asserted in ModelListPage.test.js / TestCaseListPage.test.js |
| Cancelling leaves the item untouched | pass | `onConfirm` is the only dispatch path; Cancel assertions in both page suites show zero API calls and rows still rendered |
| Stopping a running simulation or recording is confirmed as well | pass | Stop simulation (`ModelListPage`), Stop recorder (`DataRecorderListPage`), Stop build (`TestCampaignListPage`) each wrapped; stop-confirm tested in ModelListPage.test.js |
| The confirmation is reachable and dismissible by keyboard | pass | antd `Popconfirm`/`Modal` manage focus and dismiss on Esc natively; triggers are standard focusable Buttons |

**Issue #38**

| Criterion | Status | Evidence |
|-----------|--------|----------|
| A loading indicator is shown while a list request is in flight | pass | Existing global `requesting` spinner via LayoutPage; newly registered log/campaign actions covered by requestingSlice.test.js |
| A genuinely empty list shows a distinct empty state with a clear next action | pass | `ListStateEmpty` CTAs per page ("Create New Topology", "Add New Case", ...); asserted in both page suites |
| A failed request shows an error state with a retry control that re-issues the request | pass | `ListStateError` + Retry dispatching the original fetch; ModelListPage.test.js asserts the second call after failure |
| The indicator is driven by the existing request state rather than new duplicate state | pass | `requestErrorReducer` derives from the same lifecycle lists in requestingSlice.js; no per-page loading flags added |
| Detail views and long-running actions receive the same treatment | pass | DatasetPage retry banner + confirmed event deletion; long-running start/stop actions get confirms plus the in-flight spinner |

<!-- gitissue:qa v1 head=9336a31539875f796806f9b10a752d960f7dba2a profile=full cycles=2 review=clean tests=43@9336a31539875f796806f9b10a752d960f7dba2a ui=code:clean@9336a31539875f796806f9b10a752d960f7dba2a -->
