### PR TITLE
docs: document shipped authentication and add contributor docs (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,89 @@
+# Changelog
+
+All notable changes to TaS are documented in this file. Releases are cut as
+`v*` tags and published as the `ghcr.io/montimage/tas` container image (stable
+`vX.Y.Z` tags also move the `latest` tag). The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+The 2026 hardening and modernisation programme. No release tag has been cut
+from this work yet — everything below is on `master`, and the newest published
+image tags (`v1.0.x`) still predate all of it.
+
+### Security
+
+Security fixes and hardening are listed here explicitly; each also appears
+under its functional section below.
+
+- **API authentication**: every endpoint requires an authenticated session;
+  single administrator account provisioned from configuration, session
+  cookies, CSRF protection, login rate limiting (#64), asserted end-to-end
+  (#66).
+- **Filesystem containment**: name-derived file paths are contained and
+  sanitised across models, devops and test-case routes (#50, #57).
+- **CORS allowlist**: cross-origin access restricted to an explicit allowlist,
+  same-origin compared by host (#52), with body-size caps and rate limiting.
+- **Non-root container runtime** on a supported Node base image, supply-chain
+  cleanup (#51).
+- **Request validation**: parameters, query strings and bodies validated on
+  every route (#60); correct HTTP status codes without internal error leakage
+  (#61).
+- **Content Security Policy** served explicitly via an upgraded helmet
+  (#63) and enforced by default (#97).
+- **Credential hygiene**: the database connector no longer logs credentials
+  (#96).
+- **Dependency advisory gate** blocking pull requests on high/critical
+  production advisories (#101); jsoneditor advisories cleared by the v10
+  upgrade (#117).
+
+### Added
+
+- Composed deployment: the monolith image split into separate `app`, `broker`
+  and `nodered` services wired by `docker compose`, each with its own health
+  check and independent restart (#114).
+- Graceful shutdown: in-flight requests drained and the database closed on
+  `SIGTERM`/`SIGINT` (#99).
+- E2E security regression suite run on every push and pull request (#54),
+  plus lint on pull requests and weekly Dependabot updates (#103).
+- Test coverage suites for evaluation, data-sources and `/api/health` (#91);
+  the real core suites now run in CI while fake `src` test scripts were
+  retired (#124).
+- Agent-runnable environment docs (`CLAUDE.md`, `AGENTS.md`) (#87).
+- Client: confirmation gates for destructive actions and request-state
+  feedback on list views (#125).
+
+### Changed
+
+- Dashboard build migrated from CRA to Vite (#89); the compiled client bundle
+  is no longer committed and is produced at build time (#90).
+- Frontend stack uplifted: React/Router/Ant Design/testing-library major
+  upgrades (#116), topology view rebuilt on d3 7 replacing react-d3-graph
+  (#118), state layer moved to Redux Toolkit slices (#119).
+- MongoDB layer migrated to mongoose v9 (#115).
+- Runtime pinned to Node.js 24 LTS across manifests, image and CI (#120).
+- Linting consolidated on ESLint + Prettier with a pre-commit hook (#88).
+- Dependency stack upgraded with body parser aligned to query parser (#100);
+  vestigial Babel configuration removed (#121).
+- Container runs the app in production mode with explicit broker
+  configuration (#102).
+- Server correctness: log router kind required and validated at mount time
+  (#122); numeric configuration parsing made explicit with dead code swept
+  (#123); model filename reported as written (#94); logger no longer replaces
+  global console methods (#95); data-storage recovery path no longer crashes
+  (#93).
+- Release workflow strips tag prefixes exactly when publishing images (#98).
+- Documentation: deployment security posture (#53) and hardening
+  configuration knobs (#56), credential provisioning (#97), contributing
+  guide, security policy correction and this changelog (#48), README
+  authentication consistency (#86).
+
+## [1.0.3] - 2024-02-16
+
+Last tagged release before the 2026 programme. The published image tags
+`v1.0`, `v1.0.2` (2024-02-15) and `v1.0.3` all **predate authentication**:
+their API is unauthenticated, and they must not be exposed to untrusted
+networks. No in-repo changelog existed before this file.
+
+[Unreleased]: https://github.com/Montimage/tas/compare/v1.0.3...master
+[1.0.3]: https://github.com/Montimage/tas/releases/tag/v1.0.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+# Contributing to TaS
+
+Thank you for considering a contribution. This guide covers setting the
+project up, running the tests and submitting a change.
+
+## Getting started
+
+The runtime is pinned to **Node.js 24 LTS** (`.nvmrc`); both manifests declare
+it under `engines`. With Node 24 active:
+
+```
+git clone git@github.com:Montimage/tas.git
+cd tas
+npm install
+```
+
+The web dashboard under `src/client/` is built with Vite and emitted to
+`src/public/`, which the server serves at `/`. The compiled bundle is not
+committed, so build it once after installing dependencies:
+
+```
+cd src/client
+npm install
+npm run build      # emits to ../public (i.e. src/public)
+npm run dev        # instead of build, for local development with hot reload
+cd ../..
+```
+
+To run the application locally, create a `.env` from `env.example` and
+provision an administrator credential — every API endpoint requires an
+authenticated session. The exact steps are in the
+[README](README.md#install-from-source-code) (install-from-source section and
+[Provisioning the administrator credential](README.md#provisioning-the-administrator-credential)).
+
+## Running the tests
+
+```
+npm test
+```
+
+runs everything under `test/` serialised (`--test-concurrency=1`, because some
+end-to-end files each spawn their own real server instance). A full run takes
+roughly half a minute; a change is only ready when the whole suite passes.
+
+The E2E security regression suite can also be driven on its own — HTTP
+assertions (path containment, name sanitisation, CORS, rate/body limits,
+legitimate flows) and a non-root container check:
+
+```
+node --test-concurrency=1 --test test/e2e/security-suite.test.js test/e2e/limits.test.js
+
+docker build -t montimage/tas:e2e .
+TAS_IMAGE=montimage/tas:e2e node --test test/e2e/container-nonroot.test.js
+```
+
+## Lint and format
+
+Linting is ESLint; formatting is Prettier:
+
+```
+npm run lint        # eslint .
+npm run lint:fix    # eslint --fix
+npm run format:check
+npm run format      # prettier --write
+```
+
+A Husky pre-commit hook runs ESLint and Prettier on staged files via
+`lint-staged`.
+
+## Submitting a change
+
+- Branch from `master`; name branches after the issue they resolve, e.g.
+  `fix/42-short-description`, `feat/N-...`, `docs/N-...`.
+- Write [conventional commits](https://www.conventionalcommits.org/) with the
+  issue reference, one logical change per commit:
+  `fix(auth): resolve redirect loop (#42)`.
+- Open a pull request that describes what changed and why, and reference the
+  issue it closes (`Closes #N`).
+- Keep the full test suite passing and add or extend tests for behaviour you
+  change.
+
+### Continuous integration
+
+Every pull request runs the **E2E Security Regression Suite** workflow:
+
+- the full test suite plus end-to-end assertions over HTTP,
+- `eslint`,
+- a gate on high/critical advisories in production dependencies
+  (`scripts/audit-gate.js`),
+- an assertion that the built container image runs as a non-root user.
+
+A pull request is mergeable only when all of these pass. Dependency updates
+for both manifests (the server root and the dashboard client) are proposed
+weekly by Dependabot.
+
+## Reporting security issues
+
+Please do **not** open public issues for undisclosed vulnerabilities — report
+them privately as described in [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -59,11 +59,14 @@ MOSQUITTO_PASSWORD=change-me-broker
 
 ### Running only the application container
 
-The application image is published on its own and can run standalone — point
-its clients at any reachable broker via `TAS_MQTT_HOST` / `TAS_MQTT_PORT`:
+The application image can run standalone — point its clients at any reachable
+broker via `TAS_MQTT_HOST` / `TAS_MQTT_PORT`. The tags currently published to
+ghcr.io predate authentication (see the [changelog](CHANGELOG.md)), so build
+the image from this checkout instead of pulling one:
 
 ```
-TAS_IMAGE=ghcr.io/montimage/tas:v1.0.2
+docker build -t tas:local .
+TAS_IMAGE=tas:local
 
 # One-time administrator credential. The password is hashed where you type it;
 # only the scrypt hash reaches the container's environment.
@@ -218,6 +221,27 @@ Update the `host` and `port` then start the application.
 > it locally, and never commit a `.env` file. Without a local `.env`, the
 > server starts with the safe defaults from `env.example`.
 
+_Provision an administrator credential_
+
+Every API endpoint requires an authenticated session, so a fresh install
+cannot log in until the server has its administrator credential and session
+secret. Generate the password hash from this checkout and put both values in
+`.env`:
+
+```
+node -e "console.log(require('./src/server/auth/passwords').hashPassword(process.argv[1]))" 'your-password-here'
+# scrypt$16384$8$1$<salt>$<hash>
+```
+
+```
+AUTH_ADMIN_USERNAME=admin
+AUTH_ADMIN_PASSWORD_HASH=scrypt$16384$8$1$...   # output of the command above
+SESSION_SECRET=$(openssl rand -hex 32)
+```
+
+See [Provisioning the administrator credential](#provisioning-the-administrator-credential)
+in the Security section for what these values mean and for alternatives.
+
 _Start the application_
 
 ```
@@ -225,6 +249,7 @@ npm run start
 ```
 
 Access to the Test and Simulation Enabler dashboard at: `http://your_ip:3004`
+Log in with the administrator username and password you provisioned above.
 
 ## Connect to a MongoDB Server
 
@@ -649,6 +674,13 @@ above is what replaces it. No header that was previously sent has been dropped.
 See [SECURITY.md](SECURITY.md) for how to report a vulnerability privately. We
 ask that you **do not** disclose unknown issues on public channels before they
 are triaged.
+
+## Contributing
+
+Contributions are welcome — [CONTRIBUTING.md](CONTRIBUTING.md) covers how to
+set up the project, run the tests, lint and submit a change. Notable changes
+per release, with security fixes flagged explicitly, are recorded in
+[CHANGELOG.md](CHANGELOG.md).
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,14 @@ node -e "console.log(require('./src/server/auth/passwords').hashPassword(process
 ```
 AUTH_ADMIN_USERNAME=admin
 AUTH_ADMIN_PASSWORD_HASH=scrypt$16384$8$1$...   # output of the command above
-SESSION_SECRET=$(openssl rand -hex 32)
+```
+
+Generate the session secret with `openssl rand -hex 32` and paste the value it
+prints on the `SESSION_SECRET` line (`.env` values are read literally, so do not
+put the `$(openssl …)` command itself there):
+
+```
+SESSION_SECRET=64-hex-characters-printed-by-openssl
 ```
 
 See [Provisioning the administrator credential](#provisioning-the-administrator-credential)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,6 +32,11 @@ released as part of the next stable release or as a dedicated one.
 
 ## Known limitations
 
-As documented in the README, TaS currently has **no built-in authentication**.
-Until native authentication lands, operate the service on loopback or a trusted
-private network only, per the [deployment baseline](README.md#security).
+The API requires an authenticated session: there is a single administrator
+account, provisioned from configuration rather than from this repository, and
+every other caller is refused. There are no roles or per-user accounts —
+anyone holding the administrator credential can do everything — so operate
+the service on loopback or a trusted private network only, per the
+[deployment baseline](README.md#deployment-baseline). The MQTT broker
+requires authentication on its published port; the Node-RED editor has no
+credential of its own and must not be exposed to untrusted networks.


### PR DESCRIPTION
Closes #86
Closes #48

## Summary

The docs no longer described the product that exists: the standalone-container quick start still pinned `ghcr.io/montimage/tas:v1.0.2` — a tag built two years before authentication shipped (PR #64) — together with a credential-hash snippet that cannot even run on that image; SECURITY.md still claimed TaS "has **no built-in authentication**"; the source-install path never said how to provision the administrator credential needed to log in; and there was no contributing guide or changelog. This PR corrects the stale claims, completes both install paths end-to-end, and adds CONTRIBUTING.md plus CHANGELOG.md, linking all three from the README.

## Approach

Minimal unified documentation correction (batch resolution of #86 + #48, which share affected files). No code is touched; every documented command was verified against the repository it describes.

## Decision Record

- **Root cause:** Phase-0 security docs were only partially updated after authentication landed (#64): the standalone-container section kept its pre-auth image pin (`v1.0.2` — auth commit `52d0eb5` is not an ancestor of any published tag, and GHCR's newest digest dates to 2024-02), SECURITY.md kept its pre-auth disclaimer, and the plan-item-45 contributor/changelog docs were never written.
- **Options considered:** Option 1 — minimal unified docs correction (build locally instead of naming an unverifiable tag; correct SECURITY.md in place; add the two missing docs); Option 2 — comprehensive README restructure around deployment modes; Option 3 — name the *future* release tag that will contain authentication.
- **Options rejected:** Option 2 — churn far beyond either issue's acceptance criteria; Option 3 — invents facts about an unreleased tag, violating "the README describes the product that exists".
- **Selected option:** Option 1 — minimal unified docs correction.
- **Residual risk:** "tags currently published to ghcr.io predate authentication" becomes outdated the moment maintainers cut a post-auth release; mitigated by pointing at CHANGELOG.md, whose `[Unreleased]` note states exactly when that changes.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle.
- **Reproduction:** manual repro — no code seam: `git merge-base --is-ancestor 52d0eb5 v1.0.2` → NO proves the pinned image predates authentication (so its documented `hashPassword` one-liner cannot work there), and `grep -r "no built-in authentication" *.md` matched SECURITY.md only while the same file set documents session-authenticated endpoints.

Analyzed at: `fix/86-the-readme-contradicting-itself-on @ 6ac36cf` (2026-08-23)

## Changes

| File | Change |
|------|--------|
| `README.md` | Standalone-container section builds `tas:local` from source instead of pinning pre-auth `v1.0.2`; source-install path gains the missing "Provision an administrator credential" step so a clean clone can log in; new Contributing section links CONTRIBUTING.md and CHANGELOG.md |
| `SECURITY.md` | "Known limitations" rewritten from the false "no built-in authentication" claim to shipped reality (single config-provisioned admin account, everyone else refused); reporting channel and response timeline unchanged |
| `CONTRIBUTING.md` | New: prerequisites (Node 24), install, client build, tests incl. E2E security suite commands, lint/format, branch/commit conventions, CI gates |
| `CHANGELOG.md` | New, Keep-a-Changelog format: `[Unreleased]` covers the 2026 programme (PRs #50–#125) with security fixes flagged in an explicit Security section; `[1.0.3] - 2024-02-16` records that all published tags predate authentication |

## Test Results

- Unit/integration/e2e (`npm test`): 432 passed, 0 failed, 3 skipped (baseline ≥285/286 holds)
- Lint: 0 errors (2 warnings pre-existing on `master`)
- Formatting: `prettier --check` clean on all four files
- Secret scan (`gi-secscan`, policy `origin/master`): clean, 4 files scanned / 0 skipped
- QA cycles: 1

## Acceptance Criteria Verification

### #86 — Fix the README contradicting itself on authentication

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Stale "no built-in authentication" warning gone; quick start names an image tag that contains authentication | pass | Warning absent from README head (removed by #114-era rewrites); standalone section now builds `tas:local` (README.md:62-72) because every published tag provably predates auth (`git merge-base --is-ancestor 52d0eb5 <tag>` = NO for v1.0/v1.0.2/v1.0.3/v1.1; GHCR listing confirms latest = v1.0.3 digest of 2024-02) |
| Install-from-source includes client install and build | pass | "Build the dashboard" section, README.md:190-205 (landed with #89/#90, retained) |
| Following install end-to-end on a clean clone produces a dashboard that can log in | pass | New provisioning step README.md:224-245; command verified against exported `hashPassword` (src/server/auth/passwords.js:66,117); env keys match `env.example` |
| Credential provisioning step appears in the quick start, not only Security | pass | Compose path README.md:34-58; source path README.md:224-245; details remain in Security section |
| `npm test` passes at ≥285/286 | pass | 432 passed / 0 failed / 3 skipped on this exact tree |

### #48 — Add contributing, security policy and changelog documentation

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Contributing guide documents setup, tests, lint and submission | pass | CONTRIBUTING.md (all four sections) |
| Security policy names a private reporting channel and expected response time | pass | SECURITY.md:11-31 (private vulnerability reporting URL; 5 business days) — extended, not replaced |
| Changelog records notable changes per release, flagging security fixes explicitly | pass | CHANGELOG.md `### Security` subsection under `[Unreleased]` |
| Changelog covers the releases produced by this improvement programme | pass | `[Unreleased]` enumerates programme PRs #50–#125 and notes no tag has been cut yet; `[1.0.3]` anchors the last published tag |
| README links all three | pass | SECURITY.md at README.md:675; CONTRIBUTING.md + CHANGELOG.md at README.md:678-684 |

<!-- gitissue:qa v1 head=6ac36cf9d40556aca8b7fa8e25ae7b752981e912 profile=light cycles=1 review=clean tests=432@6ac36cf9d40556aca8b7fa8e25ae7b752981e912 ui=none -->
