### PR TITLE
fix(server): simulation stats hardening and update-route 404s (#16)

### DIFF
--- a/src/server/routes/data-sets.js
+++ b/src/server/routes/data-sets.js
@@ -126,6 +126,9 @@ router.post(
         { id: datasetId },
         { ...dataset, lastModified: Date.now() }
       );
+      if (!ts) {
+        return next(notFound('Data set not found'));
+      }
       res.send({
         dataset: ts,
       });

--- a/src/server/routes/events.js
+++ b/src/server/routes/events.js
@@ -200,6 +200,9 @@ router.post(
 
     try {
       const ts = await EventSchema.findByIdAndUpdate(eventId, event);
+      if (!ts) {
+        return next(notFound('Event not found'));
+      }
       res.send({
         event: ts,
       });

--- a/src/server/routes/simulation.js
+++ b/src/server/routes/simulation.js
@@ -1,3 +1,4 @@
+'use strict';
 /* Working with Data Generator */
 var express = require('express');
 const Joi = require('joi');

--- a/src/server/routes/test-campaigns.js
+++ b/src/server/routes/test-campaigns.js
@@ -115,6 +115,9 @@ router.post(
 
     try {
       const ts = await TestCampaignSchema.findOneAndUpdate({ id: testCampaignId }, testCampaign);
+      if (!ts) {
+        return next(notFound('Test campaign not found'));
+      }
       res.send({
         testCampaign: ts,
       });

--- a/src/server/routes/test-cases.js
+++ b/src/server/routes/test-cases.js
@@ -173,6 +173,9 @@ router.post(
 
     try {
       const ts = await TestCaseSchema.findOneAndUpdate({ id: testCaseId }, update);
+      if (!ts) {
+        return next(notFound('Test case not found'));
+      }
       res.send({
         testCase: ts,
       });

--- a/test/simulation-stats.test.js
+++ b/test/simulation-stats.test.js
@@ -1,0 +1,178 @@
+// Simulation statistics endpoint (issue #16).
+//
+// The route used to read a binding that was never assigned, so every call
+// threw a ReferenceError; PR #61 rewrote it onto the router's own registry.
+// What was still missing on master was strict mode - without it an
+// undeclared assignment in this module silently becomes a global that
+// persists across requests - and behavioural coverage of the running,
+// stopped and isolated-states paths. No live MongoDB is needed: the default
+// data-storage configuration is read from the committed file and no run
+// here declares devices, so nothing ever connects.
+const { test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const express = require('express');
+const { request } = require('./_http');
+
+const simulationRouter = require('../src/server/routes/simulation');
+const { OFFLINE, SIMULATING } = require('../src/core/DeviceStatus');
+const { getObjectId } = require('../src/core/utils');
+
+const simulationLogsDir = path.resolve(__dirname, '../src/server/logs/simulations');
+
+let server;
+
+before(() => {
+  // Nothing under src/server/logs is tracked, so on a fresh checkout the
+  // directory does not exist and a start would have nowhere to log.
+  fs.mkdirSync(simulationLogsDir, { recursive: true });
+  const app = express();
+  app.use(express.json());
+  app.use('/api/simulation', simulationRouter);
+  server = app.listen(0);
+});
+
+after(() => {
+  server.close();
+});
+
+const unique = (prefix) => `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+/** Remove the run log a start leaves behind; nothing else ever does. */
+const removeRunLogs = (name) => {
+  let entries;
+  try {
+    entries = fs.readdirSync(simulationLogsDir);
+  } catch (e) {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.startsWith(`${name}_`)) fs.unlinkSync(path.join(simulationLogsDir, entry));
+  }
+};
+
+test('requesting statistics with no simulation running answers null stats, not an error', async () => {
+  const res = await request(server, 'GET', '/api/simulation/stats');
+  assert.equal(res.status, 200, `stats must be served (${res.raw})`);
+  assert.equal(res.body.error, null, `a served call carries no error (${res.raw})`);
+  assert.equal(res.body.stats, null, 'an empty registry has nothing to report');
+});
+
+test('a running simulation reports its statistics, and stops reporting once stopped', async () => {
+  const name = unique('stats-topology');
+  try {
+    const started = await request(server, 'POST', '/api/simulation/start', {
+      model: { name, devices: [] },
+      options: {},
+    });
+    assert.equal(started.status, 200, `the run must start (${started.raw})`);
+
+    const stats = await request(server, 'GET', '/api/simulation/stats');
+    assert.equal(stats.status, 200, `stats must be served while running (${stats.raw})`);
+    assert.equal(stats.body.error, null, `a served call carries no error (${stats.raw})`);
+    assert.ok(
+      Array.isArray(stats.body.stats),
+      `a running simulation must report its statistics (${stats.raw})`
+    );
+
+    const stopped = await request(server, 'GET', `/api/simulation/stop/${name}.json`);
+    assert.equal(stopped.status, 200, `the run must stop (${stopped.raw})`);
+
+    const afterStop = await request(server, 'GET', '/api/simulation/stats');
+    assert.equal(afterStop.status, 200, `stats must still be served (${afterStop.raw})`);
+    assert.equal(
+      afterStop.body.stats,
+      null,
+      `a stopped simulation must not report statistics (${afterStop.raw})`
+    );
+  } finally {
+    await request(server, 'GET', `/api/simulation/stop/${name}.json`);
+    removeRunLogs(name);
+  }
+});
+
+test('concurrent runs of different topologies keep their state apart', async () => {
+  // The bug class behind this issue was shared module-level state: two
+  // handlers assigning undeclared names created globals one request could
+  // read into another's. The registry keys each run by its topology id, so
+  // two topologies started together are registered, reported and stopped
+  // independently of each other.
+  const first = unique('iv-stats-a');
+  const second = unique('iv-stats-b');
+  try {
+    const starts = await Promise.all([
+      request(server, 'POST', '/api/simulation/start', {
+        model: { name: first, devices: [] },
+        options: {},
+      }),
+      request(server, 'POST', '/api/simulation/start', {
+        model: { name: second, devices: [] },
+        options: {},
+      }),
+    ]);
+    assert.deepEqual(
+      starts.map((start) => start.status),
+      [200, 200],
+      `both distinct topologies must be servable (${starts.map((start) => start.raw).join(' | ')})`
+    );
+
+    const status = await request(server, 'GET', '/api/simulation/status');
+    assert.equal(status.status, 200, `status must be served (${status.raw})`);
+    // The registry keys each run by the hashed topology id, not the name.
+    const entries = status.body.simulationStatus || {};
+    assert.equal(
+      entries[getObjectId(second)].isRunning,
+      true,
+      'the second run must be its own entry'
+    );
+    assert.notEqual(
+      getObjectId(first),
+      getObjectId(second),
+      'the two runs must not collapse onto one key'
+    );
+
+    await request(server, 'GET', `/api/simulation/stop/${first}.json`);
+    const afterFirstStops = await request(server, 'GET', '/api/simulation/status');
+    const entriesAfter = afterFirstStops.body.simulationStatus || {};
+    assert.equal(
+      entriesAfter[getObjectId(first)].isRunning,
+      false,
+      'the stopped run reports stopped'
+    );
+    assert.equal(entriesAfter[getObjectId(second)].isRunning, true, 'the other run is untouched');
+  } finally {
+    await request(server, 'GET', `/api/simulation/stop/${first}.json`);
+    await request(server, 'GET', `/api/simulation/stop/${second}.json`);
+    removeRunLogs(first);
+    removeRunLogs(second);
+  }
+});
+
+test('the module runs in strict mode so an undeclared assignment fails loudly', () => {
+  // Strict mode is what turns this issue's whole bug class - assigning to a
+  // name that was never declared - from a silent cross-request global into
+  // a ReferenceError at the moment of the mistake.
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../src/server/routes/simulation.js'),
+    'utf8'
+  );
+  assert.match(
+    source,
+    /^['"]use strict['"];/,
+    'simulation.js must open with a use strict directive'
+  );
+
+  // The predicate /status and /stats read is the class's own status field:
+  // pinning it here keeps a future rename from silently deadening both.
+  const Simulation = require('../src/core/simulation');
+  const simulation = new Simulation({ name: unique('strict-probe'), devices: [] }, {});
+  assert.equal(simulation.status, OFFLINE, 'a fresh run is offline');
+  simulation.start();
+  try {
+    assert.equal(simulation.status, SIMULATING, 'start() marks the run running');
+  } finally {
+    simulation.stop();
+  }
+  assert.equal(simulation.status, OFFLINE, 'stop() marks the run offline');
+});

--- a/test/update-not-found.test.js
+++ b/test/update-not-found.test.js
@@ -1,0 +1,118 @@
+// Updating a database-backed resource that does not exist answers 404
+// (issue #62).
+//
+// Issue #11 routed the API onto conventional status codes through one central
+// handler, but its not-found guard for update routes landed on reports.js
+// alone. The other four update handlers kept answering 200 with a null
+// document, so a client could not tell a successful update from an update of
+// a record that was never there.
+//
+// No live MongoDB: the schemas are stubbed at the boundary where the routes
+// meet them - the same seam test/reports-pagination.test.js uses - returning
+// exactly what Mongoose returns for a missing document (null). The full route
+// pipeline runs for real: validation, dbConnector, handler, and the shared
+// error handler that renders the response.
+const { test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const { request } = require('./_http');
+
+// The routers captured their bindings from this module when they were first
+// required, so the stubs must be in place before they load. Replacing the
+// properties on the cached exports object is what puts them there - each
+// router destructures these names off this very object as it loads.
+const connectorPath = require.resolve('../src/server/routes/db-connector');
+
+/** One stub model per resource; `nextResult` is what every lookup returns. */
+let nextResult;
+const stubModel = () => ({
+  findOneAndUpdate: async () => nextResult,
+  findByIdAndUpdate: async () => nextResult,
+});
+
+const connector = require(connectorPath);
+connector.dbConnector = (req, res, next) => next();
+connector.TestCampaignSchema = stubModel();
+connector.TestCaseSchema = stubModel();
+connector.DatasetSchema = stubModel();
+connector.EventSchema = stubModel();
+
+const testCampaignRouter = require('../src/server/routes/test-campaigns');
+const testCasesRouter = require('../src/server/routes/test-cases');
+const dataSetRouter = require('../src/server/routes/data-sets');
+const eventRouter = require('../src/server/routes/events');
+
+let server;
+
+before(() => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/test-campaigns', testCampaignRouter);
+  app.use('/api/test-cases', testCasesRouter);
+  app.use('/api/data-sets', dataSetRouter);
+  app.use('/api/events', eventRouter);
+  server = app.listen(0);
+});
+
+// The listening socket is a live handle: without this the suite's process
+// outlives its tests and the runner waits for it forever.
+after(() => {
+  server.close();
+});
+
+/**
+ * Assert a failure response is exactly what the central handler renders:
+ * its status, one string message, and nothing besides `error`/`details`.
+ */
+const assertErrorShape = (res, status, context) => {
+  assert.equal(res.status, status, `expected ${status} for ${context}, got ${res.status}`);
+  assert.ok(res.body, `${context} must answer with a JSON body (${res.raw})`);
+  assert.equal(typeof res.body.error, 'string', `${context} must carry a string error`);
+  assert.ok(res.body.error.length > 0, `${context} must name the failure (${res.raw})`);
+  assert.deepEqual(
+    Object.keys(res.body).filter((key) => key !== 'error' && key !== 'details'),
+    [],
+    `an error body carries nothing but error and details: ${res.raw}`
+  );
+};
+
+// The four updates the issue names, each driven against a missing document.
+const cases = [
+  [
+    'test campaign',
+    ['POST', '/api/test-campaigns/no-such-test-campaign', { testCampaign: { name: 'x' } }],
+    'Test campaign not found',
+  ],
+  [
+    'test case',
+    ['POST', '/api/test-cases/no-such-test-case', { testCase: { name: 'x' } }],
+    'Test case not found',
+  ],
+  [
+    'data set',
+    ['POST', '/api/data-sets/no-such-data-set', { dataset: { name: 'x' } }],
+    'Data set not found',
+  ],
+  ['event', ['POST', '/api/events/no-such-event', { event: {} }], 'Event not found'],
+];
+
+for (const [resource, [method, routePath, body], message] of cases) {
+  test(`updating a non-existent ${resource} returns a JSON 404`, async () => {
+    nextResult = null; // Mongoose returns null when nothing matched.
+    const res = await request(server, method, routePath, body);
+    assertErrorShape(res, 404, `${method} ${routePath} against a missing document`);
+    assert.equal(res.body.error, message);
+  });
+}
+
+test('an update that does match a document is still served with the document', async () => {
+  // The guard exists to catch a missing document, not to refuse updates:
+  // with a document found, all four routes keep their historical shape.
+  const stored = { _id: '64b64b64b64b64b64b64b64b', id: 'stored-1', name: 'stored' };
+  nextResult = stored;
+  for (const [, [method, routePath, body]] of cases) {
+    const res = await request(server, method, routePath, body);
+    assert.equal(res.status, 200, `a matching update must be served (${res.raw})`);
+    assert.equal(res.body.error, undefined, `a served update carries no error (${res.raw})`);
+  }
+});


### PR DESCRIPTION
Closes #16
Closes #62

## Summary

Two route-module correctness fixes from the same root-cause class — modules predating #11's central-error-handler discipline:

1. **#16 — simulation stats endpoint.** The `ReferenceError` crash itself was already repaired on master by PR #61 (the route now reads the router's own registry). This PR closes what remained of the issue: the module now runs in `'use strict'`, so the undeclared-assignment bug class behind the original crash fails loudly instead of silently creating cross-request globals, and the `/stats` behaviour (running → statistics, stopped/unknown → `{error: null, stats: null}`, distinct topologies isolated) is pinned by regression tests.
2. **#62 — missing-document update 404s.** The not-found guard from reports.js is applied to the four remaining database-backed update routes, so updating a resource that does not exist answers a JSON 404 in the central error shape instead of `200` with `{resource: null}`.

## Approach

Minimal replication of merged patterns: `'use strict';` as the first statement of `simulation.js` (all assignments verified declared; the full suite now runs that module strict), and `if (!ts) return next(notFound('<Resource> not found'))` immediately after each `findOneAndUpdate`/`findByIdAndUpdate` — byte-for-byte the shape reports.js:191-193 already uses, with messages matching each route's own GET guard. Tests drive real HTTP through the full pipeline (validation → dbConnector → handler → shared errorHandler); for #62 the mongoose models are stubbed at the boundary where routes meet them, returning exactly what Mongoose returns for a missing document (`null`) — no live MongoDB needed.

## Decision Record

- **Root cause (#16):** route modules written before the #11 discipline; the crashed handler referenced an undeclared binding and two handlers assigned undeclared names that became implicit globals in the non-strict module. PR #61 removed the crash and visible leaks; strict mode + tests make the class loud and keep it fixed.
- **Selected option:** Option 1 from `.gitissue/analysis-16.json` / `analysis-62.json` (strict-mode hardening + regression tests; replicate reports guard + stubbed-model tests).
- **Options rejected:** repo-wide strict-mode rollout (far beyond the issue's module scope, large blast radius); real-MongoDB integration harness (new external test dependency for behaviour a boundary-level stub verifies just as well).

## Changes

| File | Change |
|------|--------|
| `src/server/routes/simulation.js` | `'use strict'` directive; no logic change |
| `src/server/routes/test-campaigns.js` | 404 guard on `POST /:testCampaignId` |
| `src/server/routes/test-cases.js` | 404 guard on `POST /:testCaseId` |
| `src/server/routes/data-sets.js` | 404 guard on `POST /:datasetId` |
| `src/server/routes/events.js` | 404 guard on `POST /:eventId` |
| `test/update-not-found.test.js` | New suite: four missing-document updates answer JSON 404 in the central shape; matching updates still serve 200 |
| `test/simulation-stats.test.js` | New suite: `/stats` running/stopped/empty paths, concurrent-topology isolation, strict-mode directive |

## Test Results

`npm test` on HEAD b9aedeb: **469 tests — 466 pass, 0 fail, 3 skipped** (baseline ≥285/286 intact). `npm run lint`: 0 errors (2 pre-existing warnings in untouched files). Reproduction evidence for #16: the pre-fix stats path was already repaired on master; the new suite pins it red-proof against regression (an undeclared assignment in the router now throws under strict mode and fails the suite loudly).

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| #16: statistics for a running simulation return its statistics | ✅ `simulation-stats.test.js` — running run returns non-null stats array |
| #16: unknown or stopped simulation returns clear response, not an error | ✅ empty registry and post-stop both answer `200 {error: null, stats: null}` |
| #16: no variable assigned without declaration | ✅ verified by read; enforced henceforth by strict mode |
| #16: module runs in strict mode | ✅ directive asserted by test; whole module exercised under it |
| #16: concurrent requests for different simulations do not share state | ✅ two topologies started concurrently register, report and stop independently |
| #62: updating a non-existent test campaign / test case / data set / event returns JSON 404 | ✅ one test each in `update-not-found.test.js` |
| #62: all four responses use the central error shape from `middleware/errors.js` | ✅ body asserted to carry only `{error}` with status 404 |
| #62: each covered by a test exercising the real route against a missing document | ✅ full pipeline over real HTTP with model stubbed to Mongoose's missing-document result |

<!-- gitissue:qa v1 head=b9aedeb509eb523cc4ba479a1628cf8b5b079953 profile=light cycles=1 review=clean tests=469@b9aedeb509eb523cc4ba479a1628cf8b5b079953 ui=none:clean@b9aedeb509eb523cc4ba479a1628cf8b5b079953 -->
