### PR TITLE
fix(server): refuse data-storage saves that cannot connect (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,11 @@ under its functional section below.
   (#122); numeric configuration parsing made explicit with dead code swept
   (#123); model filename reported as written (#94); logger no longer replaces
   global console methods (#95); data-storage recovery path no longer crashes
-  (#93).
+  (#93); saving a data-storage configuration whose connection cannot be
+  established is refused with a JSON 503 naming what failed, and the previous
+  configuration stays on disk and live — it is no longer saved and reported as
+  success (#18); the dashboard's connection test and save path verify through
+  the same connector seam.
 - Release workflow strips tag prefixes exactly when publishing images (#98).
 
 ### Performance

--- a/src/server/routes/data-storage.js
+++ b/src/server/routes/data-storage.js
@@ -4,7 +4,7 @@ const Joi = require('joi');
 const { getDataStorage, dbConnector, updateDataStorage } = require('./db-connector');
 let router = express.Router();
 const { validate, dataStorageSchema } = require('../middleware/validate');
-const { errorHandler, internal } = require('../middleware/errors');
+const { errorHandler, ApiError, internal } = require('../middleware/errors');
 
 // ---------------------------------------------------------------------------
 // Validation schemas for the data-storage endpoints (issue #10)
@@ -35,7 +35,10 @@ router.post('/', validate({ body: dataStorageBody }), function (req, res, next) 
   const { dataStorage } = req.body;
   updateDataStorage(dataStorage, (err, ds) => {
     if (err) {
-      next(internal('Failed to update data storage', err));
+      // A classified failure — the 503 an unreachable proposed configuration
+      // earns (#18) — already knows how to describe itself safely; anything
+      // else is a failure nobody classified and is answered as our own 500.
+      next(err instanceof ApiError ? err : internal('Failed to update data storage', err));
     } else {
       res.send({
         dataStorage: ds,

--- a/src/server/routes/db-connector.js
+++ b/src/server/routes/db-connector.js
@@ -28,10 +28,14 @@ let dbClient = null;
  * @param {Function} callback Invoked with (err, connectedClient)
  */
 const buildConnectedClient = (dataStorage, callback) => {
+  // A malformed configuration (the configuration itself missing, or connConfig
+  // not an object) must be reported through the error branch, not destructured
+  // and thrown as a TypeError. (F-BUG-002)
+  if (!dataStorage || typeof dataStorage !== 'object') {
+    console.error('[db-connector] data-storage configuration is missing');
+    return callback(new Error('data-storage configuration is missing'));
+  }
   const { protocol, connConfig } = dataStorage;
-  // A malformed configuration (connConfig missing or not an object) must
-  // be reported as an unavailable database (503), not destructured and
-  // thrown as a TypeError. (F-BUG-002)
   if (!connConfig || typeof connConfig !== 'object') {
     console.error('[db-connector] data-storage configuration is missing connConfig');
     return callback(new Error('data-storage configuration is missing connConfig'));

--- a/src/server/routes/db-connector.js
+++ b/src/server/routes/db-connector.js
@@ -16,6 +16,54 @@ let dataStorageConfig = null;
 let dbClient = null;
 
 /**
+ * Build an ENACTDB client from a data-storage configuration and prove it can
+ * actually connect, without touching any module state.
+ *
+ * This is the single verification seam (#18): the lazy connection a request
+ * needs (`getDBClient`), the dashboard's connection test (`dbConnector`) and
+ * the save path (`updateDataStorage`) all prove connectivity here, so they can
+ * never disagree about whether a configuration works.
+ *
+ * @param {Object} dataStorage The { protocol, connConfig } configuration
+ * @param {Function} callback Invoked with (err, connectedClient)
+ */
+const buildConnectedClient = (dataStorage, callback) => {
+  const { protocol, connConfig } = dataStorage;
+  // A malformed configuration (connConfig missing or not an object) must
+  // be reported as an unavailable database (503), not destructured and
+  // thrown as a TypeError. (F-BUG-002)
+  if (!connConfig || typeof connConfig !== 'object') {
+    console.error('[db-connector] data-storage configuration is missing connConfig');
+    return callback(new Error('data-storage configuration is missing connConfig'));
+  }
+  if (protocol === 'MONGODB') {
+    const { host, port, dbname, username, password } = connConfig;
+    // Connection logging names host, port and database only: username
+    // and password must never reach a log file or the logs endpoint.
+    // (F-SEC-001, #72)
+    console.log(`MongoDB configuration: host=${host} port=${port} dbname=${dbname}`);
+    let auth = null;
+    if (username && password) {
+      auth = {
+        username: username,
+        password,
+      };
+    }
+    const client = new ENACTDB(host, port, dbname, auth);
+    return client.connect((err) => {
+      if (err) {
+        console.error('[SERVER] Cannot connect to the database');
+        return callback(err);
+      } else {
+        return callback(null, client);
+      }
+    });
+  }
+  console.error(`[db-connector] Protocol is not supported ${protocol}`);
+  return callback(`Protocol is not supported ${protocol}`);
+};
+
+/**
  * Get the db client
  * @param {Function} callback The callback function
  */
@@ -39,40 +87,13 @@ const getDBClient = (callback) => {
         console.error('[SERVER] Cannot get the data storage configuration');
         return callback(err);
       } else {
-        const { protocol, connConfig } = dataStorage;
-        // A malformed configuration (connConfig missing or not an object) must
-        // be reported as an unavailable database (503), not destructured and
-        // thrown as a TypeError. (F-BUG-002)
-        if (!connConfig || typeof connConfig !== 'object') {
-          console.error('[db-connector] data-storage configuration is missing connConfig');
-          return callback(new Error('data-storage configuration is missing connConfig'));
-        }
-        if (protocol === 'MONGODB') {
-          const { host, port, dbname, username, password } = connConfig;
-          // Connection logging names host, port and database only: username
-          // and password must never reach a log file or the logs endpoint.
-          // (F-SEC-001, #72)
-          console.log(`MongoDB configuration: host=${host} port=${port} dbname=${dbname}`);
-          let auth = null;
-          if (username && password) {
-            auth = {
-              username: username,
-              password,
-            };
+        buildConnectedClient(dataStorage, (err2, client) => {
+          if (err2) {
+            return callback(err2);
           }
-          dbClient = new ENACTDB(host, port, dbname, auth);
-          dbClient.connect((err2) => {
-            if (err2) {
-              console.error('[SERVER] Cannot connect to the database');
-              return callback(err2);
-            } else {
-              return callback(null, dbClient);
-            }
-          });
-        } else {
-          console.error(`[db-connector] Protocol is not supported ${protocol}`);
-          return callback(`Protocol is not supported ${protocol}`);
-        }
+          dbClient = client;
+          return callback(null, dbClient);
+        });
       }
     });
   }
@@ -126,39 +147,60 @@ const getDataStorage = (callback) => {
 };
 
 const updateDataStorage = (dataStorage, callback) => {
-  writeToFile(
-    dataStoragePath,
-    JSON.stringify(dataStorage),
-    (err, data) => {
-      if (err) {
-        console.error('[SERVER] Cannot save the new data storage configuration', err);
-        return callback(err);
-      } else {
-        dataStorageConfig = dataStorage;
-        if (dbClient) {
-          dbClient.close();
-          dbClient = null;
-        }
-        getDBClient((err2) => {
-          if (err2) {
-            // The configuration asked for *was* written, so the update itself
-            // succeeded; only the connection it names is not answering. Report
-            // the save as done and keep the connection failure in the log —
-            // `GET /api/data-storage/test` is what probes the connection.
-            // (This branch used to test the wrong variable and then reference an
-            // `res` that does not exist here, so it could only ever have thrown.)
-            console.error(
-              `[SERVER] Data storage saved, but its connection is not reachable | ${
-                err2 && err2.stack ? err2.stack : err2
-              }`
-            );
-          }
-          return callback(null, dataStorage);
-        });
+  // Verify-then-commit (#18): a configuration that cannot connect is refused
+  // outright and nothing is written, so the previously working configuration —
+  // on disk and in memory — is never left broken. The probe runs through the
+  // same seam (`buildConnectedClient`) the dashboard's connection test uses,
+  // which is what makes Test Connection and Save agree.
+  //
+  // The current client is closed before probing because every ENACTDB rides
+  // Mongoose's shared default connection: connecting the candidate replaces
+  // that connection wholesale, so keeping the old wrapper would only leave a
+  // stale handle. If the probe then fails, `dbClient` stays cleared and the
+  // next `getDBClient` reconnects lazily from `dataStorageConfig` — which
+  // this function has deliberately not touched yet.
+  const closeCurrent = (done) => {
+    if (!dbClient) return done();
+    const current = dbClient;
+    dbClient = null;
+    return current.close(() => done());
+  };
+  closeCurrent(() => {
+    buildConnectedClient(dataStorage, (err2, candidate) => {
+      if (err2) {
+        console.error(
+          `[SERVER] Data storage not updated: the proposed configuration cannot be reached | ${
+            err2 && err2.stack ? err2.stack : err2
+          }`
+        );
+        return callback(
+          unavailable('Data storage not updated: cannot connect to the proposed database', err2)
+        );
       }
-    },
-    true
-  );
+      writeToFile(
+        dataStoragePath,
+        JSON.stringify(dataStorage),
+        (err, data) => {
+          if (err) {
+            console.error('[SERVER] Cannot save the new data storage configuration', err);
+            // The connection was proven but persistence failed: drop the
+            // verified candidate rather than run live against settings a
+            // restart would not load, and let `getDBClient` rebuild from the
+            // untouched previous configuration.
+            dbClient = null;
+            candidate.close(() => {});
+            return callback(err);
+          }
+          // Commit: the verified candidate becomes the live client and the new
+          // configuration takes effect immediately, no restart needed.
+          dbClient = candidate;
+          dataStorageConfig = dataStorage;
+          return callback(null, dataStorage);
+        },
+        true
+      );
+    });
+  });
 };
 
 /**

--- a/test/data-storage-save.test.js
+++ b/test/data-storage-save.test.js
@@ -1,0 +1,266 @@
+// Saving a data-storage configuration that cannot connect must be refused,
+// not reported as success (issue #18).
+//
+// updateDataStorage used to persist the proposed configuration first and probe
+// its connection afterwards, in a branch that inspected the wrong error value
+// and referenced an out-of-scope `res`; repaired to log-only by #61, master
+// kept answering 200 for an unreachable database while leaving the previously
+// working configuration overwritten on disk. The save path now verifies the
+// configuration through the same seam the dashboard's Test Connection uses
+// (`buildConnectedClient`) before anything is written.
+//
+// No live MongoDB: ENACTDB.prototype.connect is stubbed at the prototype seam
+// - the same technique test/data-storage.test.js uses - keyed by port so one
+// suite can mix reachable and unreachable targets. The full route pipeline
+// runs for real (validation, handler, shared error handler), and the real
+// data-storage.json is backed up and restored around the whole file, following
+// test/db-connector-recovery.test.js.
+const { test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const express = require('express');
+const { request } = require('./_http');
+
+const dataStoragePath = path.join(__dirname, '..', 'src', 'server', 'data', 'data-storage.json');
+const dbcPath = require.resolve('../src/server/routes/db-connector');
+const routerPath = require.resolve('../src/server/routes/data-storage');
+const enactPath = require.resolve('../src/core/enact-mongoose');
+
+const SECRET = 'sup3r-secret-password';
+
+const workingConfig = {
+  protocol: 'MONGODB',
+  connConfig: {
+    host: 'oldhost',
+    port: 27017,
+    username: null,
+    password: null,
+    dbname: 'olddb',
+    options: null,
+  },
+};
+
+const brokenConfig = {
+  protocol: 'MONGODB',
+  connConfig: {
+    host: 'unreachable',
+    port: 59999,
+    username: 'writer',
+    password: SECRET,
+    dbname: 'tas_db',
+    options: null,
+  },
+};
+
+const otherWorkingConfig = {
+  protocol: 'MONGODB',
+  connConfig: {
+    host: 'newhost',
+    port: 27118,
+    username: null,
+    password: null,
+    dbname: 'newdb',
+    options: null,
+  },
+};
+
+// Every ENACTDB construction the code under test performs is recorded here so
+// tests can pin how often the verification seam runs and with what settings.
+let built;
+let connectImpl;
+
+/** Install a prototype stub answering per-config via connectImpl. */
+function stubConnect() {
+  const enact = require(enactPath);
+  built = [];
+  enact.ENACTDB.prototype.connect = function (callback) {
+    built.push({ host: this.host, port: this.port, dbName: this.dbName });
+    return connectImpl.call(this, callback);
+  };
+}
+
+/**
+ * Arrange the on-disk configuration, reset the connector's module state, and
+ * mount a fresh data-storage router. The connector and the router are both
+ * re-required so the router binds the fresh module's functions; enact-mongoose
+ * deliberately stays cached so the prototype stub keeps applying.
+ */
+function freshApp(fileBody) {
+  if (fs.existsSync(dataStoragePath)) fs.rmSync(dataStoragePath, { force: true });
+  if (fileBody !== null && fileBody !== undefined) {
+    fs.writeFileSync(dataStoragePath, JSON.stringify(fileBody));
+  }
+  delete require.cache[dbcPath];
+  delete require.cache[routerPath];
+  stubConnect();
+  const dataStorageRouter = require(routerPath);
+  const app = express();
+  app.use(express.json());
+  app.use('/api/data-storage', dataStorageRouter);
+  return app;
+}
+
+/** Default stub behaviour: port 27017 connects, everything else refuses. */
+function refuseExcept(portThatWorks) {
+  return function (callback) {
+    if (this.port === portThatWorks) {
+      this.isConnected = true;
+      return callback(null);
+    }
+    return callback(new Error(`connect ECONNREFUSED ${this.host}:${this.port}`));
+  };
+}
+
+let server;
+
+before(() => {
+  // Back the real file up once; every test arranges its own state through
+  // freshApp, and after() guarantees restoration even on failure.
+  const backup = `${dataStoragePath}.test-bak`;
+  if (fs.existsSync(dataStoragePath)) fs.renameSync(dataStoragePath, backup);
+  fs.writeFileSync(dataStoragePath, JSON.stringify({ placeholder: true }), 'utf8');
+  server = freshApp(workingConfig).listen(0);
+});
+
+after(() => {
+  if (server) server.close();
+  if (fs.existsSync(dataStoragePath)) fs.rmSync(dataStoragePath, { force: true });
+  const backup = `${dataStoragePath}.test-bak`;
+  if (fs.existsSync(backup)) fs.renameSync(backup, dataStoragePath);
+});
+
+/** Assert a failure body is exactly the central handler's shape. */
+const assertErrorShape = (res, status, context) => {
+  assert.equal(res.status, status, `${context}: expected ${status}, got ${res.status}`);
+  assert.ok(res.body, `${context} must answer with a JSON body (${res.raw})`);
+  assert.equal(typeof res.body.error, 'string', `${context} must carry a string error`);
+  assert.deepEqual(
+    Object.keys(res.body).filter((key) => key !== 'error' && 'details'),
+    [],
+    `${context}: an error body carries nothing but error and details (${res.raw})`
+  );
+};
+
+test('saving a configuration that cannot connect returns 503, never success (AC1)', async () => {
+  server.close();
+  server = freshApp(workingConfig).listen(0);
+  connectImpl = refuseExcept(27017);
+
+  const res = await request(server, 'POST', '/api/data-storage', { dataStorage: brokenConfig });
+  assertErrorShape(res, 503, 'POST of an unreachable configuration');
+  assert.match(res.body.error, /cannot connect/i);
+  // Success must not leak sideways through the body either.
+  assert.equal(res.body.dataStorage, undefined);
+});
+
+test('the failure names what happened without leaking credentials (AC2)', async () => {
+  server.close();
+  server = freshApp(workingConfig).listen(0);
+  connectImpl = refuseExcept(27017);
+
+  const res = await request(server, 'POST', '/api/data-storage', { dataStorage: brokenConfig });
+  assert.equal(res.status, 503);
+  assert.ok(!res.raw.includes(SECRET), `the password must never reach the response (${res.raw})`);
+  assert.ok(
+    !res.raw.includes(brokenConfig.connConfig.username),
+    'the username must never reach the response'
+  );
+  assert.match(
+    res.body.error,
+    /data storage not updated/i,
+    'the message must say the save did not happen'
+  );
+});
+
+test('a failed save leaves the previously working configuration on disk (AC3)', async () => {
+  server.close();
+  const arranged = JSON.parse(JSON.stringify(workingConfig));
+  server = freshApp(arranged).listen(0);
+  connectImpl = refuseExcept(27017);
+
+  const res = await request(server, 'POST', '/api/data-storage', { dataStorage: brokenConfig });
+  assert.equal(res.status, 503);
+
+  const onDisk = JSON.parse(fs.readFileSync(dataStoragePath, 'utf8'));
+  assert.deepEqual(onDisk, arranged, 'disk must still hold the previous configuration');
+});
+
+test('a failed save leaves the served configuration untouched in memory (AC3)', async () => {
+  server.close();
+  server = freshApp(workingConfig).listen(0);
+  connectImpl = refuseExcept(27017);
+
+  await request(server, 'POST', '/api/data-storage', { dataStorage: brokenConfig });
+
+  const res = await request(server, 'GET', '/api/data-storage');
+  assert.equal(res.status, 200, `GET must still serve (${res.raw})`);
+  assert.deepEqual(res.body.dataStorage, workingConfig, 'the old configuration must be served');
+});
+
+test('after a failed save the connection test reconnects the previous configuration (AC3, AC5)', async () => {
+  server.close();
+  server = freshApp(workingConfig).listen(0);
+  connectImpl = refuseExcept(27017);
+
+  const failed = await request(server, 'POST', '/api/data-storage', {
+    dataStorage: brokenConfig,
+  });
+  assert.equal(failed.status, 503);
+  const postSaveBuilds = built.length;
+
+  // The refused save cleared the live client; the next verification must
+  // lazily rebuild from the untouched previous configuration — the same
+  // `buildConnectedClient` seam, reached through GET /test.
+  const res = await request(server, 'GET', '/api/data-storage/test');
+  assert.equal(res.status, 200, `the previous configuration must still work (${res.raw})`);
+  assert.equal(res.body.connectionStatus, true);
+  assert.deepEqual(
+    built.slice(postSaveBuilds),
+    [{ host: 'oldhost', port: 27017, dbName: 'olddb' }],
+    'the reconnect must use the previous settings, not the refused ones'
+  );
+});
+
+test('saving a valid configuration succeeds and takes effect without a restart (AC4)', async () => {
+  server.close();
+  server = freshApp(workingConfig).listen(0);
+  connectImpl = refuseExcept(27118);
+
+  const res = await request(server, 'POST', '/api/data-storage', {
+    dataStorage: otherWorkingConfig,
+  });
+  assert.equal(res.status, 200, `a verifiable configuration must save (${res.raw})`);
+  assert.deepEqual(res.body.dataStorage, otherWorkingConfig);
+
+  const onDisk = JSON.parse(fs.readFileSync(dataStoragePath, 'utf8'));
+  assert.deepEqual(onDisk, otherWorkingConfig, 'the new configuration must be persisted');
+
+  // Served from the committed in-memory state — no restart involved.
+  const served = await request(server, 'GET', '/api/data-storage');
+  assert.deepEqual(served.body.dataStorage, otherWorkingConfig);
+
+  // Verify-then-commit probes exactly once and promotes that verified client,
+  // so the connection test afterwards finds it already live.
+  assert.deepEqual(built, [{ host: 'newhost', port: 27118, dbName: 'newdb' }]);
+  const testRes = await request(server, 'GET', '/api/data-storage/test');
+  assert.equal(testRes.status, 200, `the promoted client must answer (${testRes.raw})`);
+  assert.equal(built.length, 1, 'an already-live client must not be rebuilt');
+});
+
+test('connection test and save share one verification seam (AC5)', async () => {
+  server.close();
+  server = freshApp(workingConfig).listen(0);
+  connectImpl = refuseExcept(-1); // nothing connects: both actions must fail alike
+
+  const testRes = await request(server, 'GET', '/api/data-storage/test');
+  assert.equal(testRes.status, 503, 'Test Connection must report unreachability');
+  const afterTest = built.length;
+  assert.ok(afterTest > 0, 'the connection test must have probed the seam');
+
+  const saveRes = await request(server, 'POST', '/api/data-storage', {
+    dataStorage: brokenConfig,
+  });
+  assert.equal(saveRes.status, 503, 'Save must report unreachability just like the test action');
+  assert.ok(built.length > afterTest, 'the save must have probed the very same seam');
+});

--- a/test/data-storage-save.test.js
+++ b/test/data-storage-save.test.js
@@ -119,7 +119,6 @@ before(() => {
   // freshApp, and after() guarantees restoration even on failure.
   const backup = `${dataStoragePath}.test-bak`;
   if (fs.existsSync(dataStoragePath)) fs.renameSync(dataStoragePath, backup);
-  fs.writeFileSync(dataStoragePath, JSON.stringify({ placeholder: true }), 'utf8');
   server = freshApp(workingConfig).listen(0);
 });
 
@@ -136,7 +135,7 @@ const assertErrorShape = (res, status, context) => {
   assert.ok(res.body, `${context} must answer with a JSON body (${res.raw})`);
   assert.equal(typeof res.body.error, 'string', `${context} must carry a string error`);
   assert.deepEqual(
-    Object.keys(res.body).filter((key) => key !== 'error' && 'details'),
+    Object.keys(res.body).filter((key) => key !== 'error' && key !== 'details'),
     [],
     `${context}: an error body carries nothing but error and details (${res.raw})`
   );
@@ -263,4 +262,26 @@ test('connection test and save share one verification seam (AC5)', async () => {
   });
   assert.equal(saveRes.status, 503, 'Save must report unreachability just like the test action');
   assert.ok(built.length > afterTest, 'the save must have probed the very same seam');
+});
+
+test('a malformed configuration reaches the error branch instead of throwing (F-BUG-002 seam)', async () => {
+  server.close();
+  server = freshApp(workingConfig).listen(0);
+  connectImpl = refuseExcept(27017);
+
+  // The route cannot send this (Joi refuses it first), but updateDataStorage
+  // is module API: a null configuration must be reported through its callback,
+  // never thrown synchronously inside an fs/connect callback.
+  const dbc = require(dbcPath);
+  await new Promise((resolve) => {
+    dbc.updateDataStorage(null, (err) => {
+      assert.ok(err, 'null configuration must be reported through the callback');
+      resolve();
+    });
+  });
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(dataStoragePath, 'utf8')),
+    workingConfig,
+    'disk must be untouched by a refused configuration'
+  );
 });


### PR DESCRIPTION
Closes #18

## Summary

Saving a data-storage configuration reported success even when the resulting connection could not be established: `updateDataStorage` persisted the proposed configuration first and probed its connection afterwards, in a branch that inspected the wrong error value and referenced an out-of-scope `res`. The #61 repair removed the crash but deliberately downgraded the branch to log-only, so master kept answering 200 for an unreachable database while the previously working configuration had already been overwritten on disk. The save path now verifies connectivity before anything is written, refuses an unreachable configuration with a JSON 503 naming what failed (no credentials), and leaves the previous configuration untouched on disk and in memory.

## Approach

Verify-then-commit: `updateDataStorage` closes the current client (every `ENACTDB` rides Mongoose's shared default connection), probes a candidate client built from the proposed configuration through a new pure `buildConnectedClient(config, cb)` seam, and only persists and promotes the candidate once that probe succeeds. On probe failure nothing is written; `dbClient` stays cleared so the next `getDBClient` lazily rebuilds from the untouched previous configuration — disk, memory and live connection all converge on the old settings with no restore step to fail halfway.

## Decision Record

- **Root cause:** the save handler tested its post-save connection in a branch that examined the wrong error variable and referenced an out-of-scope `res`, so unreachable configurations were saved and answered 200; the #61 fix removed the crash but chose log-only reporting, leaving verify-before-success unimplemented on master.
- **Options considered:** Option 1 — Verify-then-commit with rollback; Option 2 — Save-then-verify with restore-on-failure
- **Options rejected:** Option 2 — non-atomic rollback leaves a window (and failure mode) where the broken config persists on disk.
- **Selected option:** Option 1 — Verify-then-commit with rollback
- **Residual risk:** the save endpoint's contract changes from always-succeed to conditionally-failing; the dashboard saga already renders thrown error strings as notifications (`parseResponse` throws on non-OK), so no client change was needed. A failed save transiently drops the live connection until the next request lazily reconnects it from the previous configuration.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle
- **Reproduction:** `POST /api/data-storage` with an unreachable `connConfig` returned `200`, echoed success, and left `host: unreachable` persisted over the working config → regression test `test/data-storage-save.test.js`

Analyzed at: `master @ b02f52e` (2026-08-23)

## Changes

| File | Change |
|------|--------|
| `src/server/routes/db-connector.js` | Extracted `buildConnectedClient` as the single verification seam shared by `getDBClient`, `dbConnector` and the save path; rewrote `updateDataStorage` to verify-then-commit and report refused saves through a classified 503 `unavailable()` error; guarded malformed configurations at the seam (F-BUG-002 alignment). |
| `src/server/routes/data-storage.js` | Pass classified `ApiError`s straight to `next`; only unclassified failures are wrapped as 500. |
| `test/data-storage-save.test.js` | New `node:test` route suite (8 tests): refusal + status/shape, credential-free message, disk/memory untouched after a failed save, lazy self-heal of the previous configuration, valid save takes effect without restart with exactly one connect probe, test/save share one verification seam, malformed config reaches the callback instead of throwing. No live MongoDB — `ENACTDB.prototype.connect` stubbed at the prototype seam. |
| `CHANGELOG.md` | Recorded the new save contract under Changed → Server correctness. |

## Test Results

- Unit/route tests: 474 passed across the suite (477 total, 3 pre-existing environment skips)
- New tests: 8 (`test/data-storage-save.test.js`)
- Build: passed (pre-commit eslint + prettier hooks green)
- QA cycles: 1 (review found 3 issues — missing non-object config guard, test-helper filter bug, dead placeholder write — all fixed)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Saving a configuration that cannot connect returns an error rather than success | ✅ Met | `POST /api/data-storage` answers `503 {error}` — pinned by "saving a configuration that cannot connect returns 503, never success (AC1)" |
| The error names what failed in terms the user can act on, without leaking credentials | ✅ Met | `"Data storage not updated: cannot connect to the proposed database"`; response asserted free of password/username ("the failure names what happened without leaking credentials (AC2)") |
| A previously working configuration is not left broken by a failed save attempt | ✅ Met | Disk byte-compared unchanged, served memory unchanged, and `GET /api/data-storage/test` afterwards reconnects the previous settings (three AC3 tests) |
| Saving a valid configuration still succeeds and takes effect without a restart | ✅ Met | 200 echo, file persisted, immediately served from committed state; verified candidate promoted with exactly one probe (AC4 test) |
| The dashboard's connection test and the save path use the same verification | ✅ Met | Both actions proven to run through the same `buildConnectedClient`/`ENACTDB.connect` seam and to fail alike (AC5 test); dashboard saga already surfaces server errors as notifications |

<!-- gitissue:qa v1 head=8624875bdc8fc319ec8aaed9b2db0561d82673f2 profile=light cycles=1 review=clean tests=474@851d72ebe97b924d92a47ce87614bde33868d5c3 ui=none -->
