### PR TITLE
fix(client): render readable notifications instead of raw error values (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,11 @@ under its functional section below.
   configuration stays on disk and live — it is no longer saved and reported as
   success (#18); the dashboard's connection test and save path verify through
   the same connector seam.
+- Dashboard failure notifications always render a readable message: caught
+  errors are coerced at one boundary (`describeError`) instead of being
+  stringified into `{}`, a malformed topology import names the failing file
+  instead of failing silently, and raw error detail stays in the browser
+  console (#40).
 - Release workflow strips tag prefixes exactly when publishing images (#98).
 
 ### Performance

--- a/src/client/src/components/ListStates/ListStates.js
+++ b/src/client/src/components/ListStates/ListStates.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { Button, Empty } from "antd";
 
+import describeError from "../../describeError";
+
 /**
  * Shared list-view states. Every list page renders these through its antd
  * Table `locale.emptyText` slot so a genuinely empty table is
@@ -19,7 +21,7 @@ export const ListStateError = ({ message, onRetry }) => (
     image={Empty.PRESENTED_IMAGE_SIMPLE}
     description={
       <span>
-        Failed to load: {message === null || message === undefined ? "request failed" : String(message)}
+        Failed to load: {message === null || message === undefined ? "request failed" : describeError(message)}
       </span>
     }
   >

--- a/src/client/src/describeError.js
+++ b/src/client/src/describeError.js
@@ -1,0 +1,51 @@
+/**
+ * Coerce any caught failure into a message a dashboard user can act on.
+ *
+ * Sagas and page handlers pass whatever landed in their `catch` straight to
+ * setNotification, and the notification renderer used to push non-strings
+ * through JSON.stringify - which turns an Error into the useless "{}"
+ * (issue #40). This helper is the single coercion point every user-visible
+ * failure goes through:
+ *
+ * - a readable string passes through untouched;
+ * - an Error contributes its `.message`, never its `.stack` (a stack trace
+ *   and the server filesystem paths it can contain must not reach the
+ *   screen);
+ * - an object shaped `{ error: "..." }` or `{ message: "..." }` contributes
+ *   that field;
+ * - anything else falls back to generic text that says what to do next.
+ *
+ * When the value was not already display-ready, the original is handed to
+ * console.error so developers keep the technical detail users are spared.
+ */
+const FALLBACK_MESSAGE =
+  'Something went wrong while completing your request. ' +
+  'Check the browser console for technical details and try again.';
+
+const firstNonEmptyString = (...candidates) =>
+  candidates.find(
+    (candidate) => typeof candidate === 'string' && candidate.trim() !== ''
+  ) || null;
+
+const describeError = (value) => {
+  const asString = firstNonEmptyString(value);
+  if (asString !== null) {
+    return asString;
+  }
+  if (value instanceof Error) {
+    // The stack belongs in the console only; the message is what a user can
+    // read.
+    console.error('[notification] failure detail:', value);
+    return firstNonEmptyString(value.message) || FALLBACK_MESSAGE;
+  }
+  if (value !== null && typeof value === 'object') {
+    const field = firstNonEmptyString(value.error, value.message);
+    if (field !== null) {
+      return field;
+    }
+  }
+  console.error('[notification] failure detail:', value);
+  return FALLBACK_MESSAGE;
+};
+
+export default describeError;

--- a/src/client/src/describeError.test.js
+++ b/src/client/src/describeError.test.js
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import describeError from './describeError';
+
+describe('describeError', () => {
+  let consoleError;
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  test('passes a readable string through untouched', () => {
+    expect(describeError('Invalid credentials')).toBe('Invalid credentials');
+    // A plain string is already display-ready; nothing is logged.
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  test('uses the message of a thrown Error instead of "{}"', () => {
+    expect(describeError(new Error('Undefined model'))).toBe('Undefined model');
+    expect(describeError(new TypeError('Failed to fetch'))).toBe(
+      'Failed to fetch'
+    );
+  });
+
+  test('never renders an error stack or its constructor noise', () => {
+    const err = new Error('boom');
+    const shown = describeError(err);
+    expect(shown).not.toMatch(/at .+/);
+    expect(shown).not.toContain('Error:');
+    expect(shown).toBe('boom');
+  });
+
+  test('reads the message field of a server-style error object', () => {
+    expect(describeError({ error: 'Topology not found' })).toBe(
+      'Topology not found'
+    );
+    expect(describeError({ message: 'Request failed (HTTP 409)' })).toBe(
+      'Request failed (HTTP 409)'
+    );
+  });
+
+  test('falls back to actionable text for unusable values', () => {
+    for (const value of [undefined, null, {}, { error: 42 }, '', 7, ['a']]) {
+      const shown = describeError(value);
+      expect(typeof shown).toBe('string');
+      expect(shown.length).toBeGreaterThan(0);
+      // Says what to do next rather than showing "[object Object]".
+      expect(shown).toMatch(/console/i);
+      expect(shown).not.toContain('[object Object]');
+    }
+  });
+
+  test('logs the raw value for developers when coercion was needed', () => {
+    const raw = { code: 500 };
+    describeError(raw);
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError.mock.calls[0][1]).toBe(raw);
+  });
+});

--- a/src/client/src/pages/LayoutPage.js
+++ b/src/client/src/pages/LayoutPage.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { notification, Spin, Layout, Typography } from "antd";
 import { resetNotification } from "../actions";
+import describeError from "../describeError";
 import TSFooter from "../components/TSFooter";
 import "./styles.css";
 const { Title, Text } = Typography;
@@ -23,10 +24,7 @@ class LayoutPage extends Component {
         {notify &&
           notification[notify.type]({
             message: notify.type.toUpperCase(),
-            description:
-              typeof notify.message === "object"
-                ? JSON.stringify(notify.message)
-                : notify.message,
+            description: describeError(notify.message),
             onClose: () => resetNotification(),
           })}
         <Layout style={{ padding: "0px 48px 48px", margin: "30px 50px 50px" }}>

--- a/src/client/src/pages/LayoutPage.test.js
+++ b/src/client/src/pages/LayoutPage.test.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+import { render, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Capture what LayoutPage hands to antd's notification without rendering a
+// real one; every other antd export stays genuine.
+const shown = [];
+vi.mock('antd', async (importOriginal) => {
+  const actual = await importOriginal();
+  const capture = (kind) => vi.fn((config) => shown.push({ kind, config }));
+  return {
+    ...actual,
+    notification: {
+      ...actual.notification,
+      success: capture('success'),
+      error: capture('error'),
+      warning: capture('warning'),
+      info: capture('info'),
+    },
+  };
+});
+
+import LayoutPage from './LayoutPage';
+import { setNotification } from '../actions';
+import rootReducer from '../reducers';
+
+const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+const renderWithNotification = (message) => {
+  const store = createStore(rootReducer);
+  // Dispatch before the first render: LayoutPage fires the antd notification
+  // from render when a notification is in the store.
+  store.dispatch(setNotification({ type: 'error', message }));
+  return render(
+    <Provider store={store}>
+      <LayoutPage pageTitle="t">
+        <div>content</div>
+      </LayoutPage>
+    </Provider>
+  );
+};
+
+describe('LayoutPage notifications', () => {
+  beforeEach(() => {
+    shown.length = 0;
+    consoleError.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('renders a thrown Error as its message instead of "{}"', () => {
+    renderWithNotification(new Error('Undefined model'));
+    expect(shown).toHaveLength(1);
+    expect(shown[0].kind).toBe('error');
+    expect(shown[0].config.description).toBe('Undefined model');
+    // Developer detail survives in the console.
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  test('renders a server-style error object as its readable field', () => {
+    renderWithNotification({ error: 'Topology not found' });
+    expect(shown).toHaveLength(1);
+    expect(shown[0].config.description).toBe('Topology not found');
+  });
+
+  test('falls back to actionable text for unusable values', () => {
+    renderWithNotification({ unrenderable: true });
+    expect(shown).toHaveLength(1);
+    const description = shown[0].config.description;
+    expect(typeof description).toBe('string');
+    expect(description).toMatch(/console/i);
+    expect(description).not.toContain('[object Object]');
+  });
+
+  test('passes an already-readable string through untouched', () => {
+    renderWithNotification('Invalid credentials');
+    expect(shown).toHaveLength(1);
+    expect(shown[0].config.description).toBe('Invalid credentials');
+  });
+});

--- a/src/client/src/pages/ModelListPage.js
+++ b/src/client/src/pages/ModelListPage.js
@@ -20,6 +20,7 @@ import {
   requestStartSimulation,
   requestSimulationStatus,
   requestStopSimulation,
+  setNotification,
 } from "../actions";
 import { getObjectId } from "../utils";
 
@@ -31,7 +32,13 @@ class ModelListPage extends Component {
         const newModel = JSON.parse(fileReader.result);
         this.props.importNewModel(newModel);
       } catch (error) {
-        this.props.setNotification({ type: "error", message: error });
+        // Name the failing import for the user; the raw parse error stays in
+        // the console for developers.
+        console.error(`Importing "${files[0].name}" failed:`, error);
+        this.props.setNotification({
+          type: "error",
+          message: `Import failed: "${files[0].name}" is not a valid model file (JSON parsing failed). Check the file and try again.`,
+        });
       }
     };
     fileReader.readAsText(files[0]);
@@ -222,6 +229,7 @@ const mapDispatchToProps = (dispatch) => ({
   duplicateModel: (modelFileName) =>
     dispatch(requestDuplicateModel(modelFileName)),
   importNewModel: (model) => dispatch(requestAddNewModel(model)),
+  setNotification: (notification) => dispatch(setNotification(notification)),
   startSimulation: (modelFileName) =>
     dispatch(requestStartSimulation({ modelFileName })),
   stopSimulation: (modelFileName) =>

--- a/src/client/src/pages/ModelListPage.test.js
+++ b/src/client/src/pages/ModelListPage.test.js
@@ -124,4 +124,27 @@ describe('ModelListPage', () => {
     expect(await screen.findByText('topo-a')).toBeInTheDocument();
     expect(requestAllModels).toHaveBeenCalledTimes(2);
   });
+
+  test('names the problem when an imported topology file is not valid JSON', async () => {
+    const sagaMiddleware = createSagaMiddleware();
+    const store = createStore(rootReducer, applyMiddleware(sagaMiddleware));
+    sagaMiddleware.run(rootSaga);
+    const { container } = render(
+      <Provider store={store}>
+        <ModelListPage />
+      </Provider>
+    );
+    await screen.findByText('topo-a');
+    // A malformed import used to surface as "{}" (issue #40); it must name
+    // the failing file instead.
+    const broken = new File(['{ "name": oops'], 'broken-topology.json', {
+      type: 'application/json',
+    });
+    await userEvent.upload(container.querySelector('input[type="file"]'), broken);
+    await waitFor(() =>
+      expect(store.getState().notify.message).toMatch(
+        /import failed.*broken-topology\.json.*not a valid model file/i
+      )
+    );
+  });
 });


### PR DESCRIPTION
Closes #40

## Summary

Dashboard failure notifications could render as meaningless placeholders: sagas and page handlers passed whatever landed in their `catch` straight to `setNotification`, and `LayoutPage` pushed non-string values through `JSON.stringify`, which turns any `Error` into `{}`. A malformed topology import was worse — it never notified at all, because `ModelListPage` did not map `setNotification` to props, so its catch threw on a missing prop. The server-path half of this issue was already eliminated on master by the #11 central error handler and the api layer's `errorMessage()` helper; this PR closes the remaining client-side gap.

## Approach

Normalise at the render boundary (analysis option 1): one `describeError()` helper is the single coercion point every user-visible failure passes through. Readable strings pass through untouched; an `Error` contributes its `.message` (never its `.stack`); `{error|message}`-shaped objects contribute that field; anything else falls back to actionable text. Whenever a value was not already display-ready the original goes to `console.error`, so developers keep the detail users are spared.

## Decision Record

- **Root cause:** HTTP failures are already normalised to strings by the api layer over the #11 error shape, but client-thrown Errors are passed raw by ~59 saga catch sites and LayoutPage coerces them with JSON.stringify, yielding "{}" instead of a readable message; the import path additionally never dispatched because `setNotification` was unmapped.
- **Options considered:** Option 1 — Normalise at the render boundary; Option 2 — Normalise in every saga catch
- **Options rejected:** Option 2 — fifty-nine scattered edit sites that any future saga can regress, and it still needs a render-boundary backstop
- **Selected option:** Option 1 — Normalise at the render boundary
- **Residual risk:** Non-string values still sit in the Redux store between dispatch and render; harmless today because LayoutPage and ListStateError are the only renderers.
- **Effort profile:** light — fast path (pre-work Effort XS); synthesis skipped via fresh analysis reuse, QA capped at 1 cycle
- **Reproduction:** `node -e 'console.log(JSON.stringify(new Error("boom")))'` confirmed red (`{}` — the exact value LayoutPage rendered) → fixed → regression tests `src/client/src/describeError.test.js`, `src/client/src/pages/LayoutPage.test.js`, `src/client/src/pages/ModelListPage.test.js`

Analyzed at: `master @ b02f52e` (2026-08-23)

## Changes

| File | Change |
|------|--------|
| `src/client/src/describeError.js` | New coercion helper: string passthrough, Error→`.message` (never `.stack`), `{error\|message}` unwrap, actionable fallback; logs raw values to console for developers |
| `src/client/src/pages/LayoutPage.js` | Notification boundary renders `describeError(notify.message)` instead of the JSON.stringify ternary |
| `src/client/src/components/ListStates/ListStates.js` | `ListStateError` uses `describeError(message)` instead of `String(message)` (same placeholder class of bug) |
| `src/client/src/pages/ModelListPage.js` | Map `setNotification`; malformed-import catch names the failing file and next step, logging the raw SyntaxError for developers |
| `src/client/src/describeError.test.js` | 6 unit tests covering every coercible shape, no-stack guarantee, console-detail guarantee |
| `src/client/src/pages/LayoutPage.test.js` | 4 regression tests asserting what antd's notification receives for each failure shape |
| `src/client/src/pages/ModelListPage.test.js` | Regression test uploading a malformed topology file through the real store+sagas |
| `CHANGELOG.md` | Unreleased/Changed entry |

## Test Results

- Client (vitest): 54 passed (was 43; +11 new)
- Server (`npm test`): 474 passed, 3 pre-existing environment skips, 0 failed
- Build/lint: pre-commit eslint + prettier hooks passed
- QA cycles: 1 (clean)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Every notification renders a readable message regardless of the shape of the underlying error | pass | `describeError.js` wired into both renderers; Verified red: `JSON.stringify(new Error("boom"))` → `{}` → fixed → `LayoutPage.test.js` ("renders a thrown Error as its message instead of \"{}\"") and `describeError.test.js` |
| No user-facing message contains a server filesystem path or a stack trace | pass | Helper reads `.message` only, never `.stack` (asserted in "never renders an error stack"); server paths already blocked by #11 handler + api `errorMessage()` |
| Messages say what failed and what the user can do next | pass | Import message names file + "Check the file and try again"; fallback names console + retry (`describeError.js` FALLBACK_MESSAGE) |
| Technical detail remains available to developers through the browser console or a log | pass | `console.error('[notification] failure detail:', value)` asserted in `describeError.test.js` and `LayoutPage.test.js` |
| A malformed file import produces a clear message naming the problem | pass | Verified red: upload test showed the catch silently threw (setNotification unmapped) → fixed → `ModelListPage.test.js` "names the problem when an imported topology file is not valid JSON" |

<!-- gitissue:qa v1 head=2dd1de342c6b1bac1f12729e5a7ab4e19299ac6d profile=light cycles=1 review=clean tests=474@2dd1de342c6b1bac1f12729e5a7ab4e19299ac6d ui=code:clean@61b248a4c65913944737245fea386112ea46b8e5 -->
