### PR TITLE
refactor(evaluation): rename misspelled evalulate export (#20)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -9,7 +9,7 @@ the results changes:
 node scripts/benchmark-scoring.js --events 5000
 ```
 
-## Report scoring (`evalulate`, value metric)
+## Report scoring (`evaluate`, value metric)
 
 The legacy baseline is the pre-#31 implementation: a greedy first-match scan
 with `splice` inside the inner loop, O(n·m) in the event counts. The current
@@ -23,11 +23,11 @@ some noise (the realistic scoring case), scored per topic.
 Source: `scripts/benchmark-scoring.js`. Recorded run below from this working
 copy (Node v22.18.0, linux x64):
 
-| events scored | legacy scan+splice | current `evalulate` | speedup |
-| ------------- | ------------------ | ------------------- | ------- |
-| 1,000         | 143.7 ms           | 2.8 ms              | 50.7x   |
-| 5,000         | 1,396.0 ms         | 18.2 ms             | 76.6x   |
-| 20,000        | 7,922.8 ms         | 60.9 ms             | 130.0x  |
+| events scored | legacy scan+splice | current `evaluate` | speedup |
+| ------------- | ------------------ | ------------------ | ------- |
+| 1,000         | 143.7 ms           | 2.8 ms             | 50.7x   |
+| 5,000         | 1,396.0 ms         | 18.2 ms            | 76.6x   |
+| 20,000        | 7,922.8 ms         | 60.9 ms            | 130.0x  |
 
 The quadratic cost is also why scoring now reads events through a documented
 bound: `updateReportScore` loads at most `MAX_SCORING_EVENTS` (10000) events

--- a/scripts/benchmark-scoring.js
+++ b/scripts/benchmark-scoring.js
@@ -5,7 +5,7 @@
  *
  * It compares, on identical deterministic inputs:
  * - report scoring: the legacy O(n*m) greedy scan-and-splice (the code before
- *   issue #31) against the current `evalulate` (multiset map + interval
+ *   issue #31) against the current `evaluate` (multiset map + interval
  *   sweep), and
  * - event writes: one document save per event against DataStorage's batched
  *   `insertMany` queue (size trigger), both against an in-memory stand-in so
@@ -17,7 +17,7 @@
  */
 const { performance } = require('node:perf_hooks');
 
-const { evalulate, ALL_EVENTS, METRIC_VALUE } = require('../src/core/evaluation');
+const { evaluate, ALL_EVENTS, METRIC_VALUE } = require('../src/core/evaluation');
 const DataStorage = require('../src/core/communications/DataStorage');
 const EventSchema = require('../src/core/enact-mongoose/schemas/EventSchema');
 
@@ -98,7 +98,7 @@ const benchScoring = (count, runs) => {
             newEvents.map((e) => e.values)
           )
         );
-  const freshMs = timed(() => evalulate(originalEvents, newEvents, ALL_EVENTS, METRIC_VALUE));
+  const freshMs = timed(() => evaluate(originalEvents, newEvents, ALL_EVENTS, METRIC_VALUE));
   void runs;
   return { legacyMs, freshMs };
 };
@@ -162,7 +162,7 @@ const benchWrites = async (count, batchSize) => {
   console.log(`# benchmark-scoring (events=${baseEvents}, runs=${runs})`);
   console.log('');
   console.log('## Report scoring');
-  console.log('| events | legacy scan+splice | current evalulate | speedup |');
+  console.log('| events | legacy scan+splice | current evaluate | speedup |');
   console.log('|--------|--------------------|-------------------|---------|');
   for (const size of [baseEvents / 5, baseEvents, baseEvents * 4].map(Math.round)) {
     let legacyTotal = 0;

--- a/src/core/evaluation/index.js
+++ b/src/core/evaluation/index.js
@@ -4,6 +4,7 @@
  * There should be many different way to evaluate the result. In this version, we will go one by one
  * - 1: compare events order
  */
+const { deprecate } = require('util');
 
 // Threshold values
 const THRESHOLD_FLEXIBLE = 0.5;
@@ -307,7 +308,7 @@ const evaluateEvents = (originalEvents, newEvents, metricType, threshold) => {
  *  evalData: {} // more data on the evaluation
  * }
  */
-const evalulate = (
+const evaluate = (
   originalEvents,
   newEvents,
   eventType = ALL_EVENTS,
@@ -337,6 +338,13 @@ const evalulate = (
   }
 };
 
+// Deprecated misspelled name (issue #20): kept as an alias for one release,
+// then remove. Emits a DeprecationWarning on the first call per process.
+const evalulate = deprecate(
+  evaluate,
+  '[tas] evaluation.evalulate() is deprecated; use evaluation.evaluate() instead'
+);
+
 module.exports = {
   THRESHOLD_FLEXIBLE,
   THRESHOLD_NORMAL,
@@ -347,5 +355,6 @@ module.exports = {
   METRIC_VALUE,
   METRIC_TIMESTAMP,
   METRIC_VALUE_TIMESTAMP,
-  evalulate,
+  evaluate,
+  evalulate, // @deprecated use evaluate
 };

--- a/src/core/simulation/Simulation.js
+++ b/src/core/simulation/Simulation.js
@@ -1,7 +1,7 @@
 const { OFFLINE, SIMULATING } = require('../DeviceStatus');
 const { EventSchema, ReportSchema } = require('../enact-mongoose');
 const {
-  evalulate,
+  evaluate,
   THRESHOLD_FLEXIBLE,
   ALL_EVENTS,
   METRIC_VALUE_TIMESTAMP,
@@ -135,7 +135,7 @@ class Simulation {
       return stopSimulation();
     }
     const { threshold, eventType, metricType } = this.evaluationParameters;
-    const score = evalulate(originalEvents, newEvents, eventType, metricType, threshold);
+    const score = evaluate(originalEvents, newEvents, eventType, metricType, threshold);
     // Going to save the score into the report
     try {
       await ReportSchema.findOneAndUpdate({ id }, { score });

--- a/src/server/routes/reports.js
+++ b/src/server/routes/reports.js
@@ -2,7 +2,7 @@
 const express = require('express');
 const Joi = require('joi');
 const {
-  evalulate,
+  evaluate,
   ALL_EVENTS,
   METRIC_VALUE_TIMESTAMP,
   THRESHOLD_FLEXIBLE,
@@ -117,9 +117,9 @@ const updateReportScore = async (report, res, next) => {
   let newScore = score;
   if (evaluationParameters) {
     const { threshold, eventType, metricType } = evaluationParameters;
-    newScore = evalulate(originalEvents, newEvents, eventType, metricType, threshold);
+    newScore = evaluate(originalEvents, newEvents, eventType, metricType, threshold);
   } else {
-    newScore = evalulate(originalEvents, newEvents);
+    newScore = evaluate(originalEvents, newEvents);
   }
   // Going to save the score into the report
   try {

--- a/test/evaluation-linear.test.js
+++ b/test/evaluation-linear.test.js
@@ -11,7 +11,7 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 
 const {
-  evalulate,
+  evaluate,
   ALL_EVENTS,
   METRIC_VALUE,
   THRESHOLD_FLEXIBLE,
@@ -76,7 +76,7 @@ test('randomized value-metric topics score exactly like the legacy scan', () => 
 
     const originalEvents = originalValues.map((v, i) => ev('t', [v], i));
     const newEvents = newValues.map((v, i) => ev('t', [v], i));
-    const freshScore = evalulate(originalEvents, newEvents, ALL_EVENTS, METRIC_VALUE);
+    const freshScore = evaluate(originalEvents, newEvents, ALL_EVENTS, METRIC_VALUE);
     assert.equal(freshScore, expectedScore, `trial ${trial}: legacy topic score ${topicScore}`);
   }
 });
@@ -89,7 +89,7 @@ test('a large identical run scores perfectly in bounded time', () => {
   const newEvents = mk(1000000000000);
 
   const start = process.hrtime.bigint();
-  const score = evalulate(originalEvents, newEvents, ALL_EVENTS, METRIC_VALUE);
+  const score = evaluate(originalEvents, newEvents, ALL_EVENTS, METRIC_VALUE);
   const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
   assert.equal(score, 1);
   assert.ok(
@@ -114,7 +114,7 @@ test('the quadratic cost of the legacy scan is demonstrably gone', { timeout: 60
   const originalEvents = originalValues.map((v, i) => ev('t', v, i));
   const newEvents = newValues.map((v, i) => ev('t', v, i));
   const freshStart = process.hrtime.bigint();
-  const freshScore = evalulate(originalEvents, newEvents, ALL_EVENTS, METRIC_VALUE);
+  const freshScore = evaluate(originalEvents, newEvents, ALL_EVENTS, METRIC_VALUE);
   const freshMs = Number(process.hrtime.bigint() - freshStart) / 1e6;
 
   assert.equal(legacyTopicScore >= THRESHOLD_FLEXIBLE, false);

--- a/test/evaluation.test.js
+++ b/test/evaluation.test.js
@@ -3,7 +3,7 @@
 // Moved here from src/core/evaluation/index.test.js by issue #80 so the
 // `npm test` glob (test/**/*.test.js) actually runs it.
 //
-// The evaluation module is pure logic: evalulate(originalEvents, newEvents,
+// The evaluation module is pure logic: evaluate(originalEvents, newEvents,
 // eventType, metricType, threshold) returns a similarity score in [0, 1] (or
 // null for an unsupported event type, -1 for an unsupported metric). These
 // tests exercise known input/output pairs, including the empty, identical,
@@ -14,7 +14,7 @@ const assert = require('node:assert/strict');
 
 const evalMod = require('../src/core/evaluation');
 const {
-  evalulate,
+  evaluate,
   THRESHOLD_FLEXIBLE,
   THRESHOLD_NORMAL,
   THRESHOLD_STRICT,
@@ -37,7 +37,7 @@ test('identical event sets score 1.0 (value metric)', () => {
   const original = [ev('t/1', [1], 100), ev('t/2', [2], 200)];
   const fresh = [ev('t/1', [1], 100), ev('t/2', [2], 200)];
   // Value metric ignores timestamps, so identical values score 1.
-  const score = evalulate(original, fresh, ALL_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE);
+  const score = evaluate(original, fresh, ALL_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE);
   assert.equal(score, 1);
 });
 
@@ -47,25 +47,25 @@ test('value+timestamp metric: identical values with first-event baseline zero sc
   // yields NaN, so the match fails. Documented here so a later fix is caught.
   const original = [ev('t/1', [1], 100), ev('t/1', [2], 200)];
   const fresh = [ev('t/1', [1], 100), ev('t/1', [2], 200)];
-  const score = evalulate(original, fresh, ALL_EVENTS, METRIC_VALUE_TIMESTAMP, THRESHOLD_FLEXIBLE);
+  const score = evaluate(original, fresh, ALL_EVENTS, METRIC_VALUE_TIMESTAMP, THRESHOLD_FLEXIBLE);
   assert.equal(score, 0);
 });
 
 test('empty original and empty new score 1.0 (no false regression)', () => {
-  assert.equal(evalulate([], [], ALL_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE), 1);
+  assert.equal(evaluate([], [], ALL_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE), 1);
 });
 
 test('empty original, non-empty new scores 0 (nothing matched)', () => {
   const fresh = [ev('t/1', [1], 100)];
   // evaluateEvents: new has items, original empty -> newArrayRemain = all -> 0
-  const score = evalulate([], fresh, ALL_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE);
+  const score = evaluate([], fresh, ALL_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE);
   assert.equal(score, 0);
 });
 
 test('disjoint event sets score 0 (no topic overlap)', () => {
   const original = [ev('a/1', [1], 100), ev('a/2', [2], 200)];
   const fresh = [ev('b/1', [9], 100), ev('b/2', [8], 200)];
-  const score = evalulate(original, fresh, ALL_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE);
+  const score = evaluate(original, fresh, ALL_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE);
   assert.equal(score, 0);
 });
 
@@ -74,7 +74,7 @@ test('a topic with an unmatched new value scores 0 (no partial credit)', () => {
   // original, so newArrayRemain is non-empty and the topic scores 0.
   const original = [ev('t/1', [1], 100), ev('t/1', [2], 200)];
   const fresh = [ev('t/1', [1], 100), ev('t/1', [3], 200)];
-  const score = evalulate(original, fresh, ALL_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE);
+  const score = evaluate(original, fresh, ALL_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE);
   assert.equal(score, 0);
 });
 
@@ -83,8 +83,8 @@ test('a topic that is a value-subset of original is dropped by the normal thresh
   // (1/1); normal (0.75) drops it (0/1).
   const original = [ev('t/1', [1], 100), ev('t/1', [2], 200)];
   const fresh = [ev('t/1', [1], 100)];
-  const flexible = evalulate(original, fresh, ALL_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE);
-  const normal = evalulate(original, fresh, ALL_EVENTS, METRIC_VALUE, THRESHOLD_NORMAL);
+  const flexible = evaluate(original, fresh, ALL_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE);
+  const normal = evaluate(original, fresh, ALL_EVENTS, METRIC_VALUE, THRESHOLD_NORMAL);
   assert.equal(flexible, 1); // 0.5 >= 0.5
   assert.equal(normal, 0); // 0.5 < 0.75
 });
@@ -98,7 +98,7 @@ test('SENSOR_EVENTS only scores sensor events', () => {
     ev('s/1', [1], 100, true),
     ev('a/1', [9], 100, false), // actuator differs, must be ignored
   ];
-  const score = evalulate(original, fresh, SENSOR_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE);
+  const score = evaluate(original, fresh, SENSOR_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE);
   assert.equal(score, 1);
 });
 
@@ -108,21 +108,21 @@ test('ACTUATOR_EVENTS only scores actuator events', () => {
     ev('s/1', [9], 100, true), // sensor differs, must be ignored
     ev('a/1', [1], 100, false),
   ];
-  const score = evalulate(original, fresh, ACTUATOR_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE);
+  const score = evaluate(original, fresh, ACTUATOR_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE);
   assert.equal(score, 1);
 });
 
 test('value metric ignores timestamp skew', () => {
   const original = [ev('t/1', [5], 100)];
   const fresh = [ev('t/1', [5], 999999)]; // wildly different timestamp, same value
-  const score = evalulate(original, fresh, ALL_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE);
+  const score = evaluate(original, fresh, ALL_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE);
   assert.equal(score, 1);
 });
 
 test('value+timestamp metric drops when values match but timestamps skew', () => {
   const original = [ev('t/1', [5], 1000)];
   const fresh = [ev('t/1', [5], 2000)]; // same value, 100% timestamp delta (>= 1% threshold)
-  const score = evalulate(original, fresh, ALL_EVENTS, METRIC_VALUE_TIMESTAMP, THRESHOLD_FLEXIBLE);
+  const score = evaluate(original, fresh, ALL_EVENTS, METRIC_VALUE_TIMESTAMP, THRESHOLD_FLEXIBLE);
   assert.equal(score, 0);
 });
 
@@ -137,8 +137,8 @@ test('threshold filters weak matches from the score', () => {
     ev('t/1', [5], 500),
   ];
   const fresh = [ev('t/1', [1], 100), ev('t/1', [2], 200), ev('t/1', [3], 300)];
-  const flexible = evalulate(original, fresh, ALL_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE);
-  const strict = evalulate(original, fresh, ALL_EVENTS, METRIC_VALUE, THRESHOLD_STRICT);
+  const flexible = evaluate(original, fresh, ALL_EVENTS, METRIC_VALUE, THRESHOLD_FLEXIBLE);
+  const strict = evaluate(original, fresh, ALL_EVENTS, METRIC_VALUE, THRESHOLD_STRICT);
   assert.equal(flexible, 1); // the 0.6 topic passes the 0.5 threshold -> 1/1
   assert.equal(strict, 0); // the 0.6 topic fails the 1.0 threshold -> 0/1
 });
@@ -146,14 +146,14 @@ test('threshold filters weak matches from the score', () => {
 test('unsupported metric type returns -1', () => {
   const original = [ev('t/1', [1], 100)];
   const fresh = [ev('t/1', [1], 100)];
-  const score = evalulate(original, fresh, ALL_EVENTS, 'NOT_A_METRIC', THRESHOLD_FLEXIBLE);
+  const score = evaluate(original, fresh, ALL_EVENTS, 'NOT_A_METRIC', THRESHOLD_FLEXIBLE);
   assert.equal(score, -1);
 });
 
 test('unsupported event type returns null', () => {
   const original = [ev('t/1', [1], 100)];
   const fresh = [ev('t/1', [1], 100)];
-  const score = evalulate(original, fresh, 'NOT_AN_EVENT_TYPE', METRIC_VALUE, THRESHOLD_FLEXIBLE);
+  const score = evaluate(original, fresh, 'NOT_AN_EVENT_TYPE', METRIC_VALUE, THRESHOLD_FLEXIBLE);
   assert.equal(score, null);
 });
 
@@ -161,4 +161,34 @@ test('threshold constants are ordered flexible < normal < strict', () => {
   assert.ok(THRESHOLD_FLEXIBLE < THRESHOLD_NORMAL);
   assert.ok(THRESHOLD_NORMAL < THRESHOLD_STRICT);
   assert.equal(THRESHOLD_STRICT, 1.0);
+});
+
+test('deprecated evalulate alias scores identically and emits a DeprecationWarning', async () => {
+  const original = [ev('t/1', [1], 100), ev('t/2', [2], 200)];
+  const fresh = [ev('t/1', [1], 100), ev('t/2', [2], 200)];
+
+  // The alias must return exactly what evaluate returns (issue #20, scoring
+  // unchanged by the rename) while flagging itself as deprecated.
+  const warnings = [];
+  const onWarning = (w) => warnings.push(w);
+  process.on('warning', onWarning);
+  try {
+    const aliasedScore = evalMod.evalulate(
+      original,
+      fresh,
+      ALL_EVENTS,
+      METRIC_VALUE,
+      THRESHOLD_FLEXIBLE
+    );
+    assert.equal(aliasedScore, 1);
+
+    // util.deprecate emits asynchronously via process.emitWarning.
+    await new Promise((resolve) => setImmediate(resolve));
+    const deprecation = warnings.find(
+      (w) => w.name === 'DeprecationWarning' && /evalulate/.test(w.message)
+    );
+    assert.ok(deprecation, 'expected a DeprecationWarning mentioning evalulate');
+  } finally {
+    process.off('warning', onWarning);
+  }
 });


### PR DESCRIPTION
Closes #20

## Summary

The evaluation module's main entry point was exported as `evalulate` (a typo for `evaluate`) and every caller repeated the misspelling. This renames the export to `evaluate`, updates all internal call sites, and keeps `evalulate` working as a deprecated alias that emits a DeprecationWarning, so nothing breaks during a one-release migration window. Scoring behaviour is unchanged.

## Approach

Rename plus deprecated alias: the implementation function becomes `evaluate`; `evalulate` is re-exported through Node's `util.deprecate` wrapping the same function object, so results are bit-for-bit identical while the old name flags itself on first use per process. All internal callers (simulation engine, reports route, benchmark script, tests) move to `evaluate`.

## Decision Record

- **Root cause:** The module's primary scoring function was defined and exported under the misspelled name `evalulate` (src/core/evaluation/index.js); each new call site copied the misspelling from the existing ones.
- **Options considered:** Option 1 — rename to `evaluate` and keep `evalulate` as a deprecated alias; Option 2 — hard rename without an alias; Option 3 — keep the misspelled name
- **Options rejected:** Option 2 — silently breaks any external consumer of the module and violates acceptance criterion 2; Option 3 — leaves the issue's core complaint (careless-looking public API) unresolved
- **Selected option:** Option 1 — rename with deprecated alias
- **Residual risk:** none identified — the alias delegates to the identical function object; its removal after one release is a documented follow-up
- **Effort profile:** light — fast path (pre-work Effort XS); synthesis skipped, QA capped at 1 cycle

Analyzed at: `refactor/20-correct-the-misspelled-evaluation @ 10da40e` (2026-08-24)

## Changes

| File | Change |
|------|--------|
| `src/core/evaluation/index.js` | Rename `evalulate` → `evaluate`; re-export `evalulate` via `util.deprecate` with warning message |
| `src/core/simulation/Simulation.js` | Import and call `evaluate` |
| `src/server/routes/reports.js` | Import and call `evaluate` in both scoring branches |
| `scripts/benchmark-scoring.js` | Import and call `evaluate`; update labels/comments |
| `test/evaluation.test.js` | Call `evaluate`; add deprecation-alias test |
| `test/evaluation-linear.test.js` | Call `evaluate` |
| `BENCHMARKS.md` | Update recorded benchmark references to `evaluate` |

## Test Results

- Unit tests: 475 passed (full `node --test` suite, 478 total / 3 skipped — pre-existing skips)
- Integration tests: covered by the same suite (server routes), 0 failures
- E2e tests: none in this repository
- Build: lint (eslint) passed, syntax checks passed
- QA cycles: 1 (review clean, 0 blocking issues)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Correctly spelled name exported and used by all internal callers | pass | `src/core/evaluation/index.js` exports `evaluate`; grep shows zero internal `evalulate(` call sites outside the alias definition and its test |
| Misspelled name remains available as deprecated alias | pass | `module.exports.evalulate` wraps `evaluate` via `util.deprecate` (src/core/evaluation/index.js:343) |
| Deprecated alias emits a deprecation warning | pass | Test `deprecated evalulate alias scores identically and emits a DeprecationWarning` in `test/evaluation.test.js` |
| Scoring results unchanged by the rename | pass | All pre-existing score assertions pass unmodified in value (`test/evaluation.test.js`, `test/evaluation-linear.test.js`); the alias returns the identical score in the new test |

<!-- gitissue:qa v1 head=10da40e260c66302d3d5513eb9048da31ffbc999 profile=light cycles=1 review=clean tests=475@10da40e260c66302d3d5513eb9048da31ffbc999 ui=none -->
