### PR TITLE
feat(client): responsive dashboard layout on narrow viewports (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to TaS are documented in this file. Releases are cut as
 
 ## [Unreleased]
 
+### Added
+
+- **Responsive dashboard layout** (#41): below the `md` breakpoint (768px)
+  the header's section navigation collapses into a labelled, keyboard-operable
+  dropdown; data tables scroll horizontally instead of stretching the page;
+  the page shell tightens its margins and forms stack their labels on small
+  screens.
+
 ## [2.0.0] - 2026-08-24
 
 The 2026 hardening and modernisation programme, cut as a major release: the

--- a/src/client/src/App.test.js
+++ b/src/client/src/App.test.js
@@ -37,12 +37,17 @@ const makeStore = () => {
   return store;
 };
 
-const renderApp = () =>
-  render(
+const renderApp = () => {
+  // The signed-in assertions below read the desktop header ("Sign out (op)");
+  // pin the viewport wide so they exercise that layout, not the collapsed
+  // narrow one (issue #41).
+  setMatchMediaViewport(1280);
+  return render(
     <Provider store={makeStore()}>
       <App />
     </Provider>
   );
+};
 
 describe('App', () => {
   beforeEach(() => {

--- a/src/client/src/components/EventStream/EventStream.js
+++ b/src/client/src/components/EventStream/EventStream.js
@@ -212,11 +212,19 @@ class EventStream extends Component {
           bordered
           columns={columns}
           dataSource={eventStreams}
+          scroll={{ x: "max-content" }}
           title={() => title}
         />
       );
     } else {
-      return <Table bordered columns={columns} dataSource={eventStreams} />;
+      return (
+        <Table
+          bordered
+          columns={columns}
+          dataSource={eventStreams}
+          scroll={{ x: "max-content" }}
+        />
+      );
     }
   }
 }

--- a/src/client/src/components/TSHeader/TSHeader.js
+++ b/src/client/src/components/TSHeader/TSHeader.js
@@ -1,9 +1,9 @@
-import React from "react";
+import React, { useState } from "react";
 import { connect } from "react-redux";
 import { Link, useLocation } from "react-router-dom";
-import { Layout, Menu, Row, Col } from "antd";
+import { Layout, Menu, Row, Col, Grid, Dropdown } from "antd";
 import {
-  ClusterOutlined, DatabaseOutlined, DeploymentUnitOutlined, InteractionOutlined, FileTextOutlined, FolderOpenOutlined, EyeOutlined, LogoutOutlined,
+  ClusterOutlined, DatabaseOutlined, DeploymentUnitOutlined, InteractionOutlined, FileTextOutlined, FolderOpenOutlined, EyeOutlined, LogoutOutlined, MenuOutlined,
 } from "@ant-design/icons";
 
 import {
@@ -68,58 +68,130 @@ const menuNames = [
   'Report',
 ];
 
+/**
+ * Builds the section entries shared by both header layouts (issue #41).
+ *
+ * Keeping one source means the horizontal menu and the collapsed narrow-screen
+ * menu can never drift apart: same links, same labels, same router-driven
+ * aria-current marking (issue #36/#39 behaviour).
+ */
+export const buildSectionItems = (selectedKey) =>
+  menuLinks.map((link, index) => ({
+    key: `${index}`,
+    label: (
+      <Link
+        to={link}
+        aria-current={selectedKey === `${index}` ? "page" : undefined}
+      >
+        {menuIcons[index]}
+        {menuNames[index]}
+      </Link>
+    ),
+  }));
+
+const signOutItem = (authenticated, user, logout) =>
+  authenticated
+    ? [
+        {
+          key: "logout",
+          icon: <LogoutOutlined />,
+          label: user ? `Sign out (${user})` : "Sign out",
+          onClick: () => logout(),
+        },
+      ]
+    : [];
+
+/**
+ * The collapsed navigation shown below the md breakpoint (issue #41).
+ *
+ * A real button (keyboard focusable, Enter/Space activates) toggling a
+ * Dropdown whose entries are the same sections as the wide layout. antd's
+ * dropdown menu moves focus with the arrow keys once open, so the whole
+ * collapsed navigation is operable without a pointer.
+ */
+export const NarrowNav = ({ selectedKey, authenticated, user, logout }) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <Dropdown
+      trigger={["click"]}
+      onOpenChange={setOpen}
+      placement="bottomRight"
+      menu={{
+        items: [
+          ...buildSectionItems(selectedKey),
+          ...(signOutItem(authenticated, user, logout).length
+            ? [{ type: "divider" }, ...signOutItem(authenticated, user, logout)]
+            : []),
+        ],
+        selectedKeys: selectedKey ? [selectedKey] : [],
+      }}
+    >
+      <button
+        type="button"
+        className="header-nav-trigger"
+        aria-label={open ? "Close navigation menu" : "Open navigation menu"}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <MenuOutlined />
+        <span>Menu</span>
+      </button>
+    </Dropdown>
+  );
+};
+
 const TSHeader = ({ authenticated, user, logout }) => {
   // The active entry follows the router: useLocation re-renders this header
   // on every client-side navigation (issue #36).
   const { pathname } = useLocation();
   const selectedKey = selectMenuKey(pathname);
 
+  // Below the md breakpoint (768px) the eight-item horizontal menu no longer
+  // fits beside the logo; it collapses into a dropdown (issue #41).
+  // useBreakpoint reports {} before its first matchMedia evaluation, which is
+  // treated as wide so the full navigation is never hidden by default.
+  const screens = Grid.useBreakpoint();
+  const isNarrow = screens.md === false;
+
+  if (isNarrow) {
+    return (
+      <Header>
+        <Row align="middle" justify="space-between">
+          <Col span={16}>
+            <Link to="/">
+              <img src={'/img/Logo.png'} className="logo" alt="TaS dashboard home" />
+            </Link>
+          </Col>
+          <Col span={8} style={{ textAlign: "right" }}>
+            <NarrowNav
+              selectedKey={selectedKey}
+              authenticated={authenticated}
+              user={user}
+              logout={logout}
+            />
+          </Col>
+        </Row>
+      </Header>
+    );
+  }
+
   return (
     <Header>
       <Row>
-        <Col span={4}>
+        <Col xs={8} md={4}>
           <Link to="/">
-            <img
-              src={'/img/Logo.png'}
-              className="logo"
-              alt="TaS dashboard home"
-              style={{ maxWidth: "250px", objectFit: "contain" }}
-            />
+            <img src={'/img/Logo.png'} className="logo" alt="TaS dashboard home" />
           </Link>
         </Col>
-        <Col span={14} push={6}>
+        <Col xs={16} md={20} lg={{ span: 14, push: 6 }}>
           <Menu
             theme="light"
             mode="horizontal"
             style={{ lineHeight: "64px" }}
             selectedKeys={selectedKey ? [selectedKey] : []}
             items={[
-              ...menuLinks.map((link, index) => ({
-                key: `${index}`,
-                label: (
-                  <Link
-                    to={link}
-                    aria-current={selectedKey === `${index}` ? "page" : undefined}
-                  >
-                    {menuIcons[index]}
-                    {menuNames[index]}
-                  </Link>
-                ),
-              })),
-              ...(authenticated
-                ? [
-                    {
-                      key: "logout",
-                      label: (
-                        <span>
-                          <LogoutOutlined />
-                          {user ? `Sign out (${user})` : "Sign out"}
-                        </span>
-                      ),
-                      onClick: () => logout(),
-                    },
-                  ]
-                : []),
+              ...buildSectionItems(selectedKey),
+              ...signOutItem(authenticated, user, logout),
             ]}
           />
         </Col>

--- a/src/client/src/components/TSHeader/TSHeader.js
+++ b/src/client/src/components/TSHeader/TSHeader.js
@@ -111,6 +111,7 @@ const signOutItem = (authenticated, user, logout) =>
  */
 export const NarrowNav = ({ selectedKey, authenticated, user, logout }) => {
   const [open, setOpen] = useState(false);
+  const signOut = signOutItem(authenticated, user, logout);
   return (
     <Dropdown
       trigger={["click"]}
@@ -119,9 +120,7 @@ export const NarrowNav = ({ selectedKey, authenticated, user, logout }) => {
       menu={{
         items: [
           ...buildSectionItems(selectedKey),
-          ...(signOutItem(authenticated, user, logout).length
-            ? [{ type: "divider" }, ...signOutItem(authenticated, user, logout)]
-            : []),
+          ...(signOut.length ? [{ type: "divider" }, ...signOut] : []),
         ],
         selectedKeys: selectedKey ? [selectedKey] : [],
       }}

--- a/src/client/src/components/TSHeader/TSHeader.test.js
+++ b/src/client/src/components/TSHeader/TSHeader.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { afterEach, describe, expect, test } from 'vitest';
@@ -22,8 +22,13 @@ const RouteProbe = () => {
 // the router. After the fix the header is driven by useLocation and its
 // entries are router Links.
 
-const renderHeaderAt = (path) =>
-  render(
+// Issue #41: the header now has two layouts. Below the md breakpoint the
+// eight sections collapse into a dropdown; at and above it the horizontal
+// menu renders as before. Every test pins its viewport explicitly through
+// the shared setupTests helper instead of depending on the ambient stub.
+const renderHeaderAt = (path, { viewport = 1280 } = {}) => {
+  setMatchMediaViewport(viewport);
+  return render(
     <Provider store={createStore(rootReducer)}>
       <MemoryRouter initialEntries={[path]}>
         <TSHeader />
@@ -33,6 +38,7 @@ const renderHeaderAt = (path) =>
       </MemoryRouter>
     </Provider>
   );
+};
 
 const menuItem = (name) => screen.getByRole('menuitem', { name });
 
@@ -40,9 +46,14 @@ const isSelected = (item) =>
   item.classList.contains('ant-menu-item-selected') ||
   item.getAttribute('aria-selected') === 'true';
 
-describe('TSHeader active menu derivation', () => {
-  afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  // Drop the viewport override so the next render starts from the default
+  // narrow stub until it pins its own width.
+  setMatchMediaViewport();
+});
 
+describe('TSHeader active menu derivation', () => {
   test('selects the exact section on a list route', () => {
     renderHeaderAt('/simulation');
     expect(isSelected(menuItem(/simulation/i))).toBe(true);
@@ -78,8 +89,6 @@ describe('TSHeader active menu derivation', () => {
 });
 
 describe('TSHeader client-side navigation', () => {
-  afterEach(cleanup);
-
   test('a menu click moves between sections without leaving the page', async () => {
     renderHeaderAt('/models');
     await userEvent.click(screen.getByRole('link', { name: /test campaign/i }));
@@ -93,8 +102,6 @@ describe('TSHeader client-side navigation', () => {
 });
 
 describe('TSHeader accessibility (issue #39)', () => {
-  afterEach(cleanup);
-
   test('marks the active section with aria-current="page"', () => {
     renderHeaderAt('/simulation');
     // Programmatic current-page indication for assistive tech, independent
@@ -115,5 +122,63 @@ describe('TSHeader accessibility (issue #39)', () => {
     renderHeaderAt('/models');
     const logo = screen.getByAltText(/taS dashboard home/i);
     expect(logo).toHaveAttribute('alt', 'TaS dashboard home');
+  });
+});
+
+describe('TSHeader collapsed navigation on narrow viewports (issue #41)', () => {
+  test('the eight sections are not laid out horizontally below md', () => {
+    renderHeaderAt('/simulation', { viewport: 640 });
+    expect(screen.queryByRole('menuitem', { name: /simulation/i })).toBeNull();
+    expect(screen.queryByRole('menuitem', { name: /topology/i })).toBeNull();
+  });
+
+  test('a labelled trigger replaces the horizontal menu below md', () => {
+    renderHeaderAt('/simulation', { viewport: 640 });
+    const trigger = screen.getByRole('button', { name: /open navigation menu/i });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+  });
+
+  test('the trigger opens by keyboard and exposes every section', async () => {
+    renderHeaderAt('/', { viewport: 640 });
+    const trigger = screen.getByRole('button', { name: /open navigation menu/i });
+    // A native button sits in the tab order, so keyboard users reach it by
+    // tabbing; Enter then activates it exactly like a pointer click.
+    trigger.focus();
+    expect(trigger).toHaveFocus();
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /close navigation menu/i })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+    });
+    expect(screen.getByRole('menuitem', { name: /simulation/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /report/i })).toBeInTheDocument();
+  });
+
+  test('a section chosen from the collapsed menu navigates client-side', async () => {
+    renderHeaderAt('/models', { viewport: 640 });
+    await userEvent.click(screen.getByRole('button', { name: /open navigation menu/i }));
+    await userEvent.click(screen.getByRole('link', { name: /simulation/i }));
+    expect(screen.getByTestId('route-probe')).toHaveTextContent('/simulation');
+  });
+
+  test('aria-current follows the router inside the collapsed menu', async () => {
+    renderHeaderAt('/simulation', { viewport: 640 });
+    await userEvent.click(screen.getByRole('button', { name: /open navigation menu/i }));
+    const current = screen.getByRole('link', { name: /simulation/i });
+    expect(current).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: /topology/i })).not.toHaveAttribute(
+      'aria-current'
+    );
+  });
+
+  test('at md and above the horizontal menu renders without a trigger', () => {
+    renderHeaderAt('/simulation', { viewport: 800 });
+    expect(menuItem(/simulation/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /navigation menu/i })
+    ).toBeNull();
   });
 });

--- a/src/client/src/components/TSHeader/styles.css
+++ b/src/client/src/components/TSHeader/styles.css
@@ -10,3 +10,39 @@ header {
     background: #fff;
     z-index: 10;
 }
+
+/* Logo sizing moved from the inline style so the narrow-viewport override
+   below can shrink it without fighting an inline max-width (issue #41). */
+.logo {
+    max-width: 250px;
+    object-fit: contain;
+}
+
+/* Below the md breakpoint the logo shares the header row with the collapsed
+   navigation trigger, so it gives up most of its width. */
+@media (max-width: 767px) {
+    .logo {
+        max-width: 140px;
+    }
+}
+
+/* Trigger for the collapsed header navigation (issue #41). A real button:
+   keyboard focusable, Enter/Space activates, and it carries aria-expanded
+   for assistive tech. */
+.header-nav-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    font-size: 14px;
+    color: rgba(0, 0, 0, 0.88);
+    background: #fff;
+    border: 1px solid #d9d9d9;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.header-nav-trigger:hover {
+    border-color: #4096ff;
+    color: #4096ff;
+}

--- a/src/client/src/pages/DataRecorderListPage.js
+++ b/src/client/src/pages/DataRecorderListPage.js
@@ -221,7 +221,7 @@ class DataRecorderListPage extends Component {
           </Button>
         </Dropdown>
 
-        <Table columns={columns} dataSource={dataSource} locale={{ emptyText: emptyState }} />
+        <Table columns={columns} dataSource={dataSource} scroll={{ x: "max-content" }} locale={{ emptyText: emptyState }} />
         <p></p>
         <Link to={`/logs/data-recorders`}>View Logs</Link>
       </LayoutPage>

--- a/src/client/src/pages/DataRecorderPage.js
+++ b/src/client/src/pages/DataRecorderPage.js
@@ -84,7 +84,7 @@ const DataRecorderItem = ({
       </Fragment>
     }
   >
-    <Form labelCol={{ span: 4 }} wrapperCol={{ span: 14 }}>
+    <Form labelCol={{ xs: { span: 24 }, sm: { span: 4 } }} wrapperCol={{ xs: { span: 24 }, sm: { span: 14 } }}>
       <FormEditableTextItem
         label="Name"
         defaultValue={data.name}
@@ -434,7 +434,7 @@ class DataRecorderPage extends Component {
             onChange={(newName) => this.onDataChange("name", newName)}
           />
           {tempDataRecorder.dataset && (
-            <Form labelCol={{ span: 4 }} wrapperCol={{ span: 14 }}>
+            <Form labelCol={{ xs: { span: 24 }, sm: { span: 4 } }} wrapperCol={{ xs: { span: 24 }, sm: { span: 14 } }}>
               <Divider orientation="left">Data Storage </Divider>
               {tempDataRecorder.dataStorage ? (
                 <Fragment>

--- a/src/client/src/pages/DataStoragePage.js
+++ b/src/client/src/pages/DataStoragePage.js
@@ -67,10 +67,12 @@ class DataStoragePage extends Component {
       view = (
         <Form
           labelCol={{
-            span: 4,
+            xs: { span: 24 },
+            sm: { span: 4 },
           }}
           wrapperCol={{
-            span: 14,
+            xs: { span: 24 },
+            sm: { span: 14 },
           }}
         >
           <ConnectionConfig

--- a/src/client/src/pages/DatasetListPage.js
+++ b/src/client/src/pages/DatasetListPage.js
@@ -117,7 +117,7 @@ class DatasetListPage extends Component {
         <Link to={`/data-sets/new-dataset-${Date.now()}`}>
           <Button style={{ marginBottom: "10px" }}>Add New Dataset</Button>
         </Link>
-        <Table columns={columns} dataSource={dataSource} locale={{ emptyText: emptyState }} />
+        <Table columns={columns} dataSource={dataSource} scroll={{ x: "max-content" }} locale={{ emptyText: emptyState }} />
       </LayoutPage>
     );
   }

--- a/src/client/src/pages/DatasetPage.js
+++ b/src/client/src/pages/DatasetPage.js
@@ -282,7 +282,7 @@ class DatasetPage extends Component {
         {fetchFailed ? (
           <Button onClick={() => this.refetch()}>Retry loading dataset</Button>
         ) : null}
-        <Form labelCol={{ span: 8 }} wrapperCol={{ span: 16 }}>
+        <Form labelCol={{ xs: { span: 24 }, sm: { span: 8 } }} wrapperCol={{ xs: { span: 24 }, sm: { span: 16 } }}>
           {isNew ? (
             <Fragment>
               <FormEditableTextItem

--- a/src/client/src/pages/LayoutPage.js
+++ b/src/client/src/pages/LayoutPage.js
@@ -27,7 +27,7 @@ class LayoutPage extends Component {
             description: describeError(notify.message),
             onClose: () => resetNotification(),
           })}
-        <Layout style={{ padding: "0px 48px 48px", margin: "30px 50px 50px" }}>
+        <Layout className="page-shell">
           <Content>
             {pageTitle && <Title level={2}>{pageTitle}</Title>}
             {pageSubTitle && <Text type="secondary">{pageSubTitle}</Text>}

--- a/src/client/src/pages/LogsPage.js
+++ b/src/client/src/pages/LogsPage.js
@@ -107,7 +107,7 @@ class LogsPage extends Component {
           className="site-page-header"
           title={`${logFiles.length} Log Files`}
         />
-        <Table columns={columns} dataSource={dataSource} locale={{ emptyText: emptyState }} />
+        <Table columns={columns} dataSource={dataSource} scroll={{ x: "max-content" }} locale={{ emptyText: emptyState }} />
       </LayoutPage>
     );
   }

--- a/src/client/src/pages/ModelListPage.js
+++ b/src/client/src/pages/ModelListPage.js
@@ -224,7 +224,7 @@ class ModelListPage extends Component {
             Add Model <DownOutlined />
           </Button>
         </Dropdown>
-        <Table columns={columns} dataSource={dataSource} locale={{ emptyText: emptyState }} />
+        <Table columns={columns} dataSource={dataSource} scroll={{ x: "max-content" }} locale={{ emptyText: emptyState }} />
       </LayoutPage>
     );
   }

--- a/src/client/src/pages/ModelPage.js
+++ b/src/client/src/pages/ModelPage.js
@@ -161,7 +161,7 @@ const ModelDeviceItem = ({
       </Fragment>
     }
   >
-    <Form labelCol={{ span: 4 }} wrapperCol={{ span: 14 }}>
+    <Form labelCol={{ xs: { span: 24 }, sm: { span: 4 } }} wrapperCol={{ xs: { span: 24 }, sm: { span: 14 } }}>
       <FormEditableTextItem
         label="Name"
         defaultValue={data.name}
@@ -657,7 +657,7 @@ class ModelPage extends Component {
       view = (
         <Fragment>
           <p></p>
-          <Form labelCol={{ span: 4 }} wrapperCol={{ span: 14 }}>
+          <Form labelCol={{ xs: { span: 24 }, sm: { span: 4 } }} wrapperCol={{ xs: { span: 24 }, sm: { span: 14 } }}>
             <FormEditableTextItem
               label="Name"
               defaultValue={tempModel.name}

--- a/src/client/src/pages/ReportListPage.js
+++ b/src/client/src/pages/ReportListPage.js
@@ -129,6 +129,7 @@ class ReportListPage extends Component {
           columns={columns}
           dataSource={dataSource}
           pagination={pagination}
+          scroll={{ x: "max-content" }}
           locale={{ emptyText: emptyState }}
         />
       </LayoutPage>

--- a/src/client/src/pages/ReportPage.js
+++ b/src/client/src/pages/ReportPage.js
@@ -217,7 +217,7 @@ class ReportPage extends Component {
     }
     return (
       <LayoutPage pageTitle={`Report ${_id}`} pageSubTitle="Report detail">
-        <Form labelCol={{ span: 8 }} wrapperCol={{ span: 16 }}>
+        <Form labelCol={{ xs: { span: 24 }, sm: { span: 8 } }} wrapperCol={{ xs: { span: 24 }, sm: { span: 16 } }}>
           <FormTextNotEditableItem label="Id" value={_id} />
           <FormTextNotEditableItem
             label="Created At"

--- a/src/client/src/pages/SimulationPage.js
+++ b/src/client/src/pages/SimulationPage.js
@@ -105,7 +105,7 @@ class SimulationPage extends Component {
             pageTitle="Simulation Page"
             pageSubTitle="Manually perform a simulation"
           >
-            <Form labelCol={{ span: 4 }} wrapperCol={{ span: 14 }}>
+            <Form labelCol={{ xs: { span: 24 }, sm: { span: 4 } }} wrapperCol={{ xs: { span: 24 }, sm: { span: 14 } }}>
               <FormSelectItem
                 label={"Model File Name"}
                 defaultValue={modelFileName}
@@ -186,10 +186,12 @@ class SimulationPage extends Component {
       >
         <Form
           labelCol={{
-            span: 4,
+            xs: { span: 24 },
+            sm: { span: 4 },
           }}
           wrapperCol={{
-            span: 14,
+            xs: { span: 24 },
+            sm: { span: 14 },
           }}
         >
           <FormSelectItem

--- a/src/client/src/pages/TestCampaignListPage.js
+++ b/src/client/src/pages/TestCampaignListPage.js
@@ -170,7 +170,7 @@ class TestCampaignListPage extends Component {
         pageSubTitle="All the test campaigns"
       >
         <CollapseForm title="Configuration for next build" active={true}>
-          <Form labelCol={{ span: 4 }} wrapperCol={{ span: 14 }}>
+          <Form labelCol={{ xs: { span: 24 }, sm: { span: 4 } }} wrapperCol={{ xs: { span: 24 }, sm: { span: 14 } }}>
             <FormEditableTextItem
               label="WebhookURL"
               defaultValue={webhookURL}

--- a/src/client/src/pages/TestCampaignListPage.js
+++ b/src/client/src/pages/TestCampaignListPage.js
@@ -298,7 +298,7 @@ class TestCampaignListPage extends Component {
         <Link to={`/test-campaigns/new-campaign-${Date.now()}`}>
           <Button style={{ marginBottom: "10px" }}>Add New Campaign</Button>
         </Link>
-        <Table columns={columns} dataSource={dataSource} locale={{ emptyText: emptyState }} />
+        <Table columns={columns} dataSource={dataSource} scroll={{ x: "max-content" }} locale={{ emptyText: emptyState }} />
         <p></p>
         <Link to={`/logs/test-campaigns`}>View All Campaign Logs</Link>
       </LayoutPage>

--- a/src/client/src/pages/TestCampaignPage.js
+++ b/src/client/src/pages/TestCampaignPage.js
@@ -190,7 +190,7 @@ class TestCampaignPage extends Component {
         pageTitle={name}
         pageSubTitle="View and update the test campaign detail"
       >
-        <Form labelCol={{ span: 4 }} wrapperCol={{ span: 14 }}>
+        <Form labelCol={{ xs: { span: 24 }, sm: { span: 4 } }} wrapperCol={{ xs: { span: 24 }, sm: { span: 14 } }}>
           <FormEditableTextItem
             label="Id"
             defaultValue={id}

--- a/src/client/src/pages/TestCampaignPage.js
+++ b/src/client/src/pages/TestCampaignPage.js
@@ -232,7 +232,7 @@ class TestCampaignPage extends Component {
         <Link to={`/reports/?testCampaignId=${id}`}>
           <Button>View All Campaign's Reports</Button>
         </Link>
-        <Table columns={columns} dataSource={dataSource} />
+        <Table columns={columns} dataSource={dataSource} scroll={{ x: "max-content" }} />
         <Button
           onClick={() => this.saveTestCampaign()}
           disabled={isChanged ? false : true}

--- a/src/client/src/pages/TestCaseListPage.js
+++ b/src/client/src/pages/TestCaseListPage.js
@@ -89,7 +89,7 @@ class TestCaseListPage extends Component {
         <Link to={`/test-cases/new-case-${Date.now()}`}>
           <Button style={{ marginBottom: "10px" }}>Add New Case</Button>
         </Link>
-        <Table columns={columns} dataSource={dataSource} locale={{ emptyText: emptyState }} />
+        <Table columns={columns} dataSource={dataSource} scroll={{ x: "max-content" }} locale={{ emptyText: emptyState }} />
       </LayoutPage>
     );
   }

--- a/src/client/src/pages/TestCasePage.js
+++ b/src/client/src/pages/TestCasePage.js
@@ -306,7 +306,7 @@ class TestCasePage extends Component {
             onChange={(values) => this.updateDatasets(values)}
           />
         </Button>
-        <Table columns={columns} dataSource={dataSource} />
+        <Table columns={columns} dataSource={dataSource} scroll={{ x: "max-content" }} />
           <Button
             onClick={() => this.saveTestCase()}
             disabled={isChanged ? false : true}

--- a/src/client/src/pages/styles.css
+++ b/src/client/src/pages/styles.css
@@ -9,3 +9,17 @@
 .content>div {
     width: 100%;
 }
+
+/* Page shell: the fixed desktop margins from the inline style moved here so
+   narrow viewports can reclaim their width (issue #41). */
+.page-shell {
+    padding: 0 48px 48px;
+    margin: 30px 50px 50px;
+}
+
+@media (max-width: 767px) {
+    .page-shell {
+        padding: 0 12px 24px;
+        margin: 12px 8px 24px;
+    }
+}

--- a/src/client/src/setupTests.js
+++ b/src/client/src/setupTests.js
@@ -29,3 +29,28 @@ if (typeof globalThis.ResizeObserver !== 'function') {
   };
 }
 
+// Pins antd's responsive components (Grid.useBreakpoint, responsive Col
+// spans) to an emulated viewport width for tests that need a specific
+// layout, e.g. the collapsed vs horizontal header navigation (issue #41).
+// Without it the stub above answers "no" to every query, which is the
+// narrow layout. Pass no argument to restore the always-narrow default.
+globalThis.setMatchMediaViewport = (width) => {
+  if (width === undefined) {
+    delete window.matchMedia;
+    return;
+  }
+  window.matchMedia = (query) => {
+    const match = /min-width:\s*(\d+)px/.exec(query);
+    return {
+      matches: match !== null && width >= Number(match[1]),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    };
+  };
+};
+


### PR DESCRIPTION
Closes #41

## Summary

The dashboard used fixed grid proportions with an eight-item horizontal header menu, a 250px logo and fixed page margins, and nothing in the app handled a viewport below laptop width: the navigation overflowed or wrapped badly and data tables stretched past the viewport. The layout now responds to the antd `md` breakpoint (768px): narrow viewports get a collapsed, keyboard-operable header menu, tables scroll inside their container instead of overflowing the page, the page shell tightens its margins, and page-level forms stack their labels above their controls.

## Approach

Direct minimal plan (light profile) — build on the component-library work already merged on these components (#34 Vite/antd v6, #36 router-driven selection, #39 labelled collapse trigger) rather than reworking them:

- **Header** (`TSHeader`): `Grid.useBreakpoint()` selects between two layouts built from one shared item builder (`buildSectionItems`), so links, labels and router-driven `aria-current` can never drift apart. Below `md`, a real `<button>` (focusable, Enter/Space, `aria-expanded`/`aria-haspopup`) opens an antd Dropdown carrying the same sections plus Sign out; at `md`+ the horizontal menu keeps its desktop proportions (`md={20}` gives the menu more room between 768–991px; `lg`+ is pixel-identical to before). Logo sizing moved from inline style into CSS so it shrinks under 768px.
- **Tables**: every data table (9 list/detail pages + both `EventStream` variants) gets `scroll={{ x: "max-content" }}`, moving overflow into a horizontal scrollbar inside the table container.
- **Page shell** (`LayoutPage`): the fixed inline padding/margin moved to a `.page-shell` class that tightens below 768px.
- **Forms**: page-level forms use responsive cols — labels stack at `xs`, desktop proportions return at `sm`. Modal-internal forms are unchanged because the modal already constrains its own width.

## Decision Record

- **Root cause:** no breakpoint handling anywhere — fixed `Row`/`Col` spans (`4` / `14 push 6`) sized the header for ≥992px only, tables had no scroll config so wide column sets expanded the page itself, and the shell's fixed 48px/50px paddings consumed narrow viewports.
- **Options considered:** Option 1 — CSS-only overflow mitigation (hide/shrink); Option 2 — breakpoint-aware layouts reusing antd Grid/Dropdown primitives per component (selected); Option 3 — Drawer-based header navigation rewrite mirroring TSSider.
- **Options rejected:** Option 1 — masks overflow instead of fixing usability, fails AC1/AC5; Option 3 — duplicates the side-navigation pattern TSSider already provides, larger regression surface for a P3 issue.
- **Selected option:** Option 2 — breakpoint-aware layouts on existing primitives
- **Residual risk:** the collapsed trigger is ~36px tall — passes WCAG 2.5.8 AA (24px minimum) but sits under the 44px AAA best practice; antd renders one wide-layout frame before matchMedia resolves on first paint on real devices.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `refactor/41-make-the-dashboard-layout-responsive @ 0d7e91c` (2026-08-24)

## Changes

| File | Change |
|------|--------|
| `src/client/src/components/TSHeader/TSHeader.js` | Breakpoint-switched header: shared item builder, keyboard-operable collapsed nav, responsive grid cols |
| `src/client/src/components/TSHeader/styles.css` | Logo sizing in CSS + narrow override; `.header-nav-trigger` button styles |
| `src/client/src/setupTests.js` | Shared `setMatchMediaViewport()` helper pinning antd responsive components in tests |
| `src/client/src/components/TSHeader/TSHeader.test.js` | Existing tests pinned wide; new narrow-mode tests (collapse, keyboard open, client-side nav, aria-current, md threshold) |
| `src/client/src/App.test.js` | Signed-in assertions pinned to the desktop layout |
| `src/client/src/pages/LayoutPage.js` + `pages/styles.css` | Fixed shell margins → `.page-shell` class with <768px media query |
| 9 pages + `EventStream` | `scroll={{ x: "max-content" }}` on all data tables |
| 10 page-level forms | Responsive `labelCol`/`wrapperCol` (`xs` stacked, `sm`+ desktop) |
| `CHANGELOG.md` | Unreleased entry |

## Test Results

- Client suite (vitest + RTL): 77 passed (71 baseline + 6 new), 0 failed
- Root suite (`node:test`): 483 passed, 0 failed, 5 skipped — unchanged baseline maintained
- Build (`vite build`): passed
- QA cycles: 1 (review clean; 2 non-blocking notes, one addressed in fix commit)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Navigation collapses into an accessible menu below a defined breakpoint | pass | `TSHeader.js` `NarrowNav` below `md`; side navigation already collapsed via `TSSider` `breakpoint="lg"` (#39); `TSHeader.test.js` "a labelled trigger replaces the horizontal menu below md" |
| Header does not overflow or wrap awkwardly at any supported width | pass | Narrow mode removes the horizontal menu entirely; md–lg widens the nav column to 20/24; logo capped at 140px <768px (`styles.css` media query) |
| Data tables remain usable at narrow widths, scrolling rather than overflowing | pass | `scroll={{ x: "max-content" }}` across all 10 table sites (9 pages + EventStream×2) |
| Forms and modals remain usable at narrow widths | pass | Page forms stack labels at `xs`; shell margins shrink; modals constrained by antd default width + existing `min-width: 60%` rule |
| Collapsed navigation fully operable by keyboard | pass | Native `<button>` trigger (tab order, Enter/Space) with `aria-expanded`; antd dropdown arrow-key focus; `TSHeader.test.js` "the trigger opens by keyboard and exposes every section" |

<!-- gitissue:qa v1 head=97230ad611ead8cd36b56fbe32caa3a52face22f profile=light cycles=1 review=clean tests=483@e304958aaa44f789f4ec606316a0c439e7596237 ui=code:clean@1e47019b15da609c0f8bb4ad7b1a65b3112be9a4 -->