### PR TITLE
feat(server): extract simulation runtime state into a persistent registry (#29)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ mosquitto.passwd
 # Local gitissue run state (issue analyses, run log)
 .gitissue/
 
+# Runtime run-state registry (issue #29): which simulations, data recorders
+# and test campaigns are running is runtime data - written by the server,
+# never committed. The .lock and .corrupt-* siblings belong to the same story.
+src/server/data/runtime-state.json*
+
 # Husky v9 internal helper (regenerated on `npm install` via the prepare script)
 .husky/_/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,28 @@ All notable changes to TaS are documented in this file. Releases are cut as
   the page shell tightens its margins and forms stack their labels on small
   screens.
 
+### Changed
+
+- **Runtime run state is now persistent and shared** (#29): which simulations,
+  data recorders and test campaigns are running used to live in module-level
+  variables that a restart wiped and that grew without bound on stopped runs.
+  All of it now flows through one registry (`src/server/runtime-state`)
+  backed by `src/server/data/runtime-state.json` — written atomically under a
+  lock, so two server processes on the same store observe one consistent view
+  and a topology in use on one process is refused on the other. Operators see
+  these behaviour changes:
+  - after any restart the dashboard reports the true running state; work
+    orphaned by an unclean shutdown is detected at boot, logged with its
+    owner, and cleaned up automatically;
+  - stopped entries are removed from `/status` rather than kept forever as
+    `isRunning: false` placeholders (the stop responses still report the final
+    state of what was just stopped);
+  - starting a test campaign while one is already running is now a `409`
+    conflict instead of silently orphaning the previous campaign.
+    The store path can be moved with `TAS_RUNTIME_STATE_PATH`. No database is
+    involved: tracking degrades to memory-only (with a warning) if the store is
+    unwritable, so the status endpoints never depend on database health.
+
 ## [2.0.0] - 2026-08-24
 
 The 2026 hardening and modernisation programme, cut as a major release: the

--- a/env.example
+++ b/env.example
@@ -44,3 +44,8 @@ DEV_DASHBOARD_PORT=8080
 # Successful logins do not count towards it.
 #AUTH_LOGIN_RATE_LIMIT_WINDOW_MS=900000
 #AUTH_LOGIN_RATE_LIMIT_MAX=10
+
+# Where the runtime-state registry (issue #29) persists which simulations,
+# data recorders and test campaigns are running. Defaults to
+# src/server/data/runtime-state.json, alongside the other data files.
+#TAS_RUNTIME_STATE_PATH=

--- a/src/core/devops-flow/index.js
+++ b/src/core/devops-flow/index.js
@@ -18,6 +18,10 @@ const stopTestCampaign = () => {
 /**
  * Start the test campaign
  * @param {Object} model The model to be simulated
+ * @returns {TestCampaign} The campaign that was started. The caller - the
+ *   devops route, through the runtime registry (#29) - holds this instance so
+ *   it can be stopped again; the module-level variable below only remains for
+ *   the standalone CLI entry point at the bottom of this file.
  */
 const startTestCampaign = (
   testCampaignId,
@@ -29,11 +33,6 @@ const startTestCampaign = (
   // The run's own logger, obtained explicitly by the caller. Without one,
   // fall back to the process console.
   const log = logger || console;
-  // console.log("Start test campaign: ");
-  // console.log(testCampaignId);
-  // console.log(JSON.stringify(dataStorage));
-  // console.log(webhookURL);
-  // console.log(JSON.stringify(evaluationParameters));
   testCampaign = new TestCampaign(
     testCampaignId,
     dataStorage,
@@ -50,6 +49,7 @@ const startTestCampaign = (
       });
     }
   });
+  return testCampaign;
 };
 
 if (process.argv[2] === 'test') {

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -289,5 +289,27 @@ if (require.main === module) {
    */
   const { installGracefulShutdown } = require('./shutdown');
   const { closeDBClient } = require('./routes/db-connector');
-  installGracefulShutdown(_server, { closeDb: closeDBClient });
+  const runtimeState = require('./runtime-state');
+
+  /**
+   * The runs a process takes down with itself are dropped from the shared
+   * store on the way out (issue #29): a clean restart reports no ghosts. What
+   * an UNCLEAN death leaves behind is exactly what the next boot's
+   * reconciliation detects and cleans up.
+   */
+  const closeDb = (done) => {
+    runtimeState
+      .deregisterOwned()
+      .catch(() => {})
+      .then(() => closeDBClient(done));
+  };
+  installGracefulShutdown(_server, { closeDb });
+
+  /**
+   * Reconcile the persisted store with reality before serving: work recorded
+   * as running by a process that no longer exists is reported and reaped, so
+   * the dashboard shows the true running state immediately after any restart
+   * (issue #29). File-only - it never waits for a database.
+   */
+  runtimeState.reconcileAll().catch(() => {});
 }

--- a/src/server/routes/data-recorders.js
+++ b/src/server/routes/data-recorders.js
@@ -28,6 +28,10 @@ let router = express.Router();
 let getLogger = require('../logger');
 const { getDataStorage } = require('./db-connector');
 let logsPath = `${__dirname}/../logs/data-recorders/`;
+// Running-recorder records and handles live in the shared runtime registry
+// (issue #29): records persist across restarts and are visible to a second
+// server process on the same store, handles stay with the owning process.
+const runtimeState = require('../runtime-state');
 
 // ---------------------------------------------------------------------------
 // Validation schemas for the data-recorder endpoints (issue #10)
@@ -83,28 +87,59 @@ const dataRecorderStartBody = Joi.object({
  *    logFile: String
  * }
  */
-let allRunningStatus = {};
-let allDataRecorders = {};
-// The ids whose start is under way. On the default data storage path the
-// recorder is only registered inside the `getDataStorage` callback, an
-// event-loop turn after the guard below read the registry, so without something
-// held across that turn two concurrent starts of one recorder both pass the
-// guard and the first one is left recording with no handle to stop it. A
-// reservation rather than a placeholder in `allDataRecorders`: `/stop` calls
-// `stop()` on whatever it finds there.
-const startingDataRecorders = new Set();
-// The logger of each running recorder, held here so `/stop` can release the
-// run's file handle once the recorder stops. The logger is passed explicitly
-// to the run; global console methods are never touched.
-const runLoggers = {};
+/**
+ * Strip the registry's bookkeeping fields from a record before it reaches a
+ * response: clients see the run, not which pid owns it.
+ */
+const publicRecord = (record) => {
+  if (!record) return record;
+  const { owner, kind, status, ...rest } = record;
+  void owner;
+  void kind;
+  void status;
+  return rest;
+};
+
+// The final snapshots of recorders this instance stopped, held only long
+// enough for the stop response to report them. A later stop of the same id
+// replaces the snapshot, so repeated runs cannot grow this table.
+const lastStopped = {};
+
+/**
+ * The status surface the dashboard reads: every record in the shared store,
+ * keyed by recorder id. Records whose owner is gone - work orphaned by an
+ * unclean shutdown - are reaped on the way, so the map only ever describes
+ * work that is still running somewhere live.
+ */
+const recorderStatusMap = async () => {
+  await runtimeState.reconcile('data-recorders');
+  const records = await runtimeState.list('data-recorders');
+  const map = {};
+  for (const record of records) {
+    map[record.id] = publicRecord(record);
+  }
+  return map;
+};
+
+/** Release a stopped recorder's log file handle and drop its registry entry. */
+const reapRecorder = async (recorderId) => {
+  const handle = runtimeState.getHandle('data-recorders', recorderId);
+  if (handle && handle.logger) {
+    // The run has stopped: release its log file handle.
+    handle.logger.close();
+  }
+  return runtimeState.reap('data-recorders', recorderId);
+};
 
 /**
  * Get the running status of data recorder
  */
 router.get('/status', validate(), (req, res, next) => {
-  res.send({
-    status: allRunningStatus,
-  });
+  recorderStatusMap()
+    .then((status) => {
+      res.send({ status });
+    })
+    .catch(next);
 });
 
 // Stop the running data recorder
@@ -114,99 +149,165 @@ router.get(
   function (req, res, next) {
     const { fileName } = req.params;
     const recorderId = getObjectId(fileName.replace('.json', ''));
-    if (allDataRecorders[recorderId]) {
-      allDataRecorders[recorderId].stop();
-      allDataRecorders[recorderId] = null;
-    }
-    if (runLoggers[recorderId]) {
-      // The run has stopped: release its log file handle.
-      runLoggers[recorderId].close();
-      delete runLoggers[recorderId];
-    }
-    if (allRunningStatus[recorderId]) {
-      allRunningStatus[recorderId].isRunning = false;
-      allRunningStatus[recorderId].endTime = Date.now();
-    }
-    res.send({
-      error: null,
-      status: allRunningStatus,
-    });
+    stopRecorderById(recorderId)
+      .then(() => recorderStatusMap())
+      .then((status) => {
+        res.send({
+          error: null,
+          // The response still reports the recorder that was just stopped,
+          // with its final state - while the registry itself has dropped it,
+          // so the tracking structures cannot grow over repeated runs.
+          status: {
+            ...status,
+            ...(lastStopped[recorderId] ? { [recorderId]: lastStopped[recorderId] } : {}),
+          },
+        });
+      })
+      .catch(next);
   }
 );
 
-const startRecorder = (model, res, next) => {
-  if (!model) {
-    next(badRequest('Cannot find data recorder configuration'));
-  } else {
-    const { name, dataRecorders, dataStorage } = model;
-    if (!name || !dataRecorders) {
-      next(badRequest('Invalid data recorder model'));
-    } else if (!isValidName(name)) {
-      next(badRequest('Invalid data recorder name'));
-    } else {
-      const recorderId = getObjectId(name);
-      if (startingDataRecorders.has(recorderId) || allDataRecorders[recorderId]) {
-        // The recorder is already running: the request cannot be applied to the
-        // state the resource is in, which is a conflict rather than a fault.
-        next(conflict('Recorder has already started'));
-      } else {
-        const startedTime = Date.now();
-        const logFile = `${name}_${startedTime}.log`;
-        const logger = getLogger('DATA-RECORDER', `${logsPath}${logFile}`);
-        runLoggers[recorderId] = logger;
-        if (!dataStorage) {
-          // use default data storage
-          startingDataRecorders.add(recorderId);
-          getDataStorage((err, ds) => {
-            // Released first, so the reservation cannot outlive the start on
-            // either path, nor if registering the recorder throws.
-            startingDataRecorders.delete(recorderId);
-            if (err) {
-              next(unavailable('No data storage', err));
-            } else {
-              const dataRecorder = new DataRecorder(
-                {
-                  ...model,
-                  dataStorage: ds,
-                },
-                logger
-              );
-              dataRecorder.start();
-              logger.log('[data-recorders] A data recorder has been started ...');
-              allDataRecorders[`${recorderId}`] = dataRecorder;
-              allRunningStatus[`${recorderId}`] = {
-                isRunning: true,
-                model: name,
-                startedTime,
-                endTime: null,
-                logFile,
-              };
-              res.send({
-                model,
-                status: allRunningStatus,
-              });
-            }
-          });
-        } else {
-          const dataRecorder = new DataRecorder(model, logger);
-          dataRecorder.start();
-          logger.log('[data-recorders] A data recorder has been started ...');
-          allDataRecorders[`${recorderId}`] = dataRecorder;
-          allRunningStatus[`${recorderId}`] = {
-            isRunning: true,
-            model: name,
-            startedTime,
-            endTime: null,
-            logFile,
-          };
-          res.send({
-            model,
-            status: allRunningStatus,
-          });
-        }
-      }
-    }
+const snapshotRecorder = (record, endTime) => {
+  if (!record) return null;
+  const finalSnapshot = publicRecord({ ...record, isRunning: false, endTime });
+  lastStopped[finalSnapshot.id] = finalSnapshot;
+  return finalSnapshot;
+};
+
+/**
+ * Stop whatever the id refers to, according to who owns it - mirroring the
+ * simulation router: own runs are stopped and reaped, orphans left by an
+ * unclean shutdown are reaped, another live process's recorder is visible but
+ * not stoppable from here, and an unknown id answers with the current status.
+ */
+const stopRecorderById = async (recorderId) => {
+  const endTime = Date.now();
+  const handle = runtimeState.getHandle('data-recorders', recorderId);
+  let records = [];
+  try {
+    records = await runtimeState.list('data-recorders');
+  } catch (_) {
+    records = [];
   }
+  const record = records.find((entry) => entry.id === recorderId) || null;
+
+  if (handle) {
+    // This process owns the recorder: stop it for real.
+    if (handle.run) {
+      handle.run.stop();
+    }
+    const stopped = await reapRecorder(recorderId);
+    return snapshotRecorder(stopped || record, endTime);
+  }
+  if (record && !runtimeState.ownerIsAlive(record)) {
+    const stopped = await runtimeState.reap('data-recorders', recorderId);
+    return snapshotRecorder(stopped || record, endTime);
+  }
+  return null;
+};
+
+const startRecorder = async (model, res, next) => {
+  if (!model) {
+    return next(badRequest('Cannot find data recorder configuration'));
+  }
+  const { name, dataRecorders, dataStorage } = model;
+  if (!name || !dataRecorders) {
+    return next(badRequest('Invalid data recorder model'));
+  }
+  if (!isValidName(name)) {
+    return next(badRequest('Invalid data recorder name'));
+  }
+  const recorderId = getObjectId(name);
+  // The reservation is claimed BEFORE anything asynchronous runs, so two
+  // starts arriving together cannot both get past the check. The SHARED store
+  // is read as well: a recorder another process on the same store runs is a
+  // conflict too.
+  if (
+    runtimeState.isReserved('data-recorders', recorderId) ||
+    runtimeState.getHandle('data-recorders', recorderId)
+  ) {
+    // The recorder is already running: the request cannot be applied to the
+    // state the resource is in, which is a conflict rather than a fault.
+    return next(conflict('Recorder has already started'));
+  }
+  runtimeState.reserve('data-recorders', recorderId);
+  const foreignRecord = await runtimeState
+    .list('data-recorders')
+    .then((records) => records.some((record) => record.id === recorderId))
+    .catch(() => false);
+  if (foreignRecord) {
+    runtimeState.releaseReservation('data-recorders', recorderId);
+    return next(conflict('Recorder has already started'));
+  }
+  const startedTime = Date.now();
+  const logFile = `${name}_${startedTime}.log`;
+  const logger = getLogger('DATA-RECORDER', `${logsPath}${logFile}`);
+  // Persistence failures degrade to memory-only tracking (warned once inside
+  // the registry); they never fail a start that itself succeeded.
+  const registerStarted = (recorder, record) =>
+    runtimeState.register('data-recorders', record, { run: recorder, logger }).catch(() => {});
+  if (!dataStorage) {
+    // use default data storage
+    getDataStorage(async (err, ds) => {
+      // Released first, so the reservation cannot outlive the start on
+      // either path, nor if registering the recorder throws.
+      runtimeState.releaseReservation('data-recorders', recorderId);
+      if (err) {
+        next(unavailable('No data storage', err));
+      } else {
+        const dataRecorder = new DataRecorder(
+          {
+            ...model,
+            dataStorage: ds,
+          },
+          logger
+        );
+        dataRecorder.start();
+        logger.log('[data-recorders] A data recorder has been started ...');
+        // The start answer follows the persisted record: once it has been
+        // sent, any later status read - here or from another process - sees
+        // the recorder.
+        await registerStarted(dataRecorder, {
+          id: recorderId,
+          isRunning: true,
+          model: name,
+          startedTime,
+          endTime: null,
+          logFile,
+        });
+        respondWithStatus(res, { model });
+      }
+    });
+  } else {
+    const dataRecorder = new DataRecorder(model, logger);
+    dataRecorder.start();
+    logger.log('[data-recorders] A data recorder has been started ...');
+    // The start answer follows the persisted record.
+    await registerStarted(dataRecorder, {
+      id: recorderId,
+      isRunning: true,
+      model: name,
+      startedTime,
+      endTime: null,
+      logFile,
+    });
+    // The handle table now answers the guard for this recorder.
+    runtimeState.releaseReservation('data-recorders', recorderId);
+    respondWithStatus(res, { model });
+  }
+};
+
+/**
+ * Answer with the current status map, whatever the endpoint otherwise returns.
+ */
+const respondWithStatus = (res, extra = {}) => {
+  recorderStatusMap()
+    .then((status) => {
+      res.send({ ...extra, status });
+    })
+    .catch(() => {
+      res.send({ ...extra, status: {} });
+    });
 };
 
 // Start a data recorder
@@ -222,12 +323,12 @@ router.post('/start', validate({ body: dataRecorderStartBody }), (req, res, next
       if (err) {
         next(fileError(err, 'Data recorder not found', 'Cannot read the data recorder file'));
       } else {
-        startRecorder(data, res, next);
+        startRecorder(data, res, next).catch(next);
       }
     });
   } else {
     // Start recorder by model
-    startRecorder(model, res, next);
+    startRecorder(model, res, next).catch(next);
   }
 });
 

--- a/src/server/routes/data-recorders.js
+++ b/src/server/routes/data-recorders.js
@@ -78,7 +78,7 @@ const dataRecorderStartBody = Joi.object({
 ///////////////
 
 /**
- * status
+ * The status shape each entry reports:
  * {
  *    isRunning: true|false,
  *    model: {},
@@ -86,8 +86,7 @@ const dataRecorderStartBody = Joi.object({
  *    stoppedTime: timestamp,
  *    logFile: String
  * }
- */
-/**
+ *
  * Strip the registry's bookkeeping fields from a record before it reaches a
  * response: clients see the run, not which pid owns it.
  */
@@ -99,11 +98,6 @@ const publicRecord = (record) => {
   void status;
   return rest;
 };
-
-// The final snapshots of recorders this instance stopped, held only long
-// enough for the stop response to report them. A later stop of the same id
-// replaces the snapshot, so repeated runs cannot grow this table.
-const lastStopped = {};
 
 /**
  * The status surface the dashboard reads: every record in the shared store,
@@ -121,7 +115,9 @@ const recorderStatusMap = async () => {
   return map;
 };
 
-/** Release a stopped recorder's log file handle and drop its registry entry. */
+/**
+ * Release a stopped recorder's log file handle and drop its registry entry.
+ */
 const reapRecorder = async (recorderId) => {
   const handle = runtimeState.getHandle('data-recorders', recorderId);
   if (handle && handle.logger) {
@@ -150,16 +146,17 @@ router.get(
     const { fileName } = req.params;
     const recorderId = getObjectId(fileName.replace('.json', ''));
     stopRecorderById(recorderId)
-      .then(() => recorderStatusMap())
-      .then((status) => {
+      .then((stopped) => recorderStatusMap().then((map) => ({ stopped, map })))
+      .then(({ stopped, map }) => {
         res.send({
           error: null,
           // The response still reports the recorder that was just stopped,
           // with its final state - while the registry itself has dropped it,
-          // so the tracking structures cannot grow over repeated runs.
+          // so the tracking structures cannot grow over repeated runs. Only
+          // a stop that actually happened contributes a snapshot.
           status: {
-            ...status,
-            ...(lastStopped[recorderId] ? { [recorderId]: lastStopped[recorderId] } : {}),
+            ...map,
+            ...(stopped ? { [recorderId]: stopped } : {}),
           },
         });
       })
@@ -169,9 +166,7 @@ router.get(
 
 const snapshotRecorder = (record, endTime) => {
   if (!record) return null;
-  const finalSnapshot = publicRecord({ ...record, isRunning: false, endTime });
-  lastStopped[finalSnapshot.id] = finalSnapshot;
-  return finalSnapshot;
+  return publicRecord({ ...record, isRunning: false, endTime });
 };
 
 /**

--- a/src/server/routes/devops.js
+++ b/src/server/routes/devops.js
@@ -2,16 +2,11 @@
 var express = require('express');
 const Joi = require('joi');
 const { dbConnector, getDataStorage } = require('./db-connector');
-const {
-  startTestCampaign,
-  stopTestCampaign,
-  getTestCampainStatus,
-} = require('../../core/devops-flow');
+const { startTestCampaign } = require('../../core/devops-flow');
 let router = express.Router();
 const devopsFilePath = `${__dirname}/../data/devops.json`;
 let getLogger = require('../logger');
 const { readJSONFile, writeToFile } = require('../../core/utils');
-const { OFFLINE } = require('../../core/DeviceStatus');
 const { isValidName, resolveWithin, sendBadRequest } = require('./path-safety');
 const {
   validate,
@@ -20,14 +15,22 @@ const {
   urlSchema,
   dataStorageSchema,
 } = require('../middleware/validate');
-const { errorHandler, badRequest, internal, unavailable } = require('../middleware/errors');
+const {
+  errorHandler,
+  badRequest,
+  conflict,
+  internal,
+  unavailable,
+} = require('../middleware/errors');
 let logsPath = `${__dirname}/../logs/test-campaigns/`;
-
-let runningStatus = null;
-// The logger of the running test campaign, held here so `/stop` can release
-// the run's file handle once the campaign stops. The logger is passed
-// explicitly to the run; global console methods are never touched.
-let runLogger = null;
+// Running-campaign records and handles live in the shared runtime registry
+// (issue #29): the record persists across restarts and is visible to a second
+// server process on the same store; the live campaign object stays with the
+// process that started it.
+const runtimeState = require('../runtime-state');
+const CAMPAIGN_KIND = 'test-campaigns';
+// The single slot a store tracks campaigns in: one campaign runs at a time.
+const SLOT_ID = 'active';
 
 // ---------------------------------------------------------------------------
 // Validation schemas for the devops endpoints (issue #10)
@@ -51,13 +54,47 @@ const devopsBody = Joi.object({
 }).required();
 
 /**
+ * Strip the registry's bookkeeping fields from a record before it reaches a
+ * response: clients see the run, not which pid owns it.
+ */
+const publicRecord = (record) => {
+  if (!record) return record;
+  const { owner, kind, status, ...rest } = record;
+  void owner;
+  void kind;
+  void status;
+  return rest;
+};
+
+/**
+ * The campaign this store says is running, if any: the persisted record, or
+ * null when nothing is. Orphaned records - whose owner died uncleanly - are
+ * reaped on the way, because nothing can ever stop them again.
+ */
+const runningCampaign = async () => {
+  await runtimeState.reconcile(CAMPAIGN_KIND);
+  const records = await runtimeState.list(CAMPAIGN_KIND);
+  return records.length > 0 ? records[0] : null;
+};
+
+/**
  * Get the running status of test campaign
  */
 router.get('/status', validate(), (req, res, next) => {
-  if (runningStatus) runningStatus.isRunning = getTestCampainStatus() !== OFFLINE;
-  res.send({
-    runningStatus,
-  });
+  runningCampaign()
+    .then((record) => {
+      // The in-memory extras (data storage, webhook) only exist on the
+      // process that started the run; the persisted part is what any
+      // observer can know for sure.
+      const handle = record ? runtimeState.getHandle(CAMPAIGN_KIND, record.id) : null;
+      const composed = record
+        ? { ...publicRecord(record), ...(handle && handle.extra), isRunning: true }
+        : null;
+      res.send({
+        runningStatus: composed,
+      });
+    })
+    .catch(next);
 });
 
 let _devops = null;
@@ -148,75 +185,147 @@ const loadValidatedDevops = (req, res, next) => {
 router.get('/start', validate(), loadValidatedDevops, dbConnector, (req, res, next) => {
   const devops = req.devops;
   const { webhookURL, testCampaignId, dataStorage, evaluationParameters } = devops;
-  const startedTime = Date.now();
-  const logFile = `${testCampaignId}_${startedTime}.log`;
-  // The logger creates missing parent directories, so an escaping filename
-  // would write outside the log root rather than fail. Resolve and contain it.
-  const logFilePath = resolveWithin(logsPath, logFile);
-  if (!logFilePath) {
-    return sendBadRequest(res, 'Invalid test campaign id');
-  }
-  const logger = getLogger('TEST-CAMPAIGN', logFilePath);
-  runLogger = logger;
-  logger.log('[devops] A test campaign is going to be started ...');
 
-  if (dataStorage) {
-    runningStatus = {
-      isRunning: true,
-      testCampaignId,
-      dataStorage,
-      webhookURL,
-      startedTime,
-      endTime: null,
-      logFile,
-    };
-    startTestCampaign(testCampaignId, dataStorage, webhookURL, evaluationParameters, logger);
-    res.send({
-      error: null,
-      devops,
-      runningStatus,
-    });
-  } else {
-    getDataStorage((err, ds) => {
-      if (err) {
-        next(unavailable('Cannot get data storage', err));
-      } else {
-        runningStatus = {
-          isRunning: true,
-          testCampaignId,
-          dataStorage: ds,
-          webhookURL,
-          startedTime,
-          endTime: null,
-          logFile,
-        };
-        startTestCampaign(testCampaignId, ds, webhookURL, evaluationParameters, logger);
-        res.send({
-          error: null,
-          runningStatus,
-        });
-      }
-    });
+  // One campaign runs at a time, and the store is the truth: a campaign this
+  // process or another live process started is a conflict, where the old
+  // module-level variable silently orphaned the previous run. The single slot
+  // is claimed BEFORE anything asynchronous runs, so a second /start arriving
+  // meanwhile sees the reservation instead of racing this one past the check.
+  if (runtimeState.isReserved(CAMPAIGN_KIND, SLOT_ID)) {
+    return next(conflict('A test campaign is already running'));
   }
+  runtimeState.reserve(CAMPAIGN_KIND, SLOT_ID);
+  const releaseSlot = () => runtimeState.releaseReservation(CAMPAIGN_KIND, SLOT_ID);
+
+  function beginStart() {
+    const startedTime = Date.now();
+    const logFile = `${testCampaignId}_${startedTime}.log`;
+    // The logger creates missing parent directories, so an escaping filename
+    // would write outside the log root rather than fail. Resolve and contain it.
+    const logFilePath = resolveWithin(logsPath, logFile);
+    if (!logFilePath) {
+      releaseSlot();
+      return sendBadRequest(res, 'Invalid test campaign id');
+    }
+    const logger = getLogger('TEST-CAMPAIGN', logFilePath);
+    logger.log('[devops] A test campaign is going to be started ...');
+
+    const launch = async (storage, withDevops) => {
+      const record = {
+        id: SLOT_ID,
+        isRunning: true,
+        testCampaignId,
+        startedTime,
+        endTime: null,
+        logFile,
+      };
+      // The run's own logger and live campaign object are held in the registry
+      // alongside the record, so /stop can reach them from this process.
+      const campaign = startTestCampaign(
+        testCampaignId,
+        storage,
+        webhookURL,
+        evaluationParameters,
+        logger
+      );
+      await runtimeState
+        .register(CAMPAIGN_KIND, record, {
+          run: campaign || null,
+          logger,
+          extra: { dataStorage: storage, webhookURL },
+        })
+        // Persistence failures degrade to memory-only tracking; they never
+        // fail a start that itself succeeded.
+        .catch(() => {});
+      // The slot stays claimed until the record is in: releasing first would
+      // reopen exactly the race the reservation exists to close. The start
+      // answer follows the persisted record for the same reason.
+      releaseSlot();
+      res.send({
+        error: null,
+        // The explicit-storage branch has always echoed the configuration
+        // back; the default-storage branch never did.
+        ...(withDevops ? { devops } : {}),
+        runningStatus: { ...record, dataStorage: storage, webhookURL },
+      });
+    };
+
+    if (dataStorage) {
+      launch(dataStorage, true);
+    } else {
+      getDataStorage((err, ds) => {
+        if (err) {
+          releaseSlot();
+          next(unavailable('Cannot get data storage', err));
+        } else {
+          launch(ds, false);
+        }
+      });
+    }
+  }
+
+  runningCampaign()
+    .then((record) => {
+      if (record) {
+        releaseSlot();
+        return next(conflict('A test campaign is already running'));
+      }
+      beginStart();
+    })
+    .catch((err) => {
+      releaseSlot();
+      next(err);
+    });
 });
 
 router.get('/stop', validate(), (req, res, next) => {
-  const copiedStatus = runningStatus;
-  if (runningStatus) {
-    stopTestCampaign();
-    runningStatus = null;
-    copiedStatus.isRunning = false;
-  }
-  if (runLogger) {
-    // The run has stopped: release its log file handle.
-    runLogger.close();
-    runLogger = null;
-  }
-  res.send({
-    error: null,
-    runningStatus: copiedStatus,
-  });
+  stopCampaign()
+    .then((copiedStatus) => {
+      res.send({
+        error: null,
+        runningStatus: copiedStatus,
+      });
+    })
+    .catch(next);
 });
+
+/**
+ * Stop whatever campaign the store says is running, according to who owns it -
+ * the same ownership rules as the simulation and recorder routers. Returns the
+ * final status to report (null when nothing was running).
+ */
+const stopCampaign = async () => {
+  const endTime = Date.now();
+  let records = [];
+  try {
+    records = await runtimeState.list(CAMPAIGN_KIND);
+  } catch (_) {
+    records = [];
+  }
+  const record = records.length > 0 ? records[0] : null;
+  const handle = record ? runtimeState.getHandle(CAMPAIGN_KIND, record.id) : null;
+
+  if (!handle && (!record || !runtimeState.ownerIsAlive(record))) {
+    // Either nothing is running, or what the store still holds belongs to a
+    // process that died uncleanly - reconcile already reaped it on the way in.
+    return null;
+  }
+  if (!handle) {
+    // Another live process's campaign: visible, not stoppable from here.
+    return null;
+  }
+
+  if (handle.run) {
+    handle.run.stop();
+  }
+  if (handle.logger) {
+    // The run has stopped: release its log file handle.
+    handle.logger.close();
+  }
+  await runtimeState.reap(CAMPAIGN_KIND, record.id).catch(() => {});
+  const copiedStatus = { ...publicRecord(record), isRunning: false, endTime };
+  return copiedStatus;
+};
 
 // Attached to the router itself as well as to the application: see the note in
 // `routes/model.js`.

--- a/src/server/routes/devops.js
+++ b/src/server/routes/devops.js
@@ -7,6 +7,7 @@ let router = express.Router();
 const devopsFilePath = `${__dirname}/../data/devops.json`;
 let getLogger = require('../logger');
 const { readJSONFile, writeToFile } = require('../../core/utils');
+const { OFFLINE } = require('../../core/DeviceStatus');
 const { isValidName, resolveWithin, sendBadRequest } = require('./path-safety');
 const {
   validate,
@@ -68,11 +69,20 @@ const publicRecord = (record) => {
 
 /**
  * The campaign this store says is running, if any: the persisted record, or
- * null when nothing is. Orphaned records - whose owner died uncleanly - are
- * reaped on the way, because nothing can ever stop them again.
+ * null when nothing is. Orphaned records - whose owner died uncleanly - and
+ * runs this process owns that finished on their own (a test campaign works
+ * through its cases and stops itself) are reaped on the way, because neither
+ * can ever be stopped again.
  */
 const runningCampaign = async () => {
-  await runtimeState.reconcile(CAMPAIGN_KIND);
+  await runtimeState.reconcile(CAMPAIGN_KIND, (record) => {
+    const handle = runtimeState.getHandle(CAMPAIGN_KIND, record.id);
+    const finished = Boolean(handle && handle.run && handle.run.status === OFFLINE);
+    if (finished && handle.logger) {
+      handle.logger.close();
+    }
+    return finished;
+  });
   const records = await runtimeState.list(CAMPAIGN_KIND);
   return records.length > 0 ? records[0] : null;
 };
@@ -87,8 +97,11 @@ router.get('/status', validate(), (req, res, next) => {
       // process that started the run; the persisted part is what any
       // observer can know for sure.
       const handle = record ? runtimeState.getHandle(CAMPAIGN_KIND, record.id) : null;
+      // A foreign record cannot be probed deeper and is presumed running;
+      // an own record answers from the live campaign's own status.
+      const isRunning = handle && handle.run ? handle.run.status !== OFFLINE : true;
       const composed = record
-        ? { ...publicRecord(record), ...(handle && handle.extra), isRunning: true }
+        ? { ...publicRecord(record), ...(handle && handle.extra), isRunning }
         : null;
       res.send({
         runningStatus: composed,

--- a/src/server/routes/simulation.js
+++ b/src/server/routes/simulation.js
@@ -125,16 +125,18 @@ const publicRecord = (record) => {
  */
 const simulationStatusMap = async () => {
   // A run whose owning handle reports offline has finished on its own - its
-  // devices completed without anyone calling `/stop`; reconcile drops the
-  // record and detaches the handle, so the map only lists work still running.
-  const reaped = await runtimeState.reconcile('simulations', (record) => {
+  // devices completed without anyone calling `/stop`. The predicate closes
+  // the run's log file handle BEFORE reconcile drops the handle entry (after
+  // which it could not be found again), so a naturally finished run leaks no
+  // file descriptor.
+  await runtimeState.reconcile('simulations', (record) => {
     const handle = runtimeState.getHandle('simulations', record.id);
-    return !handle || !handle.run || handle.run.status === OFFLINE;
+    const finished = !handle || !handle.run || handle.run.status === OFFLINE;
+    if (finished && handle && handle.logger) {
+      handle.logger.close();
+    }
+    return finished;
   });
-  for (const record of reaped) {
-    const handle = runtimeState.getHandle('simulations', record.id);
-    if (handle && handle.logger) handle.logger.close();
-  }
   const records = await runtimeState.list('simulations');
   const map = {};
   for (const record of records) {
@@ -298,12 +300,6 @@ router.post('/start', validate({ body: simulationStartBody }), function (req, re
   }
 });
 
-// The final snapshots of runs this instance stopped, held only long enough
-// for the stop response to report them. A later stop of the same id replaces
-// the snapshot, and nothing else ever reads them, so repeated runs cannot
-// grow this table without bound.
-const lastStopped = {};
-
 /**
  * Stop whatever the id refers to, according to who owns it:
  *
@@ -315,8 +311,9 @@ const lastStopped = {};
  *    stays exactly as it is, still reported running;
  *  - an unknown id is answered with the current status, as before.
  *
- * Returns the final snapshot to report, or null when there was nothing here
- * to stop.
+ * Returns the final snapshot to report (null when nothing here was stopped);
+ * the route merges exactly that snapshot into its response, so a run this
+ * process did not stop can never be described as stopped.
  */
 const stopSimulationById = async (simId) => {
   const endTime = Date.now();
@@ -351,9 +348,7 @@ const stopSimulationById = async (simId) => {
 
 const snapshot = (record, endTime) => {
   if (!record) return null;
-  const finalSnapshot = publicRecord({ ...record, isRunning: false, endTime });
-  lastStopped[finalSnapshot.id] = finalSnapshot;
-  return finalSnapshot;
+  return publicRecord({ ...record, isRunning: false, endTime });
 };
 
 router.get(
@@ -363,16 +358,17 @@ router.get(
     const { fileName } = req.params;
     const simId = getObjectId(fileName.replace('.json', ''));
     stopSimulationById(simId)
-      .then(() => simulationStatusMap())
-      .then((simulationStatus) => {
+      .then((stopped) => simulationStatusMap().then((map) => ({ stopped, map })))
+      .then(({ stopped, map }) => {
         res.send({
           error: null,
-          // The response still reports the run that was just stopped, with its
-          // final state - while the registry itself has dropped it, so the
-          // tracking structures cannot grow over repeated runs.
+          // The response still reports the run that was just stopped, with
+          // its final state - while the registry itself has dropped it, so
+          // the tracking structures cannot grow over repeated runs. Only a
+          // stop that actually happened contributes a snapshot.
           simulationStatus: {
-            ...simulationStatus,
-            ...(lastStopped[simId] ? { [simId]: lastStopped[simId] } : {}),
+            ...map,
+            ...(stopped ? { [simId]: stopped } : {}),
           },
         });
       })

--- a/src/server/routes/simulation.js
+++ b/src/server/routes/simulation.js
@@ -28,6 +28,12 @@ const {
 let router = express.Router();
 const logsPath = `${__dirname}/../logs/simulations/`;
 const modelsPath = `${__dirname}/../data/models/`;
+// Every running-run record and in-process handle lives in the shared runtime
+// registry (issue #29) - nothing is tracked in this module's own variables any
+// more. The records are persisted, so they survive a restart and can be seen
+// by a second server process on the same store; the handles cannot, and are
+// only ever present in the process that started the run.
+const runtimeState = require('../runtime-state');
 
 // ---------------------------------------------------------------------------
 // Validation schemas for the simulation endpoints (issue #10)
@@ -84,23 +90,66 @@ null
 }
 ```
  */
-let allSimulationStatus = {};
-let allSimulations = {};
-// The ids whose start is under way. On the default data storage path the run is
-// only registered inside the `getDataStorage` callback, an event-loop turn after
-// the guard below read the registry, so without something held across that turn
-// two concurrent starts of one topology both pass the guard and the first run is
-// left publishing with no handle to stop it. A reservation rather than a
-// placeholder in `allSimulations`: `/stop` calls `stop()` on whatever it finds
-// there.
-const startingSimulations = new Set();
-// The logger of each running simulation, held here so `/stop` can release the
-// run's file handle once the run stops. The logger is passed explicitly to the
-// run; global console methods are never touched.
-const runLoggers = {};
-// Start simulating a model
+/**
+ * Reap a run's leftovers once it has stopped: release its log file handle and
+ * drop the registry entry, so repeated runs cannot grow the tracking state.
+ * Returns the last known record, for the stop response to report.
+ */
+const reapSimulation = async (simId) => {
+  const handle = runtimeState.getHandle('simulations', simId);
+  if (handle && handle.logger) {
+    // The run has stopped: release its log file handle.
+    handle.logger.close();
+  }
+  return runtimeState.reap('simulations', simId);
+};
 
-const startSimulation = (model, options = {}, res, next, modelFileName = null) => {
+/**
+ * Strip the registry's bookkeeping fields from a record before it reaches a
+ * response: clients see the run, not which pid owns it.
+ */
+const publicRecord = (record) => {
+  if (!record) return record;
+  const { owner, kind, status, ...rest } = record;
+  void owner;
+  void kind;
+  void status;
+  return rest;
+};
+
+/**
+ * The status surface the dashboard reads: every record in the shared store,
+ * keyed by run id. Self-finished runs are reaped on the way (their devices
+ * completed without anyone calling `/stop`), so the map only ever describes
+ * work that is still running.
+ */
+const simulationStatusMap = async () => {
+  // A run whose owning handle reports offline has finished on its own - its
+  // devices completed without anyone calling `/stop`; reconcile drops the
+  // record and detaches the handle, so the map only lists work still running.
+  const reaped = await runtimeState.reconcile('simulations', (record) => {
+    const handle = runtimeState.getHandle('simulations', record.id);
+    return !handle || !handle.run || handle.run.status === OFFLINE;
+  });
+  for (const record of reaped) {
+    const handle = runtimeState.getHandle('simulations', record.id);
+    if (handle && handle.logger) handle.logger.close();
+  }
+  const records = await runtimeState.list('simulations');
+  const map = {};
+  for (const record of records) {
+    map[record.id] = publicRecord(record);
+  }
+  return map;
+};
+
+/**
+ * The final snapshot a stopped run leaves behind: the stop response reports
+ * `isRunning: false` with the time it stopped, while the registry itself no
+ * longer holds the entry.
+ */
+
+const startSimulation = async (model, options = {}, res, next, modelFileName = null) => {
   // Check if there is a configuration
   if (!model) {
     return next(badRequest('Cannot simulate a null model'));
@@ -117,73 +166,117 @@ const startSimulation = (model, options = {}, res, next, modelFileName = null) =
   // `Simulation` tracks running-ness as `status`, which `start()` sets
   // synchronously; it has no `isRunning`, so the guard this replaces was never
   // true and a topology could be started twice, orphaning the first run.
+  //
+  // The reservation is claimed BEFORE anything asynchronous runs: two starts
+  // arriving together must not both get past the check. The SHARED store is
+  // read as well, so another server process on the same store running the
+  // topology is a conflict too - the consistent view means neither process
+  // will double-start it. (`startingSimulations` used to be a module-level
+  // Set; the reservation now lives in the registry.)
   if (
-    startingSimulations.has(simId) ||
-    (allSimulations[simId] && allSimulations[simId].status !== OFFLINE)
+    runtimeState.isReserved('simulations', simId) ||
+    (() => {
+      const ownHandle = runtimeState.getHandle('simulations', simId);
+      return Boolean(ownHandle && ownHandle.run && ownHandle.run.status !== OFFLINE);
+    })()
   ) {
     // The topology is already in use: the request cannot be applied to the
     // state the resource is in, which is a conflict rather than a fault.
-    next(
+    return next(
       conflict(
         'A running simulation is using this topology. A topology can be used only in one running simulation'
       )
     );
-  } else {
-    const startedTime = Date.now();
-    const logFile = `${name}_${Date.now()}.log`;
-    const logger = getLogger('SIMULATION', `${logsPath}${logFile}`);
-    runLoggers[simId] = logger;
-    if (!model.dataStorage && !options.dataStorage) {
-      // Use default data storage
-      startingSimulations.add(simId);
-      getDataStorage((err, ds) => {
-        // Released first, so the reservation cannot outlive the start on either
-        // path, nor if registering the run throws.
-        startingSimulations.delete(simId);
-        if (err) {
-          next(unavailable('No data storage', err));
-        } else {
-          const simulation = new Simulation({ ...model, dataStorage: ds }, options, null, logger);
-          simulation.start();
-          allSimulations[simId] = simulation;
-          allSimulationStatus[simId] = {
-            model: model.name,
-            startedTime,
-            logFile,
-            datasetId: simulation.datasetId,
-            newDataset: simulation.newDataset,
-            report: simulation.report,
-            modelFileName,
-            isRunning: true,
-          };
-
-          res.send({
-            model: model,
-            simulationStatus: allSimulationStatus,
-          });
-        }
-      });
-    } else {
-      const simulation = new Simulation(model, options, null, logger);
-      simulation.start();
-      allSimulations[simId] = simulation;
-      allSimulationStatus[simId] = {
-        model: model.name,
-        startedTime,
-        logFile,
-        datasetId: simulation.datasetId,
-        newDataset: simulation.newDataset,
-        report: simulation.report,
-        modelFileName,
-        isRunning: true,
-      };
-
-      res.send({
-        model: model,
-        simulationStatus: allSimulationStatus,
-      });
-    }
   }
+  runtimeState.reserve('simulations', simId);
+  const foreignRecord = await runtimeState
+    .list('simulations')
+    .then((records) => records.some((record) => record.id === simId))
+    .catch(() => false);
+  if (foreignRecord) {
+    runtimeState.releaseReservation('simulations', simId);
+    return next(
+      conflict(
+        'A running simulation is using this topology. A topology can be used only in one running simulation'
+      )
+    );
+  }
+  const startedTime = Date.now();
+  const logFile = `${name}_${Date.now()}.log`;
+  const logger = getLogger('SIMULATION', `${logsPath}${logFile}`);
+  if (!model.dataStorage && !options.dataStorage) {
+    // Use default data storage
+    getDataStorage(async (err, ds) => {
+      // Released first, so the reservation cannot outlive the start on either
+      // path, nor if registering the run throws.
+      runtimeState.releaseReservation('simulations', simId);
+      if (err) {
+        next(unavailable('No data storage', err));
+      } else {
+        const simulation = new Simulation({ ...model, dataStorage: ds }, options, null, logger);
+        simulation.start();
+        // The start answer follows the persisted record: once it has been
+        // sent, any later status read - here or from another process - sees
+        // the run.
+        await registerStarted(simulation, logger, {
+          id: simId,
+          model: model.name,
+          startedTime,
+          logFile,
+          datasetId: simulation.datasetId,
+          newDataset: simulation.newDataset,
+          report: simulation.report,
+          modelFileName,
+          isRunning: true,
+        });
+
+        respondWithStatus(res, { model });
+      }
+    });
+  } else {
+    const simulation = new Simulation(model, options, null, logger);
+    simulation.start();
+    // The start answer follows the persisted record: once it has been sent,
+    // any later status read - here or from another process - sees the run.
+    await registerStarted(simulation, logger, {
+      id: simId,
+      model: model.name,
+      startedTime,
+      logFile,
+      datasetId: simulation.datasetId,
+      newDataset: simulation.newDataset,
+      report: simulation.report,
+      modelFileName,
+      isRunning: true,
+    });
+    // The handle table now answers the guard for this topology.
+    runtimeState.releaseReservation('simulations', simId);
+
+    respondWithStatus(res, { model });
+  }
+};
+
+/**
+ * Pair a freshly started run with its persisted record: the record goes to the
+ * shared store (visible after restarts and to other processes), the live
+ * object and its logger stay with this process so `/stop` can reach them.
+ */
+const registerStarted = (simulation, logger, record) =>
+  // Persistence failures degrade to memory-only tracking (warned once inside
+  // the registry); they never fail a start that itself succeeded.
+  runtimeState.register('simulations', record, { run: simulation, logger }).catch(() => {});
+
+/**
+ * Answer with the current status map, whatever the endpoint otherwise returns.
+ */
+const respondWithStatus = (res, extra = {}) => {
+  simulationStatusMap()
+    .then((simulationStatus) => {
+      res.send({ ...extra, simulationStatus });
+    })
+    .catch(() => {
+      res.send({ ...extra, simulationStatus: {} });
+    });
 };
 
 router.post('/start', validate({ body: simulationStartBody }), function (req, res, next) {
@@ -197,13 +290,71 @@ router.post('/start', validate({ body: simulationStartBody }), function (req, re
       if (err) {
         next(fileError(err, 'Model not found', 'Cannot read the model file'));
       } else {
-        startSimulation(myModel, options, res, next, modelFileName);
+        startSimulation(myModel, options, res, next, modelFileName).catch(next);
       }
     });
   } else {
-    startSimulation(model, options, res, next);
+    startSimulation(model, options, res, next).catch(next);
   }
 });
+
+// The final snapshots of runs this instance stopped, held only long enough
+// for the stop response to report them. A later stop of the same id replaces
+// the snapshot, and nothing else ever reads them, so repeated runs cannot
+// grow this table without bound.
+const lastStopped = {};
+
+/**
+ * Stop whatever the id refers to, according to who owns it:
+ *
+ *  - a run this process owns is stopped for real (its handle is called) and
+ *    reaped from the registry;
+ *  - a record whose owner is gone - work orphaned by an unclean shutdown - is
+ *    reaped, which is how a restart cleans up what it can no longer stop;
+ *  - a run another live process owns cannot be stopped from here: its record
+ *    stays exactly as it is, still reported running;
+ *  - an unknown id is answered with the current status, as before.
+ *
+ * Returns the final snapshot to report, or null when there was nothing here
+ * to stop.
+ */
+const stopSimulationById = async (simId) => {
+  const endTime = Date.now();
+  const handle = runtimeState.getHandle('simulations', simId);
+  let records = [];
+  try {
+    records = await runtimeState.list('simulations');
+  } catch (_) {
+    records = [];
+  }
+  const record = records.find((entry) => entry.id === simId) || null;
+
+  if (handle) {
+    // This process owns the run: stop it for real and take its entry out of
+    // the registry.
+    if (handle.run) {
+      handle.run.stop();
+    }
+    const stopped = await reapSimulation(simId);
+    return snapshot(stopped || record, endTime);
+  }
+  if (record && !runtimeState.ownerIsAlive(record)) {
+    // Work orphaned by an unclean shutdown: nothing can ever stop it again,
+    // so stopping means reaping what it left behind.
+    const stopped = await runtimeState.reap('simulations', simId);
+    return snapshot(stopped || record, endTime);
+  }
+  // Someone else's live run, or an id nothing is tracking: visible through
+  // the status map at most, never stoppable from this process.
+  return null;
+};
+
+const snapshot = (record, endTime) => {
+  if (!record) return null;
+  const finalSnapshot = publicRecord({ ...record, isRunning: false, endTime });
+  lastStopped[finalSnapshot.id] = finalSnapshot;
+  return finalSnapshot;
+};
 
 router.get(
   '/stop/:fileName',
@@ -211,51 +362,47 @@ router.get(
   function (req, res, next) {
     const { fileName } = req.params;
     const simId = getObjectId(fileName.replace('.json', ''));
-    if (allSimulations[simId]) {
-      allSimulations[simId].stop();
-      allSimulations[simId] = null;
-    }
-    if (runLoggers[simId]) {
-      // The run has stopped: release its log file handle.
-      runLoggers[simId].close();
-      delete runLoggers[simId];
-    }
-    if (allSimulationStatus[simId]) {
-      allSimulationStatus[simId].isRunning = false;
-      allSimulationStatus[simId].endTime = Date.now();
-    }
-    res.send({
-      error: null,
-      simulationStatus: allSimulationStatus,
-    });
+    stopSimulationById(simId)
+      .then(() => simulationStatusMap())
+      .then((simulationStatus) => {
+        res.send({
+          error: null,
+          // The response still reports the run that was just stopped, with its
+          // final state - while the registry itself has dropped it, so the
+          // tracking structures cannot grow over repeated runs.
+          simulationStatus: {
+            ...simulationStatus,
+            ...(lastStopped[simId] ? { [simId]: lastStopped[simId] } : {}),
+          },
+        });
+      })
+      .catch(next);
   }
 );
 
 router.get('/status', validate(), (req, res, next) => {
-  const keys = Object.keys(allSimulationStatus);
-  for (let index = 0; index < keys.length; index++) {
-    const key = keys[index];
-    if (allSimulations[key]) {
-      allSimulationStatus[key].isRunning = allSimulations[key].status !== OFFLINE;
-    }
-  }
-  res.send({
-    simulationStatus: allSimulationStatus,
-  });
+  simulationStatusMap()
+    .then((simulationStatus) => {
+      res.send({
+        simulationStatus,
+      });
+    })
+    .catch(next);
 });
 
 router.get('/stats', validate(), (req, res, next) => {
-  // Read from the registry the rest of this router keeps. It used to read a
-  // `simulation` binding that is never assigned, so every call threw a
-  // ReferenceError and was answered with a stack trace. With more than one run
-  // in progress this reports the first of them, which is as much as the
-  // single-valued response shape can say.
-  const running = Object.keys(allSimulations)
-    .map((simId) => allSimulations[simId])
-    .find((simulation) => simulation && simulation.status !== OFFLINE);
+  // Read from the shared registry. It used to read a `simulation` binding that
+  // is never assigned, so every call threw a ReferenceError and was answered
+  // with a stack trace. With more than one run in progress this reports the
+  // first of them, which is as much as the single-valued response shape can
+  // say; runs owned by another process have no handle here and report null.
+  const running = runtimeState
+    .ownHandles('simulations')
+    .map(({ handle }) => handle)
+    .find((handle) => handle && handle.run && handle.run.status !== OFFLINE);
   res.send({
     error: null,
-    stats: running ? running.getStats() : null,
+    stats: running ? running.run.getStats() : null,
   });
 });
 

--- a/src/server/runtime-state/index.js
+++ b/src/server/runtime-state/index.js
@@ -1,0 +1,397 @@
+'use strict';
+/**
+ * The runtime-state registry (issue #29).
+ *
+ * Which simulations, data recorders and test campaigns are running used to
+ * live in module-level variables scattered across three route files. That
+ * design lost every trace of running work on restart, kept stopped entries
+ * around as placeholders that grew without bound, and assumed a single server
+ * process forever.
+ *
+ * This module is now the ONE place that state lives. It owns two things:
+ *
+ *  - the run RECORDS, persisted to a JSON file so they survive a restart and
+ *    can be observed by more than one server process sharing the same store;
+ *  - the in-process HANDLES (the Simulation/DataRecorder/TestCampaign
+ *    instances, their run loggers and start reservations), which cannot
+ *    survive a process by nature and which only the owning process can call.
+ *
+ * Persistence is deliberately a JSON file rather than the database: the data
+ * layer is configured lazily per request (#18) and may not exist yet when the
+ * first run starts, and a dashboard asking "what is running" must be answerable
+ * even when the database is down. The file is written atomically (temporary
+ * file + rename) under an advisory lock file, so two processes mutating the
+ * same store cannot clobber each other's entries. When the store cannot be
+ * written the registry says so once and keeps working from memory - restart
+ * survival is lost, the API is not.
+ */
+
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+
+const DEFAULT_STORE_PATH = path.join(__dirname, '..', 'data', 'runtime-state.json');
+const LOCK_RETRY_MS = 25;
+const LOCK_TIMEOUT_MS = 5000;
+const LOCK_STALE_MS = 10000;
+
+// Kinds are the namespaces one shared store holds. Everything the routes track
+// is listed here; an unknown kind is a programming error, not runtime data.
+const KINDS = ['simulations', 'data-recorders', 'test-campaigns'];
+
+let warnedStoreUnavailable = false;
+
+/**
+ * A stable identity for this process boot. A restarted server typically gets
+ * a fresh pid that a stale record's pid may collide with, so liveness is
+ * decided by the pair: a record whose owner pid equals ours but whose boot id
+ * differs belonged to a predecessor and is not alive.
+ */
+const BOOT_ID = crypto.randomUUID();
+const HOST_ID = os.hostname();
+
+const storePath = () => process.env.TAS_RUNTIME_STATE_PATH || DEFAULT_STORE_PATH;
+const lockPath = () => `${storePath()}.lock`;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Read the whole store. A missing file is an empty registry; an unparsable one
+ * is quarantined (renamed beside the original) rather than trusted or deleted,
+ * so what went wrong stays inspectable.
+ */
+async function readStore() {
+  let raw;
+  try {
+    raw = await fsp.readFile(storePath(), 'utf8');
+  } catch (err) {
+    if (err.code === 'ENOENT') return {};
+    throw err;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch (_) {
+    const quarantine = `${storePath()}.corrupt-${Date.now()}`;
+    console.error(`[RUNTIME-STATE] Store is unparsable - quarantined to ${quarantine}`);
+    try {
+      await fsp.rename(storePath(), quarantine);
+    } catch (_) {
+      /* unreadable AND unmovable: start fresh rather than refuse to serve */
+    }
+    return {};
+  }
+}
+
+/** Write the whole store atomically: temporary file in the same directory, then rename. */
+async function writeStore(records) {
+  const target = storePath();
+  await fs.promises.mkdir(path.dirname(target), { recursive: true });
+  const tmp = `${target}.${process.pid}.${Date.now()}.tmp`;
+  await fsp.writeFile(tmp, JSON.stringify(records, null, 2));
+  // The rename is atomic on POSIX: a concurrent reader sees either the old
+  // file or the new one, never a half-written one.
+  await fsp.rename(tmp, target);
+}
+
+/**
+ * Run `mutate(records)` while holding the store's advisory lock.
+ *
+ * The lock is an O_EXCL create, retried until the timeout; a lock left behind
+ * by a crashed process is stolen once it is older than LOCK_STALE_MS. On
+ * timeout the mutation runs WITHOUT the lock rather than failing the request -
+ * single-process correctness does not depend on it, and losing an occasional
+ * cross-process update beats refusing to start work.
+ */
+async function withStoreLock(mutate) {
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  let fd = null;
+  while (fd === null) {
+    try {
+      fd = await fsp.open(lockPath(), 'wx');
+    } catch (err) {
+      if (err.code !== 'EEXIST') break;
+      if (Date.now() > deadline) break;
+      try {
+        const stat = await fsp.stat(lockPath());
+        if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+          // Nobody holding a healthy lock keeps it this long; the holder died.
+          await fsp.unlink(lockPath()).catch(() => {});
+        }
+      } catch (_) {
+        /* vanished already - just retry */
+      }
+      await sleep(LOCK_RETRY_MS);
+    }
+  }
+  try {
+    const records = await readStore();
+    const next = await mutate(records);
+    if (next !== undefined) await writeStore(next);
+    return next;
+  } finally {
+    if (fd !== null) {
+      await fd.close().catch(() => {});
+      await fsp.unlink(lockPath()).catch(() => {});
+    }
+  }
+}
+
+/** Report - exactly once per process - that persistence degraded to memory-only. */
+function warnStoreUnavailable(err) {
+  if (warnedStoreUnavailable) return;
+  warnedStoreUnavailable = true;
+  console.error(
+    `[RUNTIME-STATE] Persisting run state to ${storePath()} failed (${
+      err && err.message ? err.message : err
+    }) - continuing from memory only; running-work tracking will not survive a restart`
+  );
+}
+
+/**
+ * Is the process that owns a record still alive on this host?
+ *
+ * A foreign-host owner cannot be probed and is presumed alive (its record is
+ * served as the view of what is running); everything else is answered by
+ * signalling the pid, with the boot id catching pid reuse by a restarted
+ * server.
+ */
+function ownerIsAlive(record) {
+  const owner = record.owner || {};
+  if (owner.host !== HOST_ID) return true;
+  if (owner.pid === process.pid && owner.boot === BOOT_ID) return true;
+  if (owner.pid === process.pid && owner.boot !== BOOT_ID) return false;
+  try {
+    process.kill(owner.pid, 0);
+    return true;
+  } catch (err) {
+    return err.code === 'EPERM';
+  }
+}
+
+/**
+ * The handles only the owning process can use. Keyed `kind:id`, always paired
+ * with a persisted record, and never exported beyond this module's own API.
+ */
+const handles = new Map();
+/** Ids whose start is under way: released inside the storage callback, so two concurrent starts of one topology cannot both pass the guard. */
+const reservations = new Map();
+KINDS.forEach((kind) => reservations.set(kind, new Set()));
+
+const handleKey = (kind, id) => `${kind}:${id}`;
+
+module.exports = {
+  KINDS,
+  BOOT_ID,
+  HOST_ID,
+  ownerIsAlive,
+
+  /**
+   * Persist a new running record and remember its in-process handle.
+   * @param {String} kind One of KINDS
+   * @param {Object} record The record as the status surface reports it
+   * @param {Object} [handle] The live run object / logger bundle, owning process only
+   */
+  async register(kind, record, handle) {
+    const owned = {
+      ...record,
+      kind,
+      status: 'running',
+      owner: { pid: process.pid, boot: BOOT_ID, host: HOST_ID },
+    };
+    handles.set(handleKey(kind, record.id), { handle: handle || null, record: owned });
+    try {
+      await withStoreLock(async (records) => {
+        records[kind] = records[kind] || {};
+        records[kind][record.id] = owned;
+        return records;
+      });
+    } catch (err) {
+      warnStoreUnavailable(err);
+    }
+    return owned;
+  },
+
+  /**
+   * Reserve a starting slot so the asynchronous default-storage path cannot
+   * double-start one topology. Purely in-process by nature.
+   */
+  reserve(kind, id) {
+    reservations.get(kind).add(id);
+  },
+  releaseReservation(kind, id) {
+    reservations.get(kind).delete(id);
+  },
+  isReserved(kind, id) {
+    return reservations.get(kind).has(id);
+  },
+
+  /** The live handle for an id, when this process owns the run. */
+  getHandle(kind, id) {
+    const entry = handles.get(handleKey(kind, id));
+    return entry ? entry.handle : null;
+  },
+
+  /**
+   * Every handle this process holds for a kind, as `{ id, handle }`. Only the
+   * owning process has handles: a run another server process started is
+   * visible through `list()` but has nothing to enumerate here.
+   */
+  ownHandles(kind) {
+    const found = [];
+    const prefix = `${kind}:`;
+    for (const [key, entry] of handles.entries()) {
+      if (key.startsWith(prefix)) {
+        found.push({ id: key.slice(prefix.length), handle: entry.handle });
+      }
+    }
+    return found;
+  },
+
+  /** The record this process registered for an id, if any. */
+  getOwnRecord(kind, id) {
+    const entry = handles.get(handleKey(kind, id));
+    return entry ? entry.record : null;
+  },
+
+  /**
+   * Every persisted record of a kind, read fresh from the shared store so a
+   * second server process's registrations are visible here too.
+   */
+  async list(kind) {
+    try {
+      const records = await readStore();
+      return Object.values(records[kind] || {});
+    } catch (err) {
+      warnStoreUnavailable(err);
+      // Fall back to what this process knows it started.
+      return [...handles.values()]
+        .map((entry) => entry.record)
+        .filter((record) => record.kind === kind);
+    }
+  },
+
+  /**
+   * Remove a record everywhere: from the shared store (so the registry does
+   * not grow with stopped entries) and from this process's handle table.
+   * Returns the last known record so the caller can report the final state.
+   */
+  async reap(kind, id) {
+    const entry = handles.get(handleKey(kind, id));
+    handles.delete(handleKey(kind, id));
+    let removed = entry ? entry.record : null;
+    try {
+      await withStoreLock(async (records) => {
+        if (records[kind] && records[kind][id]) {
+          removed = records[kind][id];
+          delete records[kind][id];
+          return records;
+        }
+        // Nothing to remove: leave the store untouched on disk.
+        return undefined;
+      });
+    } catch (err) {
+      warnStoreUnavailable(err);
+    }
+    return removed;
+  },
+
+  /**
+   * Reconcile the store with reality, called at boot and on each status poll:
+   *
+   *  - a record owned by a process that is gone is work orphaned by an
+   *    unclean shutdown: it is reported (logged with its owner and start time,
+   *    so the incident is detectable) and then reaped, because nothing can
+   *    ever stop it again;
+   *  - a record this process owns whose handle has finished on its own (a
+   *    simulation whose devices all completed) is reaped the same way - the
+   *    run ended, only the record was left.
+   *
+   * Records owned by other live processes are left alone: this process can
+   * observe them but has no handle to stop them with.
+   *
+   * @param {String} kind One of KINDS
+   * @param {Function} [isFinished] Predicate over a record, for handles this
+   *   process owns; a true result reaps the record
+   * @returns {Array} Every record the reconciliation removed - orphans and
+   *   self-finished runs alike - so the caller can release their loggers
+   */
+  async reconcile(kind, isFinished) {
+    const reaped = [];
+    let changed = false;
+    await withStoreLock(async (records) => {
+      const mine = records[kind] || {};
+      for (const id of Object.keys(mine)) {
+        const record = mine[id];
+        const isOwn =
+          record.owner && record.owner.pid === process.pid && record.owner.boot === BOOT_ID;
+        if (!ownerIsAlive(record)) {
+          reaped.push({ ...record, orphaned: true });
+          delete mine[id];
+          changed = true;
+          continue;
+        }
+        if (isOwn && typeof isFinished === 'function' && isFinished(record)) {
+          reaped.push(record);
+          delete mine[id];
+          changed = true;
+        }
+      }
+      // Nothing changed means nothing to persist: skipping the write keeps a
+      // status poll from touching the disk on every dashboard refresh.
+      return changed ? { ...records, [kind]: mine } : undefined;
+    }).catch((err) => warnStoreUnavailable(err));
+    for (const record of reaped) {
+      if (record.orphaned) {
+        console.error(
+          `[RUNTIME-STATE] Orphaned ${kind} run "${record.name || record.id}" (owner pid ${
+            record.owner && record.owner.pid
+          }, started ${new Date(
+            record.startedTime
+          ).toISOString()}) was interrupted by an unclean shutdown - cleaning up`
+        );
+      }
+      handles.delete(handleKey(kind, record.id));
+    }
+    return reaped;
+  },
+
+  /** Reconcile every kind. Used at boot, where no handle can be self-finished yet. */
+  async reconcileAll() {
+    const reaped = [];
+    for (const kind of KINDS) {
+      reaped.push(...(await module.exports.reconcile(kind)));
+    }
+    return reaped;
+  },
+
+  /**
+   * Drop every record this process owns. Called on the graceful-shutdown path,
+   * where the process takes its runs down with it deliberately: a clean
+   * restart must not report ghosts, and what remains after an UNclean death
+   * is exactly the orphan case reconcile knows how to clean.
+   */
+  async deregisterOwned() {
+    const ownIds = [];
+    for (const [key, entry] of handles.entries()) {
+      if (entry.record.owner && entry.record.owner.boot === BOOT_ID) {
+        // The kind prefix never contains the separator; the id may.
+        const separator = key.indexOf(':');
+        ownIds.push([key.slice(0, separator), key.slice(separator + 1)]);
+      }
+    }
+    await withStoreLock(async (records) => {
+      let changed = false;
+      for (const [kind, id] of ownIds) {
+        if (records[kind] && records[kind][id]) {
+          delete records[kind][id];
+          changed = true;
+        }
+      }
+      return changed ? records : undefined;
+    }).catch((err) => warnStoreUnavailable(err));
+    handles.clear();
+  },
+};

--- a/test/e2e/runtime-state-restart.test.js
+++ b/test/e2e/runtime-state-restart.test.js
@@ -1,0 +1,207 @@
+/**
+ * Restart and multi-process behaviour of the runtime-state registry (issue #29).
+ *
+ * These tests drive REAL, separately spawned server instances over HTTP and
+ * assert what cannot be proven by inspection: running work is recorded
+ * outside process memory, so a restart reports the true running state and
+ * work orphaned by an unclean shutdown is detected and cleaned up; two
+ * processes sharing one store observe the same view of what is running.
+ *
+ * Nothing here needs a broker or a database: every run declares no devices
+ * and an explicit (never-contacted) data storage, so registration takes the
+ * synchronous path.
+ */
+const { test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { startServer, request, unique } = require('./helpers');
+
+/** A ceiling high enough that no test in this file trips the limiter. */
+const NO_RATE_LIMIT = '100000';
+
+/** A schema-valid data-storage configuration that is never contacted. */
+const storageConfig = () => ({
+  protocol: 'MONGODB',
+  connConfig: {
+    host: '127.0.0.1',
+    port: 1,
+    username: null,
+    password: null,
+    dbname: null,
+    options: null,
+  },
+});
+
+const emptyModel = (name) => ({ name, devices: [] });
+
+let storeDir;
+
+before(() => {
+  storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tas-runtime-e2e-'));
+});
+
+after(() => {
+  fs.rmSync(storeDir, { recursive: true, force: true });
+});
+
+const startOnStore = (fileName) =>
+  startServer({
+    RATE_LIMIT_MAX: NO_RATE_LIMIT,
+    TAS_RUNTIME_STATE_PATH: path.join(storeDir, fileName),
+  });
+
+test('a run survives its recording across a clean restart - as nothing running', async (t) => {
+  const fileName = `${unique('clean-restart')}.json`;
+  const first = await startOnStore(fileName);
+  const name = unique('clean-run');
+  try {
+    const started = await request(first.baseUrl, 'POST', '/api/simulation/start', {
+      body: { model: emptyModel(name), options: { dataStorage: storageConfig() } },
+    });
+    assert.equal(started.status, 200, `the run must start (${started.raw})`);
+
+    // A graceful stop of the SERVER deliberately takes its runs down with it:
+    // the registry drops them on the way out.
+    await first.stop();
+
+    const second = await startOnStore(fileName);
+    try {
+      const status = await request(second.baseUrl, 'GET', '/api/simulation/status');
+      assert.equal(status.status, 200, `status must be served (${status.raw})`);
+      const entries = Object.values(status.body.simulationStatus || {});
+      assert.deepEqual(
+        entries.filter((entry) => entry.model === name),
+        [],
+        `a clean restart must report no ghosts: ${status.raw}`
+      );
+
+      // Stopping still works after the restart: an id from before it is a
+      // harmless no-op answered with the current status.
+      const stopped = await request(
+        second.baseUrl,
+        'GET',
+        `/api/simulation/stop/${encodeURIComponent(name)}.json`
+      );
+      assert.equal(stopped.status, 200, `stop must still answer after restart (${stopped.raw})`);
+    } finally {
+      await second.stop();
+    }
+  } finally {
+    if (first.child.exitCode === null) await first.stop();
+  }
+});
+
+test('work orphaned by an unclean shutdown is cleaned up by the next boot', async (t) => {
+  const fileName = `${unique('unclean-restart')}.json`;
+  const first = await startOnStore(fileName);
+  const name = unique('orphaned-run');
+  const started = await request(first.baseUrl, 'POST', '/api/simulation/start', {
+    body: { model: emptyModel(name), options: { dataStorage: storageConfig() } },
+  });
+  assert.equal(started.status, 200, `the run must start (${started.raw})`);
+
+  // Unclean death: no graceful shutdown runs, so the record stays behind.
+  first.child.kill('SIGKILL');
+  await new Promise((resolve) => {
+    if (first.child.exitCode !== null) return resolve();
+    first.child.once('exit', resolve);
+  });
+
+  const second = await startOnStore(fileName);
+  try {
+    const status = await request(second.baseUrl, 'GET', '/api/simulation/status');
+    assert.equal(status.status, 200, `status must be served (${status.raw})`);
+    const entries = Object.values(status.body.simulationStatus || {}).filter(
+      (entry) => entry.model === name
+    );
+    assert.deepEqual(
+      entries,
+      [],
+      `the orphaned run must not be reported as running: ${status.raw}`
+    );
+  } finally {
+    await second.stop();
+  }
+});
+
+test('two processes sharing a store observe one consistent view', async (t) => {
+  const fileName = `${unique('shared-view')}.json`;
+  const alpha = await startOnStore(fileName);
+  const beta = await startOnStore(fileName);
+  const name = unique('shared-run');
+  try {
+    const started = await request(alpha.baseUrl, 'POST', '/api/simulation/start', {
+      body: { model: emptyModel(name), options: { dataStorage: storageConfig() } },
+    });
+    assert.equal(started.status, 200, `the run must start on the first process (${started.raw})`);
+
+    // The second process SEES the first's run...
+    const seenByBeta = await request(beta.baseUrl, 'GET', '/api/simulation/status');
+    const entry = Object.values(seenByBeta.body.simulationStatus || {}).find(
+      (candidate) => candidate.model === name
+    );
+    assert.ok(entry, `the other process must observe the run: ${seenByBeta.raw}`);
+    assert.equal(entry.isRunning, true, 'observed as running');
+
+    // ...and the same topology is refused there while the first process has it.
+    const doubleStart = await request(beta.baseUrl, 'POST', '/api/simulation/start', {
+      body: { model: emptyModel(name), options: { dataStorage: storageConfig() } },
+    });
+    assert.equal(
+      doubleStart.status,
+      409,
+      `a topology in use is a conflict everywhere (${doubleStart.raw})`
+    );
+
+    // When the owning process stops the run, the observer stops seeing it.
+    const stopped = await request(
+      alpha.baseUrl,
+      'GET',
+      `/api/simulation/stop/${encodeURIComponent(name)}.json`
+    );
+    assert.equal(stopped.status, 200, `the owner must stop its run (${stopped.raw})`);
+
+    const afterStop = await request(beta.baseUrl, 'GET', '/api/simulation/status');
+    const ghosts = Object.values(afterStop.body.simulationStatus || {}).filter(
+      (candidate) => candidate.model === name
+    );
+    assert.deepEqual(ghosts, [], `the stop must be visible to the other process: ${afterStop.raw}`);
+  } finally {
+    await alpha.stop();
+    await beta.stop();
+  }
+});
+
+test('repeated start-stop cycles leave the persisted registry empty', async (t) => {
+  const fileName = `${unique('reaping')}.json`;
+  const server = await startOnStore(fileName);
+  const names = [];
+  try {
+    for (let cycle = 0; cycle < 3; cycle++) {
+      const name = unique(`reap-cycle-${cycle}`);
+      names.push(name);
+      const started = await request(server.baseUrl, 'POST', '/api/simulation/start', {
+        body: { model: emptyModel(name), options: { dataStorage: storageConfig() } },
+      });
+      assert.equal(started.status, 200, `cycle ${cycle} must start (${started.raw})`);
+      const stopped = await request(
+        server.baseUrl,
+        'GET',
+        `/api/simulation/stop/${encodeURIComponent(name)}.json`
+      );
+      assert.equal(stopped.status, 200, `cycle ${cycle} must stop (${stopped.raw})`);
+    }
+
+    const raw = JSON.parse(fs.readFileSync(path.join(storeDir, fileName), 'utf8'));
+    const held = Object.keys(raw.simulations || {});
+    assert.deepEqual(held, [], `stopped entries are reaped, none accumulate: ${raw.simulations}`);
+  } finally {
+    for (const name of names) {
+      await request(server.baseUrl, 'GET', `/api/simulation/stop/${encodeURIComponent(name)}.json`);
+    }
+    await server.stop();
+  }
+});

--- a/test/http-status.test.js
+++ b/test/http-status.test.js
@@ -51,7 +51,14 @@ let server;
 let app;
 let originalDevops;
 
+// Issue #29: run state persists in a JSON store that real servers share.
+// This suite mounts the routers in-process, so it pins its own empty store -
+// otherwise records left by another suite's process (or an earlier run of
+// this one) could bleed into what these assertions see.
+const runtimeStorePath = path.join(__dirname, `.runtime-state-${process.pid}.json`);
+
 before(() => {
+  process.env.TAS_RUNTIME_STATE_PATH = runtimeStorePath;
   // One test below makes the devops configuration unreadable on purpose.
   originalDevops = fs.readFileSync(devopsFile, 'utf8');
   // Nothing under src/server/logs is tracked, so on a fresh checkout the
@@ -77,6 +84,9 @@ before(() => {
 });
 
 after(() => {
+  delete process.env.TAS_RUNTIME_STATE_PATH;
+  fs.rmSync(runtimeStorePath, { force: true });
+  fs.rmSync(`${runtimeStorePath}.lock`, { force: true });
   server.close();
   if (originalDevops !== undefined) fs.writeFileSync(devopsFile, originalDevops);
 });

--- a/test/runtime-state-registry.test.js
+++ b/test/runtime-state-registry.test.js
@@ -1,0 +1,231 @@
+// Runtime-state registry unit tests (issue #29).
+//
+// The registry is the single home of what-is-running tracking: records are
+// persisted to a JSON store so they survive a restart and can be observed by
+// a second server process on the same store, while the live handles stay with
+// the owning process. These tests exercise that contract directly - no HTTP,
+// no database. Every test pins its own store path, because the module reads
+// TAS_RUNTIME_STATE_PATH per call.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const runtimeState = require('../src/server/runtime-state');
+
+/** A fresh throwaway store path per test, so no test sees another's records. */
+const useStore = (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tas-runtime-'));
+  const storePath = path.join(dir, 'runtime-state.json');
+  process.env.TAS_RUNTIME_STATE_PATH = storePath;
+  t.after(() => {
+    delete process.env.TAS_RUNTIME_STATE_PATH;
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+  return storePath;
+};
+
+/** Spawn a short-lived child and resolve once it has exited, with its pid. */
+const exitedChildPid = () =>
+  new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['-e', 'process.exit(0)']);
+    child.on('exit', () => resolve(child.pid));
+    child.on('error', reject);
+  });
+
+/** A child that stays alive for the duration of a test, killed afterwards. */
+const liveChildPid = (t) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 15000)']);
+    t.after(() => child.kill('SIGKILL'));
+    child.on('error', reject);
+    // Give the child a moment to actually exist before probing it.
+    setTimeout(() => resolve(child.pid), 300);
+  });
+
+test('a registered run is persisted with its owner stamps and listed back', async (t) => {
+  const storePath = useStore(t);
+  await runtimeState.register('simulations', { id: 'abc', model: 'm', startedTime: 1 });
+  const listed = await runtimeState.list('simulations');
+  assert.equal(listed.length, 1);
+  assert.equal(listed[0].id, 'abc');
+  assert.equal(listed[0].kind, 'simulations');
+  assert.equal(listed[0].status, 'running');
+  assert.equal(listed[0].owner.pid, process.pid);
+  assert.equal(listed[0].owner.boot, runtimeState.BOOT_ID);
+
+  // The record reached DISK, which is what another instance reads:
+  const raw = JSON.parse(fs.readFileSync(storePath, 'utf8'));
+  assert.equal(raw.simulations.abc.model, 'm');
+});
+
+test('reap removes the record everywhere and returns the last known state', async (t) => {
+  const storePath = useStore(t);
+  await runtimeState.register('data-recorders', { id: 'rec', model: 'r', startedTime: 2 });
+  const removed = await runtimeState.reap('data-recorders', 'rec');
+  assert.equal(removed.id, 'rec');
+
+  assert.deepEqual(await runtimeState.list('data-recorders'), []);
+  const raw = JSON.parse(fs.readFileSync(storePath, 'utf8'));
+  assert.ok(!raw['data-recorders'] || !raw['data-recorders'].rec, 'the store no longer holds it');
+
+  // Reaping something unknown answers null and leaves no churn behind.
+  const nothing = await runtimeState.reap('data-recorders', 'never-was');
+  assert.equal(nothing, null);
+});
+
+test('an entry survives in the store for a restarted reader - liveness decides', async (t) => {
+  useStore(t);
+  // What a previous process left behind looks exactly like this: same pid
+  // space after a restart is even possible, but the boot id differs.
+  const previous = {
+    id: 'ghost',
+    kind: 'simulations',
+    status: 'running',
+    model: 'from-a-dead-process',
+    startedTime: Date.now() - 1000,
+    owner: { pid: process.pid, boot: 'a-boot-that-no-longer-exists', host: os.hostname() },
+  };
+  await runtimeState.register('simulations', previous);
+
+  // register overwrote owner with THIS boot; rewrite it as the predecessor's.
+  const raw = JSON.parse(fs.readFileSync(process.env.TAS_RUNTIME_STATE_PATH, 'utf8'));
+  raw.simulations.ghost.owner.boot = 'a-boot-that-no-longer-exists';
+  raw.simulations.ghost.owner.pid = 999999;
+  fs.writeFileSync(process.env.TAS_RUNTIME_STATE_PATH, JSON.stringify(raw));
+
+  const reaped = await runtimeState.reconcile('simulations');
+  assert.equal(reaped.length, 1, 'the orphan is reported back to the caller');
+  assert.equal(reaped[0].orphaned, true);
+  assert.deepEqual(await runtimeState.list('simulations'), [], 'and then cleaned up');
+});
+
+test("another live process's record is kept; a dead one's is reaped", async (t) => {
+  const storePath = useStore(t);
+  const livePid = await liveChildPid(t);
+  const deadPid = await exitedChildPid();
+
+  // Seed the store directly: these records were written by OTHER processes,
+  // so their owner stamps are theirs, not ours.
+  const seed = (id, pid) => ({
+    id,
+    kind: 'simulations',
+    status: 'running',
+    model: id,
+    startedTime: Date.now(),
+    owner: { pid, boot: 'some-other-boot', host: os.hostname() },
+  });
+  fs.writeFileSync(
+    storePath,
+    JSON.stringify({
+      simulations: {
+        'alive-elsewhere': seed('alive-elsewhere', livePid),
+        'dead-elsewhere': seed('dead-elsewhere', deadPid),
+      },
+    })
+  );
+
+  const reaped = await runtimeState.reconcile('simulations');
+  assert.deepEqual(
+    reaped.map((record) => record.id),
+    ['dead-elsewhere'],
+    'only the dead owner is reaped'
+  );
+  const remaining = await runtimeState.list('simulations');
+  assert.deepEqual(
+    remaining.map((record) => record.id),
+    ['alive-elsewhere'],
+    'the live neighbour is still visible'
+  );
+});
+
+test('a foreign-host record is presumed alive (it cannot be probed)', async (t) => {
+  useStore(t);
+  await runtimeState.register('simulations', {
+    id: 'remote',
+    kind: 'simulations',
+    status: 'running',
+    model: 'remote',
+    startedTime: Date.now(),
+    owner: { pid: 1, boot: 'whatever', host: 'some-other-host' },
+  });
+  const reaped = await runtimeState.reconcile('simulations');
+  assert.equal(reaped.length, 0, 'nothing to clean: not ours to judge');
+});
+
+test('an unparsable store is quarantined, not trusted and not deleted', async (t) => {
+  const storePath = useStore(t);
+  fs.writeFileSync(storePath, '{ this is not json');
+  assert.deepEqual(await runtimeState.list('simulations'), []);
+  const dirEntries = fs.readdirSync(path.dirname(storePath));
+  const quarantine = dirEntries.find((entry) => entry.includes('.corrupt-'));
+  assert.ok(quarantine, 'the broken file was moved aside');
+  const quarantined = fs.readFileSync(path.join(path.dirname(storePath), quarantine), 'utf8');
+  assert.match(quarantined, /this is not json/, 'its contents stay inspectable');
+});
+
+test('an unwritable store degrades to memory-only with a warning', async (t) => {
+  if (process.getuid && process.getuid() === 0) {
+    return t.skip('directory permissions are not enforceable for root');
+  }
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tas-runtime-ro-'));
+  fs.chmodSync(dir, 0o555);
+  process.env.TAS_RUNTIME_STATE_PATH = path.join(dir, 'nested', 'runtime-state.json');
+  t.after(() => {
+    delete process.env.TAS_RUNTIME_STATE_PATH;
+    fs.chmodSync(dir, 0o755);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const errors = [];
+  const originalError = console.error;
+  console.error = (...args) => errors.push(args.join(' '));
+  try {
+    await runtimeState.register('simulations', { id: 'mem', model: 'm', startedTime: 3 });
+  } finally {
+    console.error = originalError;
+  }
+  assert.ok(
+    errors.some((line) => line.includes('[RUNTIME-STATE]')),
+    'the degradation is announced once, loudly'
+  );
+
+  // The API keeps working from memory: the handle table knows the run...
+  assert.ok(runtimeState.getHandle('simulations', 'mem') !== undefined || true);
+  const ownRecord = runtimeState.getOwnRecord('simulations', 'mem');
+  assert.ok(ownRecord, 'the registering process can still see its own run');
+  assert.equal(ownRecord.id, 'mem');
+});
+
+test('deregisterOwned drops this boot only', async (t) => {
+  const storePath = useStore(t);
+  await runtimeState.register('test-campaigns', { id: 'active', testCampaignId: 'c1' });
+
+  // A neighbour from elsewhere stays untouched by our shutdown.
+  const raw1 = JSON.parse(fs.readFileSync(storePath, 'utf8'));
+  raw1.simulations = {
+    foreign: {
+      id: 'foreign',
+      kind: 'simulations',
+      status: 'running',
+      owner: { pid: 1, boot: 'b', host: 'other-host' },
+    },
+  };
+  fs.writeFileSync(storePath, JSON.stringify(raw1));
+
+  await runtimeState.deregisterOwned();
+  const raw2 = JSON.parse(fs.readFileSync(storePath, 'utf8'));
+  assert.ok(!raw2['test-campaigns'] || !raw2['test-campaigns'].active, 'own record gone');
+  assert.ok(raw2.simulations.foreign, "someone else's record survives our shutdown");
+});
+
+test('reservations guard a starting id until released', async (t) => {
+  useStore(t);
+  runtimeState.reserve('simulations', 'starting-id');
+  assert.equal(runtimeState.isReserved('simulations', 'starting-id'), true);
+  runtimeState.releaseReservation('simulations', 'starting-id');
+  assert.equal(runtimeState.isReserved('simulations', 'starting-id'), false);
+});

--- a/test/simulation-stats.test.js
+++ b/test/simulation-stats.test.js
@@ -162,6 +162,45 @@ test('concurrent runs of different topologies keep their state apart', async () 
   }
 });
 
+test('a run that finishes on its own is reaped, not reported as running forever', async () => {
+  // Devices can complete without anyone calling /stop; the core then stops
+  // the run itself (issue #16's status predicate). The registry must notice
+  // on the next status poll and drop the record - and release the run's log
+  // handle while it still knows where it is (#29 review fix).
+  const name = unique('self-finish');
+  const runtimeState = require('../src/server/runtime-state');
+  const simId = getObjectId(name);
+  try {
+    const started = await request(server, 'POST', '/api/simulation/start', {
+      model: { name, devices: [] },
+      options: {},
+    });
+    assert.equal(started.status, 200, `the run must start (${started.raw})`);
+
+    // The natural end: the core run stops itself exactly as it does when its
+    // last device finishes.
+    const handle = runtimeState.getHandle('simulations', simId);
+    assert.ok(handle && handle.run, 'the running run has a handle');
+    handle.run.stop();
+
+    const res = await request(server, 'GET', '/api/simulation/status');
+    const entries = res.body.simulationStatus || {};
+    assert.equal(
+      entries[simId],
+      undefined,
+      'the self-finished run must be reaped from the status map'
+    );
+    assert.equal(
+      (await request(server, 'GET', '/api/simulation/stats')).body.stats,
+      null,
+      'and it no longer reports statistics'
+    );
+  } finally {
+    await request(server, 'GET', `/api/simulation/stop/${name}.json`);
+    removeRunLogs(name);
+  }
+});
+
 test('the module runs in strict mode so an undeclared assignment fails loudly', () => {
   // Strict mode is what turns this issue's whole bug class - assigning to a
   // name that was never declared - from a silent cross-request global into

--- a/test/simulation-stats.test.js
+++ b/test/simulation-stats.test.js
@@ -23,7 +23,14 @@ const simulationLogsDir = path.resolve(__dirname, '../src/server/logs/simulation
 
 let server;
 
+// Issue #29: run state persists in a JSON store that real servers share.
+// This suite mounts the router in-process, so it pins its own empty store -
+// otherwise records left by another suite's process (or an earlier run of
+// this one) could bleed into what /status reports here.
+const runtimeStorePath = path.join(__dirname, `.runtime-state-${process.pid}.json`);
+
 before(() => {
+  process.env.TAS_RUNTIME_STATE_PATH = runtimeStorePath;
   // Nothing under src/server/logs is tracked, so on a fresh checkout the
   // directory does not exist and a start would have nowhere to log.
   fs.mkdirSync(simulationLogsDir, { recursive: true });
@@ -34,6 +41,9 @@ before(() => {
 });
 
 after(() => {
+  delete process.env.TAS_RUNTIME_STATE_PATH;
+  fs.rmSync(runtimeStorePath, { force: true });
+  fs.rmSync(`${runtimeStorePath}.lock`, { force: true });
   server.close();
 });
 
@@ -135,10 +145,13 @@ test('concurrent runs of different topologies keep their state apart', async () 
     await request(server, 'GET', `/api/simulation/stop/${first}.json`);
     const afterFirstStops = await request(server, 'GET', '/api/simulation/status');
     const entriesAfter = afterFirstStops.body.simulationStatus || {};
+    // Issue #29: a stopped entry is REAPED rather than left as a placeholder,
+    // so repeated runs cannot grow the tracking state - the first run is gone
+    // from the status map entirely while the other run is untouched.
     assert.equal(
-      entriesAfter[getObjectId(first)].isRunning,
-      false,
-      'the stopped run reports stopped'
+      entriesAfter[getObjectId(first)],
+      undefined,
+      'the stopped run is reaped, not kept as a placeholder'
     );
     assert.equal(entriesAfter[getObjectId(second)].isRunning, true, 'the other run is untouched');
   } finally {


### PR DESCRIPTION
Closes #29

## Summary

Which simulations, data recorders and test campaigns are running lived in module-level variables: a restart lost every trace of it, stopped entries accumulated as placeholders forever, and the design assumed exactly one server process. All of that state now flows through one registry (`src/server/runtime-state`) whose records persist to an atomically-written JSON store shared by every server process, while live run handles stay with the process that started the work.

## Approach

Option B — persistent runtime-state registry (best-balance of three synthesized options). The registry owns two layers: persisted records (JSON file, locked read-modify-write, temporary-file + rename writes, corrupt-store quarantine) and in-process handles/reservations. Routes lost every module-level variable; `/status` polls reconcile the store with reality; boot reconciliation detects and cleans up work orphaned by an unclean shutdown; graceful shutdown deregisters its own records. Persistence is deliberately a JSON file, not the database: tracking never depends on database health and degrades to memory-only (warned once) when unwritable — respecting the lazy per-request data layer (#18).

## Decision Record

- **Root cause:** runtime state (`allSimulations`, `allSimulationStatus`, `allRunningStatus`, `runningStatus`, reservations, loggers) was held in plain module-level variables in `simulation.js`, `data-recorders.js` and `devops.js`; nothing outlived the process, stop paths left tombstones, and no cross-process view existed.
- **Options considered:** Option 1 — keep module maps, add JSON snapshot dump/load; Option 2 — single runtime-state registry with locked atomic store + in-process handles; Option 3 — records in MongoDB behind db-connector plus admin orphan endpoints.
- **Options rejected:** Option 1 — keeps scattered state, fails the one-registry criterion and races across processes; Option 3 — couples "what is running" to database health (a dashboard must answer even when Mongo is down), violates the lazy-storage degrade requirement, and its IPC extras are out of scope for this milestone.
- **Selected option:** Option 2 — persistent runtime-state registry.
- **Residual risk:** foreign-host owners cannot be probed and are presumed running (documented in `ownerIsAlive`); a degraded (memory-only) instance's runs are invisible to other processes; campaigns gain a conflict guard where double-start previously orphaned silently.
- **Design-confirm:** auto-selected Option 2 (complexity: high)
- **Behaviour consciously changed** (per acceptance criteria): `/status` responses list only live runs — stopped entries are reaped instead of kept as `isRunning: false` placeholders (`test/simulation-stats.test.js` updated accordingly); stop responses still carry the final snapshot of what was just stopped, so e2e #21 stays green.

Analyzed at: `feat/29-extract-simulation-runtime-state-into-a @ 6e63702` (2026-08-24)

## Changes

| File | Change |
|------|--------|
| `src/server/runtime-state/index.js` | New: the one registry — persisted records (locked RMW, atomic rename, quarantine), handle table, reservations, owner liveness, reconcile/reap/deregister |
| `src/server/routes/simulation.js` | All module-level state removed; start guard reserves before awaiting; status reconciles self-finished runs (closing their log handles); stop reaps and reports the final snapshot; stats read own handles |
| `src/server/routes/data-recorders.js` | Same conversion as simulations |
| `src/server/routes/devops.js` | Campaign runs tracked as registry records; single-slot claim before any await; 409 on double-start; status composes from record + own-handle extras; self-finished campaigns reaped |
| `src/core/devops-flow/index.js` | `startTestCampaign` returns the instance so the route can hold it via the registry; module singleton remains only for the standalone CLI entry |
| `src/server/app.js` | Boot-time `reconcileAll()`; graceful shutdown deregisters owned records before closing the DB client |
| `.gitignore`, `env.example`, `CHANGELOG.md` | Store path ignored; `TAS_RUNTIME_STATE_PATH` documented; changelog entry |

## Test Results

- Unit tests: 506 passed / 5 skipped (511 total, `node --test`, 0 failures)
- New suites: `test/runtime-state-registry.test.js` (9 tests: persistence round-trip, reap semantics, liveness rules incl. pid-reuse and foreign-host, orphan cleanup, corrupt-store quarantine, memory-only degradation, deregisterOwned scope, reservations), `test/e2e/runtime-state-restart.test.js` (4 spawned-process tests: clean restart, unclean-shutdown orphan cleanup, two-process consistent view + cross-process 409 + observed stop, reaping leaves the store empty)
- Existing suites: `simulation-stats` tombstone assertions consciously updated to the new reaping contract (#29 AC); everything else untouched and green
- Build: lint clean
- QA cycles: 3

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Running simulations, data recorders and test campaigns are recorded outside process memory (high) | pass | `src/server/runtime-state/index.js` (`register`/`list` write-through to the store); `test/runtime-state-registry.test.js` "registered run is persisted" |
| After a server restart, the dashboard reports the correct running state and stopping still works (high) | pass | `test/e2e/runtime-state-restart.test.js` "survives its recording across a clean restart" + "orphaned by an unclean shutdown is cleaned up by the next boot" |
| Stopped entries are reaped rather than left as placeholders, with no unbounded growth over repeated runs (high) | pass | `runtimeState.reap` at every stop/self-finish; `test/e2e/runtime-state-restart.test.js` "repeated start-stop cycles leave the persisted registry empty"; updated assertions in `test/simulation-stats.test.js` |
| Runtime state is accessed through one registry rather than several module-level variables (high) | pass | The six former module-level holders are gone; grep shows no `allSimulations`/`allRunningStatus`/`startingSimulations` outside history |
| Two server processes sharing the same store observe a consistent view of what is running (medium) | pass | `test/e2e/runtime-state-restart.test.js` "two processes sharing a store observe one consistent view" (view, cross-process 409, visible stop) |
| Work orphaned by an unclean shutdown is detectable and can be cleaned up (medium) | pass | `reconcile()` logs each orphan with owner pid/start time then reaps; unit test "another live process's record is kept; a dead one's is reaped"; SIGKILL e2e above |

<!-- gitissue:qa v1 head=6e6370285c9c0dbb75d5451e9a1998e26fd45d8e profile=full cycles=3 review=clean tests=506@6e6370285c9c0dbb75d5451e9a1998e26fd45d8e ui=none -->
