### PR TITLE
refactor(server): store topologies and recorders durably (#30)

### DIFF
--- a/env.example
+++ b/env.example
@@ -49,3 +49,13 @@ DEV_DASHBOARD_PORT=8080
 # data recorders and test campaigns are running. Defaults to
 # src/server/data/runtime-state.json, alongside the other data files.
 #TAS_RUNTIME_STATE_PATH=
+
+# Where the stored artefacts live (issue #30). Topologies, data-recorder
+# definitions and the service configuration are records of an artifact store
+# that writes them atomically and serialises concurrent edits; existing files
+# in these directories were written by earlier versions and are adopted as
+# they are. Defaults: src/server/data/models, src/server/data/data-recorders
+# and src/server/data (which holds data-storage.json).
+#TAS_MODELS_DIR=
+#TAS_DATA_RECORDERS_DIR=
+#TAS_DATA_DIR=

--- a/src/server/artifact-store/index.js
+++ b/src/server/artifact-store/index.js
@@ -183,29 +183,33 @@ function createArtifactStore({ root, label }) {
   /**
    * Write one record atomically: temporary file in the same directory, fsync,
    * rename over the target. A crash at any point leaves either the old record
-   * or the new one - never a truncated file - with at worst an orphaned `.tmp`
-   * beside it, which `list()` ignores.
+   * or the new one - never a truncated file - and every failure before the
+   * rename cleans its temporary file up behind it.
    */
   const writeRecordAtomic = async (target, document) => {
     const tmp = `${target}.${process.pid}.${Date.now()}.tmp`;
     let handle = null;
     try {
+      // Serialising can throw on its own (a document JSON cannot represent);
+      // the cleanup below must cover that too, not just filesystem failures.
+      const serialized = JSON.stringify(document, null, 2);
       handle = await fsp.open(tmp, 'wx');
-      await handle.writeFile(JSON.stringify(document, null, 2));
+      await handle.writeFile(serialized);
       // Durability before the rename: once the rename lands the record must
       // already be on disk, or a crash could swap in a name whose contents
       // were still in page cache.
       await handle.sync();
+      await fsp.rename(tmp, target);
+    } catch (err) {
+      // Whatever failed - serialising, creating the temp file, writing,
+      // syncing or the rename itself - the previous record is untouched; just
+      // do not leave an orphaned temporary file behind.
+      await fsp.unlink(tmp).catch(() => {});
+      throw err;
     } finally {
       if (handle !== null) {
         await handle.close().catch(() => {});
       }
-    }
-    try {
-      await fsp.rename(tmp, target);
-    } catch (err) {
-      await fsp.unlink(tmp).catch(() => {});
-      throw err;
     }
   };
 

--- a/src/server/artifact-store/index.js
+++ b/src/server/artifact-store/index.js
@@ -1,0 +1,347 @@
+'use strict';
+/**
+ * The artifact store (issue #30).
+ *
+ * Topologies, data recorders and the service configuration used to be read and
+ * rewritten as loose JSON files straight from the route handlers: a full-file
+ * read-modify-write with no locking and no atomicity. Two concurrent edits
+ * silently discarded one another, and a crash partway through a write could
+ * leave a truncated file that no longer parsed - taking the stored record with
+ * it.
+ *
+ * This module is the ONE place that I/O now goes through. Every record stays
+ * its own file under the store's root directory (so existing records are
+ * adopted in place on upgrade - there is nothing to migrate), but the writes
+ * are serialized and atomic:
+ *
+ *  - every mutation runs while holding an advisory lock file (an O_EXCL
+ *    create, retried until a timeout; a lock left behind by a crashed process
+ *    is stolen once it is older than LOCK_STALE_MS), so two concurrent edits
+ *    of the same record queue up instead of racing, and a mutation always
+ *    applies to the state the previous one left behind;
+ *  - every write lands first in a temporary file that is fsynced and then
+ *    renamed over the target. The rename is atomic on POSIX: a concurrent
+ *    reader sees either the old record or the new one, never a half-written
+ *    one, and a crash during the write leaves the previous record intact with
+ *    at worst an orphaned temporary file beside it;
+ *  - a record that does not parse is quarantined (renamed beside the original)
+ *    rather than served or silently deleted, so what went wrong stays
+ *    inspectable.
+ *
+ * Like the runtime-state registry (#29), persistence degrades loudly rather
+ * than taking the API down: an unwritable store fails exactly the request that
+ * needed it, and nothing else.
+ */
+
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+
+const LOCK_RETRY_MS = 25;
+const LOCK_TIMEOUT_MS = 5000;
+const LOCK_STALE_MS = 10000;
+
+/** Extension every stored record carries; anything else in the root is not a record. */
+const RECORD_EXTENSION = '.json';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Errors carry a stable `code` so route handlers can translate them into HTTP
+ * responses without this module knowing about HTTP: EARTIFACTCONFLICT maps to
+ * 409, EARTIFACTPATH to 400, and native ENOENT flows through the existing
+ * `fileError` mapping to 404 untouched.
+ */
+const artifactError = (code, message) => {
+  const err = new Error(message);
+  err.code = code;
+  return err;
+};
+
+/**
+ * Contain a record name inside the store's root directory.
+ *
+ * Records are flat files, so anything carrying a separator, a traversal
+ * sequence or an absolute path cannot name a record at all. Checked again at
+ * this sink even though the request layer validates names first: the store is
+ * also reachable from code paths that never saw the request schemas.
+ *
+ * @param {String} fileName The record file name, extension included
+ * @returns {String} The resolved absolute path
+ * @throws {Error} code EARTIFACTPATH when the name escapes the root
+ */
+const containedPath = (root, fileName) => {
+  if (
+    typeof fileName !== 'string' ||
+    fileName.length === 0 ||
+    fileName !== path.basename(fileName) ||
+    !fileName.endsWith(RECORD_EXTENSION) ||
+    fileName === '.' ||
+    fileName === '..'
+  ) {
+    throw artifactError('EARTIFACTPATH', `Invalid record name: ${fileName}`);
+  }
+  return path.join(root, fileName);
+};
+
+/**
+ * Create a store over one directory of JSON record files.
+ *
+ * @param {Object} options
+ * @param {String} options.root Absolute path of the directory holding the records
+ * @param {String} options.label Short name used for the lock file and log lines
+ * @returns {Object} The store instance
+ */
+function createArtifactStore({ root, label }) {
+  const absoluteRoot = path.resolve(root);
+  const lockFile = path.join(absoluteRoot, `.${label}.lock`);
+
+  /**
+   * In-process fairness for the cross-process lock: concurrent callers queue
+   * on this chain instead of hammering the O_EXCL retry loop against each
+   * other. The chained promise swallows outcomes so one failed mutation never
+   * stalls the ones queued behind it.
+   */
+  let mutexChain = Promise.resolve();
+
+  /**
+   * Run `mutate` while holding the advisory lock file.
+   *
+   * The lock is an O_EXCL create retried until the deadline; a lock left
+   * behind by a crashed holder is stolen once it is older than
+   * LOCK_STALE_MS. On timeout the mutation still runs, without the lock -
+   * single-process correctness comes from the in-process chain, and losing an
+   * occasional cross-process update beats refusing to serve.
+   *
+   * @param {Function} mutate Invoked with no arguments; its resolution is the outcome
+   * @returns {Promise<*>} Whatever `mutate` resolved with
+   */
+  const withFileLock = async (mutate) => {
+    await fsp.mkdir(absoluteRoot, { recursive: true });
+    let fd = null;
+    const deadline = Date.now() + LOCK_TIMEOUT_MS;
+    while (fd === null) {
+      try {
+        fd = await fsp.open(lockFile, 'wx');
+      } catch (err) {
+        if (err.code !== 'EEXIST') break;
+        if (Date.now() > deadline) break;
+        try {
+          const stat = await fsp.stat(lockFile);
+          if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+            // Nobody holding a healthy lock keeps it this long; the holder died.
+            await fsp.unlink(lockFile).catch(() => {});
+          }
+        } catch (_) {
+          /* vanished already - just retry */
+        }
+        await sleep(LOCK_RETRY_MS);
+      }
+    }
+    try {
+      return await mutate();
+    } finally {
+      if (fd !== null) {
+        await fd.close().catch(() => {});
+        await fsp.unlink(lockFile).catch(() => {});
+      }
+    }
+  };
+
+  /** Serialize a mutation through the in-process chain AND the file lock. */
+  const exclusively = (mutate) => {
+    const run = mutexChain.then(() => withFileLock(mutate));
+    mutexChain = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
+  };
+
+  /**
+   * Read and parse one record. A record that does not parse is quarantined
+   * beside the original and reported as corrupt - it is never served, and
+   * never quietly deleted.
+   */
+  const readRecord = async (target) => {
+    const raw = await fsp.readFile(target, 'utf8');
+    try {
+      return JSON.parse(raw);
+    } catch (_) {
+      const quarantine = `${target}.corrupt-${Date.now()}`;
+      console.error(
+        `[${label}] Record is unparsable - quarantined to ${path.basename(quarantine)}`
+      );
+      await fsp.rename(target, quarantine).catch(() => {});
+      throw artifactError(
+        'EARTIFACTCORRUPT',
+        'Stored record is unparsable and has been quarantined'
+      );
+    }
+  };
+
+  /**
+   * Write one record atomically: temporary file in the same directory, fsync,
+   * rename over the target. A crash at any point leaves either the old record
+   * or the new one - never a truncated file - with at worst an orphaned `.tmp`
+   * beside it, which `list()` ignores.
+   */
+  const writeRecordAtomic = async (target, document) => {
+    const tmp = `${target}.${process.pid}.${Date.now()}.tmp`;
+    let handle = null;
+    try {
+      handle = await fsp.open(tmp, 'wx');
+      await handle.writeFile(JSON.stringify(document, null, 2));
+      // Durability before the rename: once the rename lands the record must
+      // already be on disk, or a crash could swap in a name whose contents
+      // were still in page cache.
+      await handle.sync();
+    } finally {
+      if (handle !== null) {
+        await handle.close().catch(() => {});
+      }
+    }
+    try {
+      await fsp.rename(tmp, target);
+    } catch (err) {
+      await fsp.unlink(tmp).catch(() => {});
+      throw err;
+    }
+  };
+
+  const recordExists = async (target) => {
+    try {
+      await fsp.access(target);
+      return true;
+    } catch (err) {
+      if (err.code === 'ENOENT') return false;
+      throw err;
+    }
+  };
+
+  return {
+    /** The absolute root this store was created over. */
+    root: absoluteRoot,
+
+    /**
+     * Every record file name in the store, sorted. Temporary and quarantined
+     * artifacts of interrupted writes do not carry the bare `.json` suffix and
+     * are never listed.
+     *
+     * @returns {Promise<String[]>} Record file names, extension included
+     */
+    async list() {
+      await fsp.mkdir(absoluteRoot, { recursive: true });
+      const entries = await fsp.readdir(absoluteRoot);
+      return entries
+        .filter((entry) => entry.endsWith(RECORD_EXTENSION))
+        .filter((entry) => path.basename(entry) === entry)
+        .sort();
+    },
+
+    /**
+     * Read one record by file name.
+     *
+     * @param {String} fileName Record file name, extension included
+     * @returns {Promise<Object>} The parsed record
+     * @throws {Error} ENOENT-shaped when absent (maps to 404 upstream),
+     *   EARTIFACTCORRUPT when unparsable, EARTIFACTPATH when the name escapes
+     */
+    async read(fileName) {
+      return readRecord(containedPath(absoluteRoot, fileName));
+    },
+
+    /**
+     * Does a record exist? Probes are only meaningful inside `withExclusive`,
+     * where no mutation can land between the probe and the caller's own write.
+     */
+    async exists(fileName) {
+      return recordExists(containedPath(absoluteRoot, fileName));
+    },
+
+    /**
+     * Write a record. Refuses to replace an existing record unless asked,
+     * which is how the create path earns its conflict answer.
+     *
+     * @param {String} fileName Record file name, extension included
+     * @param {Object} document The record to persist
+     * @param {Object} [options]
+     * @param {Boolean} [options.overwrite] Replace an existing record (default false)
+     * @throws {Error} EARTIFACTCONFLICT when the name is taken and overwrite was not set
+     */
+    async write(fileName, document, { overwrite = false } = {}) {
+      return exclusively(async () => {
+        const target = containedPath(absoluteRoot, fileName);
+        if (!overwrite && (await recordExists(target))) {
+          throw artifactError('EARTIFACTCONFLICT', `Record already exists: ${fileName}`);
+        }
+        return writeRecordAtomic(target, document);
+      });
+    },
+
+    /**
+     * Atomically move a record: the content is written under the new name and
+     * the old name is removed, both inside one lock, so no observer can see
+     * both copies or neither. With an optional transform applied on the way.
+     *
+     * @param {String} oldFileName Source record
+     * @param {String} newFileName Target record
+     * @param {Function} [transform] Invoked with the parsed source record
+     * @returns {Promise<Object>} The record as written under the new name
+     * @throws {Error} EARTIFACTCONFLICT when the target name is taken
+     */
+    async rename(oldFileName, newFileName, transform) {
+      return exclusively(async () => {
+        const source = containedPath(absoluteRoot, oldFileName);
+        const target = containedPath(absoluteRoot, newFileName);
+        if (source === target) {
+          return readRecord(source);
+        }
+        const record = transform ? transform(await readRecord(source)) : await readRecord(source);
+        if (await recordExists(target)) {
+          throw artifactError('EARTIFACTCONFLICT', `Record already exists: ${newFileName}`);
+        }
+        await writeRecordAtomic(target, record);
+        await fsp.unlink(source).catch(() => {});
+        return record;
+      });
+    },
+
+    /**
+     * Remove a record. Absence throws an ENOENT-shaped error so the caller's
+     * existing missing-file mapping answers it.
+     */
+    async remove(fileName) {
+      return exclusively(async () => {
+        const target = containedPath(absoluteRoot, fileName);
+        await fsp.unlink(target);
+      });
+    },
+
+    /**
+     * Run a composed mutation while holding the store's lock.
+     *
+     * For multi-step mutations (a duplicate that must search for a free name
+     * and then claim it) whose steps must not interleave with any other
+     * mutation of this store. The callback receives the store's UNLOCKED
+     * primitives (`read`, `exists`, `writeRaw`, `remove`) - calling the locked
+     * public methods from inside would deadlock on the in-process chain.
+     *
+     * @param {Function} mutate Invoked with the unlocked API
+     * @returns {Promise<*>} Whatever `mutate` resolved with
+     */
+    async withExclusive(mutate) {
+      return exclusively(async () =>
+        mutate({
+          read: (fileName) => readRecord(containedPath(absoluteRoot, fileName)),
+          exists: (fileName) => recordExists(containedPath(absoluteRoot, fileName)),
+          writeRaw: (fileName, document) =>
+            writeRecordAtomic(containedPath(absoluteRoot, fileName), document),
+          remove: (fileName) => fsp.unlink(containedPath(absoluteRoot, fileName)),
+        })
+      );
+    },
+  };
+}
+
+module.exports = { createArtifactStore };

--- a/src/server/routes/data-recorders.js
+++ b/src/server/routes/data-recorders.js
@@ -1,10 +1,9 @@
 /* Working with Data Generator */
 var express = require('express');
-var path = require('path');
 const Joi = require('joi');
 const DataRecorder = require('../../core/data-recorder');
 
-const { readJSONFile, writeToFile, readDir, deleteFile, getObjectId } = require('../../core/utils');
+const { getObjectId } = require('../../core/utils');
 const { isValidName, resolveWithin, sendBadRequest } = require('./path-safety');
 const {
   validate,
@@ -23,10 +22,22 @@ const {
   internal,
   unavailable,
 } = require('../middleware/errors');
-const dataRecordersPath = `${__dirname}/../data/data-recorders/`;
+const { createArtifactStore } = require('../artifact-store');
 let router = express.Router();
 let getLogger = require('../logger');
 const { getDataStorage } = require('./db-connector');
+// The stored recorder definitions are records of the artifact store (issue
+// #30): writes are serialized under the store's lock and land atomically, so
+// concurrent edits queue up instead of discarding one another and a crash
+// mid-write cannot leave a truncated file behind. Existing loose files in the
+// directory are adopted as they are - there is no migration step.
+// `TAS_DATA_RECORDERS_DIR` moves the store (tests use a scratch directory).
+const dataRecordersPath =
+  process.env.TAS_DATA_RECORDERS_DIR || `${__dirname}/../data/data-recorders/`;
+const recordersStore = createArtifactStore({
+  root: dataRecordersPath,
+  label: 'data-recorders',
+});
 let logsPath = `${__dirname}/../logs/data-recorders/`;
 // Running-recorder records and handles live in the shared runtime registry
 // (issue #29): records persist across restarts and are visible to a second
@@ -310,17 +321,19 @@ router.post('/start', validate({ body: dataRecorderStartBody }), (req, res, next
   const { model, dataRecorderFileName } = req.body;
   if (dataRecorderFileName) {
     // start recorder by file name
-    const dataRecorderFile = resolveWithin(dataRecordersPath, dataRecorderFileName);
-    if (!dataRecorderFile) {
+    // Containment, not validation: the schema has already established that the
+    // name is well formed, but the path it derives is still checked at the sink.
+    if (!resolveWithin(recordersStore.root, dataRecorderFileName)) {
       return sendBadRequest(res, 'Invalid data recorder file name');
     }
-    readJSONFile(dataRecorderFile, (err, data) => {
-      if (err) {
-        next(fileError(err, 'Data recorder not found', 'Cannot read the data recorder file'));
-      } else {
+    recordersStore
+      .read(dataRecorderFileName)
+      .then((data) => {
         startRecorder(data, res, next).catch(next);
-      }
-    });
+      })
+      .catch((err) =>
+        next(fileError(err, 'Data recorder not found', 'Cannot read the data recorder file'))
+      );
   } else {
     // Start recorder by model
     startRecorder(model, res, next).catch(next);
@@ -329,16 +342,15 @@ router.post('/start', validate({ body: dataRecorderStartBody }), (req, res, next
 
 // Read the list of data recorders
 router.get('/models/', validate(), (req, res, next) => {
-  readDir(dataRecordersPath, (err, files) => {
-    if (err) {
-      next(internal('Cannot read the data recorders directory', err));
-    } else {
+  recordersStore
+    .list()
+    .then((dataRecorders) => {
       res.send({
         error: null,
-        dataRecorders: files.filter((f) => path.extname(f) === '.json'),
+        dataRecorders,
       });
-    }
-  });
+    })
+    .catch((err) => next(internal('Cannot read the data recorders directory', err)));
 });
 
 // Read a specific data recorder by its name:
@@ -347,22 +359,30 @@ router.get(
   validate({ params: { fileName: recorderNameParam } }),
   function (req, res, next) {
     const { fileName } = req.params;
-    const dataRecorderFile = resolveWithin(dataRecordersPath, fileName);
-    if (!dataRecorderFile) {
+    if (!resolveWithin(recordersStore.root, fileName)) {
       return sendBadRequest(res, 'Invalid data recorder name');
     }
-    readJSONFile(dataRecorderFile, (err, data) => {
-      if (err) {
-        next(fileError(err, 'Data recorder not found', 'Cannot read the data recorder file'));
-      } else {
+    recordersStore
+      .read(fileName)
+      .then((data) => {
         res.send({
           error: null,
           dataRecorder: data,
         });
-      }
-    });
+      })
+      .catch((err) =>
+        next(fileError(err, 'Data recorder not found', 'Cannot read the data recorder file'))
+      );
   }
 );
+
+/** Map a store write failure onto its HTTP answer; a taken name is a conflict. */
+const saveError = (message, next) => (err) => {
+  if (err && err.code === 'EARTIFACTCONFLICT') {
+    return next(conflict('A data recorder with this name already exists'));
+  }
+  return next(internal(message, err));
+};
 
 const updateDataRecorder = (fileName, dataRecorder, res, next) => {
   const { name } = dataRecorder;
@@ -372,89 +392,84 @@ const updateDataRecorder = (fileName, dataRecorder, res, next) => {
     return sendBadRequest(res, 'Invalid data recorder name');
   }
   const newName = `${name}.json`;
-  const oldDataRecorderFile = resolveWithin(dataRecordersPath, fileName);
-  const newDataRecorderFile = resolveWithin(dataRecordersPath, newName);
-  if (!oldDataRecorderFile || !newDataRecorderFile) {
+  if (
+    !resolveWithin(recordersStore.root, fileName) ||
+    !resolveWithin(recordersStore.root, newName)
+  ) {
     return sendBadRequest(res, 'Invalid data recorder name');
   }
+  const sameName = (message) => (err) => {
+    if (err && err.code === 'EARTIFACTCONFLICT') {
+      return next(conflict('A data recorder with this name already exists'));
+    }
+    return next(internal(message, err));
+  };
   if (newName === fileName) {
-    writeToFile(
-      newDataRecorderFile,
-      JSON.stringify(dataRecorder),
-      (err, data) => {
-        if (err) {
-          next(internal('Cannot save the new configuration', err));
-        } else {
-          res.send({
-            dataRecorderFileName: fileName,
-          });
-        }
-      },
-      true
-    );
+    recordersStore
+      .write(newName, dataRecorder, { overwrite: true })
+      .then(() => {
+        res.send({
+          dataRecorderFileName: fileName,
+        });
+      })
+      .catch(sameName('Cannot save the new configuration'));
   } else {
-    // new file
-    writeToFile(
-      newDataRecorderFile,
-      JSON.stringify(dataRecorder),
-      (err, data) => {
-        if (err) {
-          next(internal('Cannot save the new configuration', err));
-        } else {
-          deleteFile(oldDataRecorderFile, (err2) => {
-            if (err2) {
-              next(internal('Cannot remove the old data recorder file', err2));
-            } else {
-              res.send({
-                dataRecorderFileName: fileName,
-              });
-            }
-          });
+    // Rename inside the store: the copy under the new name lands atomically
+    // and the old one is removed within the same locked step.
+    recordersStore
+      .rename(fileName, newName)
+      .then(() => {
+        res.send({
+          dataRecorderFileName: fileName,
+        });
+      })
+      .catch((err) => {
+        if (err && err.code === 'EARTIFACTCONFLICT') {
+          return next(conflict('A data recorder with this name already exists'));
         }
-      },
-      true
-    );
+        if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) {
+          return next(
+            fileError(err, 'Data recorder not found', 'Cannot read the data recorder file')
+          );
+        }
+        return next(internal('Cannot save the new configuration', err));
+      });
   }
 };
 
 const duplicateDataRecorder = (fileName, res, next) => {
-  const dataRecorderFile = resolveWithin(dataRecordersPath, fileName);
-  if (!dataRecorderFile) {
+  if (!resolveWithin(recordersStore.root, fileName)) {
     return sendBadRequest(res, 'Invalid data recorder name');
   }
-  readJSONFile(dataRecorderFile, (err, data) => {
-    if (err) {
-      next(fileError(err, 'Data recorder not found', 'Cannot read the data recorder file'));
-    } else {
+  recordersStore
+    .withExclusive(async (unlocked) => {
+      const data = await unlocked.read(fileName);
       const newName = `${data.name} [Duplicated]`;
-      const newDataRecorder = {
-        ...data,
-        name: newName,
-      };
       if (!isValidName(newName)) {
-        return sendBadRequest(res, 'Invalid data recorder name');
+        const err = new Error('Invalid data recorder name');
+        err.code = 'EARTIFACTPATH';
+        throw err;
       }
       const newFileName = `${newName}.json`;
-      const newDataRecorderFile = resolveWithin(dataRecordersPath, newFileName);
-      if (!newDataRecorderFile) {
+      await unlocked.writeRaw(newFileName, { ...data, name: newName });
+      return { newFileName };
+    })
+    .then(({ newFileName }) => {
+      res.send({
+        dataRecorderFileName: newFileName,
+      });
+    })
+    .catch((err) => {
+      if (err.code === 'EARTIFACTPATH') {
         return sendBadRequest(res, 'Invalid data recorder name');
       }
-      writeToFile(
-        newDataRecorderFile,
-        JSON.stringify(newDataRecorder),
-        (err, dupDataRecorder) => {
-          if (err) {
-            next(internal('Cannot save the duplicated data recorder', err));
-          } else {
-            res.send({
-              dataRecorderFileName: newFileName,
-            });
-          }
-        },
-        true
-      );
-    }
-  });
+      if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
+        return next(
+          fileError(err, 'Data recorder not found', 'Cannot read the data recorder file')
+        );
+      }
+      return saveError('Cannot save the duplicated data recorder', next)(err);
+    });
 };
 
 // Update a data recorder
@@ -483,20 +498,20 @@ router.post('/models', validate({ body: dataRecorderCreateBody }), function (req
     return sendBadRequest(res, 'Invalid data recorder name');
   }
   const dataRecorderFileName = `${dataRecorder.name}.json`;
-  const dataRecorderFile = resolveWithin(dataRecordersPath, dataRecorderFileName);
-  if (!dataRecorderFile) {
+  if (!resolveWithin(recordersStore.root, dataRecorderFileName)) {
     return sendBadRequest(res, 'Invalid data recorder name');
   }
-  writeToFile(dataRecorderFile, JSON.stringify(dataRecorder), (err, data) => {
-    if (err) {
-      next(internal('Cannot save the new configuration', err));
-    } else {
+  // The store refuses to replace an existing record, so saving over a taken
+  // name is answered with a conflict instead of a silently renamed copy.
+  recordersStore
+    .write(dataRecorderFileName, dataRecorder)
+    .then(() => {
       res.send({
         error: null,
         dataRecorderFileName,
       });
-    }
-  });
+    })
+    .catch(saveError('Cannot save the new configuration', next));
 });
 
 // Delete a data recorder
@@ -505,20 +520,20 @@ router.delete(
   validate({ params: { fileName: recorderNameParam } }),
   function (req, res, next) {
     const { fileName } = req.params;
-    const dataRecorderFile = resolveWithin(dataRecordersPath, fileName);
-    if (!dataRecorderFile) {
+    if (!resolveWithin(recordersStore.root, fileName)) {
       return sendBadRequest(res, 'Invalid data recorder name');
     }
-    deleteFile(dataRecorderFile, (err) => {
-      if (err) {
-        next(fileError(err, 'Data recorder not found', 'Cannot delete the data recorder file'));
-      } else {
+    recordersStore
+      .remove(fileName)
+      .then(() => {
         res.send({
           error: null,
           result: true,
         });
-      }
-    });
+      })
+      .catch((err) =>
+        next(fileError(err, 'Data recorder not found', 'Cannot delete the data recorder file'))
+      );
   }
 );
 

--- a/src/server/routes/db-connector.js
+++ b/src/server/routes/db-connector.js
@@ -7,13 +7,33 @@ const {
   TestCampaignSchema,
 } = require('../../core/enact-mongoose');
 
-const { readJSONFile, writeToFile } = require('../../core/utils');
+const { createArtifactStore } = require('../artifact-store');
 const { unavailable } = require('../middleware/errors');
 
-const dataStoragePath = `${__dirname}/../data/data-storage.json`;
+// The service configuration is a record of the artifact store (issue #30):
+// reads go through the store on EVERY call - there is no in-memory copy that
+// can go stale, so a configuration change takes effect without a restart -
+// and writes are serialized and atomic, so a crash mid-save cannot leave a
+// truncated configuration behind. `TAS_DATA_DIR` moves the store (tests use a
+// scratch directory).
+const dataStorageDir = process.env.TAS_DATA_DIR || `${__dirname}/../data`;
+const DATA_STORAGE_FILE = 'data-storage.json';
+const dataStorageStore = createArtifactStore({ root: dataStorageDir, label: 'data-storage' });
 
-let dataStorageConfig = null;
 let dbClient = null;
+
+/** The configuration served when no stored one exists yet (a fresh volume). */
+const DEFAULT_DATA_STORAGE = {
+  protocol: 'MONGODB',
+  connConfig: {
+    host: 'localhost',
+    port: 27017,
+    username: null,
+    password: null,
+    dbname: null,
+    options: null,
+  },
+};
 
 /**
  * Build an ENACTDB client from a data-storage configuration and prove it can
@@ -108,46 +128,45 @@ const getDBClient = (callback) => {
 ///////////////
 // Read a specific model by its name:
 
+/**
+ * Read the service configuration, straight from the store.
+ *
+ * Deliberately NOT cached: the configuration is one small file read locally,
+ * and serving it fresh is what lets a configuration change take effect
+ * without a restart (#30). A missing configuration - a fresh volume - is
+ * bootstrapped with the default. The default MUST use the same nested
+ * { protocol, connConfig: {…} } shape as a committed data-storage.json,
+ * otherwise getDBClient destructures connConfig (undefined) and throws a
+ * TypeError instead of reporting a clean failure. (F-BUG-002)
+ *
+ * @param {Function} callback Invoked with (err, dataStorage)
+ */
 const getDataStorage = (callback) => {
-  if (dataStorageConfig) return callback(null, dataStorageConfig);
-  return readJSONFile(dataStoragePath, (err, data) => {
-    if (err) {
-      console.error('[SERVER] reading data storage', err);
-      // The default MUST use the same nested { protocol, connConfig: {…} }
-      // shape as the committed data-storage.json, otherwise getDBClient
-      // destructures connConfig (undefined) and throws a TypeError inside this
-      // fs callback — an uncaught exception on the fresh-volume / first-run
-      // path instead of a clean 503. (F-BUG-002)
-      const defaultDataStorage = {
-        protocol: 'MONGODB',
-        connConfig: {
-          host: 'localhost',
-          port: 27017,
-          username: null,
-          password: null,
-          dbname: null,
-          options: null,
-        },
-      };
-      writeToFile(
-        dataStoragePath,
-        JSON.stringify(defaultDataStorage),
-        (err2, data) => {
-          if (err2) {
-            console.error('[SERVER] saving data storage', err2);
-            return callback(err2);
-          } else {
-            dataStorageConfig = defaultDataStorage;
-            return callback(null, dataStorageConfig);
+  dataStorageStore
+    .read(DATA_STORAGE_FILE)
+    .then((data) => callback(null, data))
+    .catch((err) => {
+      if (err.code !== 'ENOENT') {
+        console.error('[SERVER] reading data storage', err);
+        return callback(err);
+      }
+      // Bootstrap the default. The write refuses to replace an existing
+      // record: if another process bootstrapped first, serve what it wrote -
+      // which is byte-for-byte the same default anyway.
+      dataStorageStore
+        .write(DATA_STORAGE_FILE, DEFAULT_DATA_STORAGE)
+        .then(() => callback(null, DEFAULT_DATA_STORAGE))
+        .catch((writeErr) => {
+          if (writeErr && writeErr.code === 'EARTIFACTCONFLICT') {
+            return dataStorageStore
+              .read(DATA_STORAGE_FILE)
+              .then((winner) => callback(null, winner))
+              .catch((reErr) => callback(reErr));
           }
-        },
-        true
-      );
-    } else {
-      dataStorageConfig = data;
-      return callback(null, dataStorageConfig);
-    }
-  });
+          console.error('[SERVER] saving data storage', writeErr);
+          return callback(writeErr);
+        });
+    });
 };
 
 const updateDataStorage = (dataStorage, callback) => {
@@ -161,8 +180,8 @@ const updateDataStorage = (dataStorage, callback) => {
   // Mongoose's shared default connection: connecting the candidate replaces
   // that connection wholesale, so keeping the old wrapper would only leave a
   // stale handle. If the probe then fails, `dbClient` stays cleared and the
-  // next `getDBClient` reconnects lazily from `dataStorageConfig` — which
-  // this function has deliberately not touched yet.
+  // next `getDBClient` reconnects lazily from the stored configuration —
+  // which this function has deliberately not touched yet.
   const closeCurrent = (done) => {
     if (!dbClient) return done();
     const current = dbClient;
@@ -181,28 +200,24 @@ const updateDataStorage = (dataStorage, callback) => {
           unavailable('Data storage not updated: cannot connect to the proposed database', err2)
         );
       }
-      writeToFile(
-        dataStoragePath,
-        JSON.stringify(dataStorage),
-        (err, data) => {
-          if (err) {
-            console.error('[SERVER] Cannot save the new data storage configuration', err);
-            // The connection was proven but persistence failed: drop the
-            // verified candidate rather than run live against settings a
-            // restart would not load, and let `getDBClient` rebuild from the
-            // untouched previous configuration.
-            dbClient = null;
-            candidate.close(() => {});
-            return callback(err);
-          }
+      dataStorageStore
+        .write(DATA_STORAGE_FILE, dataStorage, { overwrite: true })
+        .then(() => {
           // Commit: the verified candidate becomes the live client and the new
           // configuration takes effect immediately, no restart needed.
           dbClient = candidate;
-          dataStorageConfig = dataStorage;
           return callback(null, dataStorage);
-        },
-        true
-      );
+        })
+        .catch((err) => {
+          console.error('[SERVER] Cannot save the new data storage configuration', err);
+          // The connection was proven but persistence failed: drop the
+          // verified candidate rather than run live against settings a
+          // restart would not load, and let `getDBClient` rebuild from the
+          // untouched previous configuration.
+          dbClient = null;
+          candidate.close(() => {});
+          return callback(err);
+        });
     });
   });
 };

--- a/src/server/routes/db-connector.js
+++ b/src/server/routes/db-connector.js
@@ -126,7 +126,6 @@ const getDBClient = (callback) => {
 ///////////////
 // Data Storage
 ///////////////
-// Read a specific model by its name:
 
 /**
  * Read the service configuration, straight from the store.

--- a/src/server/routes/model.js
+++ b/src/server/routes/model.js
@@ -1,10 +1,9 @@
+'use strict';
 /* Working with Data Generator */
 var express = require('express');
-var path = require('path');
-var fs = require('fs');
 const Joi = require('joi');
 
-const { readJSONFile, writeToFile, readDir, deleteFile } = require('../../core/utils');
+const { createArtifactStore } = require('../artifact-store');
 const { isValidName, resolveWithin, sendBadRequest } = require('./path-safety');
 const {
   validate,
@@ -14,8 +13,39 @@ const {
   simulationRunFields,
 } = require('../middleware/validate');
 const { errorHandler, fileError, internal, conflict } = require('../middleware/errors');
-const modelsPath = `${__dirname}/../data/models/`;
+
+// The topologies live as records of the artifact store (issue #30): writes are
+// serialized under the store's lock and land atomically, so concurrent edits
+// queue up instead of discarding one another and a crash mid-write cannot leave
+// a truncated file behind. Existing loose files in the directory are adopted
+// as they are - there is no migration step. `TAS_MODELS_DIR` moves the store
+// (tests use this to work against a scratch directory).
+const modelsPath = process.env.TAS_MODELS_DIR || `${__dirname}/../data/models/`;
+const modelsStore = createArtifactStore({ root: modelsPath, label: 'models' });
 let router = express.Router();
+
+/**
+ * Translate an artifact-store failure into its HTTP answer: a taken name is a
+ * conflict, anything else is ours. Missing records never reach here - the
+ * store throws them with a native ENOENT code, which `fileError` maps to 404.
+ */
+const saveError = (next, err) => {
+  if (err && err.code === 'EARTIFACTCONFLICT') {
+    return next(conflict('A model with this name already exists'));
+  }
+  return next(internal('Cannot save the new configuration', err));
+};
+
+/**
+ * The rename variant of `saveError`: renaming needs the source record to
+ * exist, so its absence is answered as the missing resource it is.
+ */
+const renameError = (next, err) => {
+  if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) {
+    return next(fileError(err, 'Model not found', 'Cannot read the model file'));
+  }
+  return saveError(next, err);
+};
 
 // ---------------------------------------------------------------------------
 // Validation schemas for the model endpoints (issue #10)
@@ -56,16 +86,15 @@ const modelUpdateBody = Joi.object({
 
 // Read the list of models
 router.get('/', validate(), (req, res, next) => {
-  readDir(modelsPath, (err, files) => {
-    if (err) {
-      next(internal('Cannot read the models directory', err));
-    } else {
+  modelsStore
+    .list()
+    .then((models) => {
       res.send({
         error: null,
-        models: files.filter((f) => path.extname(f) === '.json'),
+        models,
       });
-    }
-  });
+    })
+    .catch((err) => next(internal('Cannot read the models directory', err)));
 });
 
 // Read a specific model by its name:
@@ -74,20 +103,20 @@ router.get(
   validate({ params: { fileName: modelNameParam } }),
   function (req, res, next) {
     const { fileName } = req.params;
-    const modelFile = resolveWithin(modelsPath, fileName);
-    if (!modelFile) {
+    // Containment, not validation: the schema has already established that the
+    // name is well formed, but the path it derives is still checked at the sink.
+    if (!resolveWithin(modelsStore.root, fileName)) {
       return sendBadRequest(res, 'Invalid model name');
     }
-    readJSONFile(modelFile, (err, data) => {
-      if (err) {
-        next(fileError(err, 'Model not found', 'Cannot read the model file'));
-      } else {
+    modelsStore
+      .read(fileName)
+      .then((data) => {
         res.send({
           error: null,
           model: data,
         });
-      }
-    });
+      })
+      .catch((err) => next(fileError(err, 'Model not found', 'Cannot read the model file')));
   }
 );
 
@@ -99,54 +128,64 @@ const MAX_DUPLICATE_CANDIDATES = 1000;
  * Derive the first available "<name> [Duplicated]" filename for a duplicate.
  * Every candidate is re-checked against the name allowlist, because the
  * suffix grows the name and the length cap may cut the search short.
+ *
+ * The search runs inside the caller's exclusive section, so no other mutation
+ * of the store can claim the found name between the probe and the write.
  * @param {String} sourceName The stored model name being duplicated
- * @returns {{name: String, path: String}|null} A free candidate, or null
+ * @param {Object} unlocked The artifact store's unlocked primitives
+ * @returns {Promise<{name: String, fileName: String}|null>} A free candidate, or null
  */
-const findFreeDuplicate = (sourceName) => {
+const findFreeDuplicate = async (sourceName, unlocked) => {
   for (let i = 1; i <= MAX_DUPLICATE_CANDIDATES; i++) {
     const candidate = i === 1 ? `${sourceName} [Duplicated]` : `${sourceName} [Duplicated] ${i}`;
     if (!isValidName(candidate)) continue;
-    const candidatePath = resolveWithin(modelsPath, `${candidate}.json`);
-    if (candidatePath && !fs.existsSync(candidatePath)) {
-      return { name: candidate, path: candidatePath };
+    const candidateFileName = `${candidate}.json`;
+    if (resolveWithin(modelsStore.root, candidateFileName)) {
+      try {
+        if (!(await unlocked.exists(candidateFileName))) {
+          return { name: candidate, fileName: candidateFileName };
+        }
+      } catch (_) {
+        // An unreadable directory answers "not free" and the search moves on.
+      }
     }
   }
   return null;
 };
 
 const duplicateModel = (fileName, res, next) => {
-  const modelFile = resolveWithin(modelsPath, fileName);
-  if (!modelFile) {
+  // Containment first: the rest of this handler works on names derived from it.
+  if (!resolveWithin(modelsStore.root, fileName)) {
     return sendBadRequest(res, 'Invalid model name');
   }
-  readJSONFile(modelFile, (err, data) => {
-    if (err) {
-      next(fileError(err, 'Model not found', 'Cannot read the model file'));
-    } else {
+  modelsStore
+    .withExclusive(async (unlocked) => {
+      const source = await unlocked.read(fileName);
       // Collision policy (issue #70): duplicating must never overwrite an
-      // earlier copy, so write to a name proven free and report exactly it.
-      const free = findFreeDuplicate(data.name);
+      // earlier copy, so write to a name proven free inside this exclusive
+      // section and report exactly it.
+      const free = await findFreeDuplicate(source.name, unlocked);
       if (!free) {
+        return { conflict: true };
+      }
+      await unlocked.writeRaw(`${free.name}.json`, { ...source, name: free.name });
+      return { modelFileName: `${free.name}.json` };
+    })
+    .then((outcome) => {
+      if (outcome.conflict) {
         return next(conflict('Cannot derive a free name for the duplicated model'));
       }
-      const newModel = { ...data, name: free.name };
-      const newFileName = `${free.name}.json`;
-      writeToFile(
-        free.path,
-        JSON.stringify(newModel),
-        (err2) => {
-          if (err2) {
-            next(internal('Cannot save the duplicated model', err2));
-          } else {
-            res.send({
-              modelFileName: newFileName,
-            });
-          }
-        },
-        true
-      );
-    }
-  });
+      res.send({ modelFileName: outcome.modelFileName });
+    })
+    .catch((err) => {
+      if (err.code === 'EARTIFACTPATH') {
+        return sendBadRequest(res, 'Invalid model name');
+      }
+      if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
+        return next(fileError(err, 'Model not found', 'Cannot read the model file'));
+      }
+      return next(internal('Cannot save the duplicated model', err));
+    });
 };
 
 const updateModel = (model, fileName, res, next) => {
@@ -157,54 +196,34 @@ const updateModel = (model, fileName, res, next) => {
     return sendBadRequest(res, 'Invalid model name');
   }
   const newName = `${name}.json`;
-  const oldModelFile = resolveWithin(modelsPath, fileName);
-  if (!oldModelFile) {
-    return sendBadRequest(res, 'Invalid model name');
-  }
-  const modelFile = resolveWithin(modelsPath, newName);
-  if (!modelFile) {
+  if (!resolveWithin(modelsStore.root, fileName) || !resolveWithin(modelsStore.root, newName)) {
     return sendBadRequest(res, 'Invalid model name');
   }
   if (fileName === newName) {
-    writeToFile(
-      modelFile,
-      JSON.stringify(model),
-      (err, data) => {
-        if (err) {
-          next(internal('Cannot save the new configuration', err));
-        } else {
-          res.send({
-            modelFileName: fileName,
-          });
-        }
-      },
-      true
-    );
+    modelsStore
+      .write(newName, model, { overwrite: true })
+      .then(() => {
+        res.send({
+          modelFileName: fileName,
+        });
+      })
+      .catch((err) => saveError(next, err));
   } else {
-    writeToFile(
-      modelFile,
-      JSON.stringify(model),
-      (err, data) => {
-        if (err) {
-          next(internal('Cannot save the new configuration', err));
-        } else {
-          // Delete the old model
-          deleteFile(oldModelFile, (err2) => {
-            if (err2) {
-              // The new file is already written, so the rename succeeded from the
-              // caller's point of view; the leftover is a server-side problem.
-              console.error(
-                `[SERVER] Cannot remove the renamed model file | ${err2.stack || err2}`
-              );
-            }
-            res.send({
-              modelFileName: newName,
-            });
-          });
-        }
-      },
-      true
-    );
+    // Rename inside the store: the copy under the new name lands atomically
+    // and the old one is removed within the same locked step, so a crash or a
+    // concurrent reader can never see both copies or neither.
+    modelsStore
+      .rename(fileName, newName)
+      .then(() => {
+        res.send({
+          modelFileName: newName,
+        });
+      })
+      .catch((err) =>
+        err && err.code === 'EARTIFACTCONFLICT'
+          ? next(conflict('A model with this name already exists'))
+          : renameError(next, err)
+      );
   }
 };
 
@@ -236,30 +255,21 @@ router.post('/', validate({ body: modelCreateBody }), function (req, res, next) 
   }
 
   const modelFileName = `${model.name}.json`;
-  const modelFilePath = resolveWithin(modelsPath, modelFileName);
-  if (!modelFilePath) {
+  if (!resolveWithin(modelsStore.root, modelFileName)) {
     return sendBadRequest(res, 'Invalid model name');
   }
-  // Collision policy (issue #70): refuse a duplicate name instead of letting
-  // writeToFile silently rename the target — the filename this handler returns
-  // must always be the exact file that was written.
-  if (fs.existsSync(modelFilePath)) {
-    return next(conflict('A model with this name already exists'));
-  }
-  writeToFile(
-    modelFilePath,
-    JSON.stringify(model),
-    (err, data) => {
-      if (err) {
-        next(internal('Cannot save the new configuration', err));
-      } else {
-        res.send({
-          modelFileName,
-        });
-      }
-    },
-    true
-  );
+  // Collision policy (issue #70), enforced by the store itself: the write
+  // refuses to replace an existing record, so duplicating a name is answered
+  // with a conflict and the filename this handler returns is always the exact
+  // record that was written.
+  modelsStore
+    .write(modelFileName, model)
+    .then(() => {
+      res.send({
+        modelFileName,
+      });
+    })
+    .catch((err) => saveError(next, err));
 });
 
 // Delete a model
@@ -268,19 +278,17 @@ router.delete(
   validate({ params: { fileName: modelNameParam } }),
   function (req, res, next) {
     const { fileName } = req.params;
-    const modelFile = resolveWithin(modelsPath, fileName);
-    if (!modelFile) {
+    if (!resolveWithin(modelsStore.root, fileName)) {
       return sendBadRequest(res, 'Invalid model name');
     }
-    deleteFile(modelFile, (err) => {
-      if (err) {
-        next(fileError(err, 'Model not found', 'Cannot delete the model file'));
-      } else {
+    modelsStore
+      .remove(fileName)
+      .then(() => {
         res.send({
           result: true,
         });
-      }
-    });
+      })
+      .catch((err) => next(fileError(err, 'Model not found', 'Cannot delete the model file')));
   }
 );
 

--- a/src/server/routes/simulation.js
+++ b/src/server/routes/simulation.js
@@ -5,10 +5,9 @@ const Joi = require('joi');
 const { OFFLINE } = require('../../core/DeviceStatus');
 let getLogger = require('../logger');
 const Simulation = require('../../core/simulation');
-const { readJSONFile } = require('../../core/utils');
+const { getObjectId } = require('../../core/utils');
 const { isValidName, resolveWithin, sendBadRequest } = require('./path-safety');
 const { getDataStorage } = require('./db-connector');
-const { getObjectId } = require('../../core/utils');
 const {
   validate,
   documentSchema,
@@ -27,7 +26,15 @@ const {
 
 let router = express.Router();
 const logsPath = `${__dirname}/../logs/simulations/`;
-const modelsPath = `${__dirname}/../data/models/`;
+// Stored topologies are records of the artifact store (issue #30) shared with
+// the model routes: reads see either a complete previous record or a complete
+// new one, never a half-written file. `TAS_MODELS_DIR` moves it (tests use a
+// scratch directory); the same override configures `routes/model.js`.
+const modelsPath = process.env.TAS_MODELS_DIR || `${__dirname}/../data/models/`;
+const modelsStore = require('../artifact-store').createArtifactStore({
+  root: modelsPath,
+  label: 'models',
+});
 // Every running-run record and in-process handle lives in the shared runtime
 // registry (issue #29) - nothing is tracked in this module's own variables any
 // more. The records are persisted, so they survive a restart and can be seen
@@ -284,17 +291,17 @@ const respondWithStatus = (res, extra = {}) => {
 router.post('/start', validate({ body: simulationStartBody }), function (req, res, next) {
   const { model, modelFileName, options } = req.body;
   if (modelFileName) {
-    const modelFilePath = resolveWithin(modelsPath, modelFileName);
-    if (!modelFilePath) {
+    // Containment, not validation: the schema has already established that the
+    // name is well formed, but the path it derives is still checked at the sink.
+    if (!resolveWithin(modelsStore.root, modelFileName)) {
       return sendBadRequest(res, 'Invalid model file name');
     }
-    readJSONFile(modelFilePath, (err, myModel) => {
-      if (err) {
-        next(fileError(err, 'Model not found', 'Cannot read the model file'));
-      } else {
+    modelsStore
+      .read(modelFileName)
+      .then((myModel) => {
         startSimulation(myModel, options, res, next, modelFileName).catch(next);
-      }
-    });
+      })
+      .catch((err) => next(fileError(err, 'Model not found', 'Cannot read the model file')));
   } else {
     startSimulation(model, options, res, next).catch(next);
   }

--- a/test/artifact-store.test.js
+++ b/test/artifact-store.test.js
@@ -138,6 +138,23 @@ test('a failed write cleans its temporary file and leaves the target intact', as
   assert.deepEqual(leftovers, [], 'the failed temporary file must be cleaned up');
 });
 
+test('a record JSON cannot represent is refused without leaving artifacts', async (t) => {
+  const root = scratchDir(t);
+  const store = createArtifactStore({ root, label: 'unit' });
+  await store.write('safe.json', { v: 1 });
+
+  const circular = {};
+  circular.self = circular;
+  await assert.rejects(store.write('circular.json', circular), TypeError);
+  // The failure happened before any file was touched: the store is unchanged
+  // and no temporary artifact was left behind.
+  assert.deepEqual(await store.list(), ['safe.json']);
+  assert.deepEqual(
+    fs.readdirSync(root).filter((f) => f.endsWith('.tmp')),
+    []
+  );
+});
+
 test('an unparsable record is quarantined, not served or deleted', async (t) => {
   const root = scratchDir(t);
   const store = createArtifactStore({ root, label: 'unit' });

--- a/test/artifact-store.test.js
+++ b/test/artifact-store.test.js
@@ -1,0 +1,204 @@
+// Unit tests for the artifact store (issue #30): the one place topology,
+// data-recorder and service-configuration records are read and written.
+//
+// The guarantees under test are exactly the ones the loose JSON files could
+// not make: writes are atomic (a crash mid-write leaves the previous record
+// readable, never a truncated file), mutations serialize (two overlapping
+// edits cannot silently discard one another), unparsable records are
+// quarantined instead of served or deleted, and record names cannot escape
+// the store's root directory. Every suite runs against a scratch directory -
+// nothing here touches a live database or the repository's data files.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const { createArtifactStore } = require('../src/server/artifact-store');
+
+function scratchDir(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tas-artifacts-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+test('write then read round-trips a record', async (t) => {
+  const store = createArtifactStore({ root: scratchDir(t), label: 'unit' });
+  const doc = { name: 'topology', devices: [{ id: 1 }] };
+  await store.write('topology.json', doc);
+  assert.deepEqual(await store.read('topology.json'), doc);
+});
+
+test('list returns only bare .json records, sorted, ignoring write artifacts', async (t) => {
+  const root = scratchDir(t);
+  const store = createArtifactStore({ root, label: 'unit' });
+  await store.write('b.json', {});
+  await store.write('a.json', {});
+  // Artifacts of an interrupted write / a quarantine must never be listed.
+  fs.writeFileSync(path.join(root, 'c.json.123.456.tmp'), '{');
+  fs.writeFileSync(path.join(root, 'd.json.corrupt-789'), '{');
+  assert.deepEqual(await store.list(), ['a.json', 'b.json']);
+});
+
+test('writing over an existing name without overwrite conflicts', async (t) => {
+  const store = createArtifactStore({ root: scratchDir(t), label: 'unit' });
+  await store.write('x.json', { v: 1 });
+  await assert.rejects(store.write('x.json', { v: 2 }), (err) => {
+    assert.equal(err.code, 'EARTIFACTCONFLICT');
+    return true;
+  });
+  assert.deepEqual(await store.read('x.json'), { v: 1 }, 'the original must survive');
+  await store.write('x.json', { v: 3 }, { overwrite: true });
+  assert.deepEqual(await store.read('x.json'), { v: 3 });
+});
+
+test('reading an absent record throws an ENOENT-shaped error', async (t) => {
+  const store = createArtifactStore({ root: scratchDir(t), label: 'unit' });
+  await assert.rejects(store.read('absent.json'), (err) => err.code === 'ENOENT');
+  await assert.rejects(store.remove('absent.json'), (err) => err.code === 'ENOENT');
+});
+
+test('rename moves the record and removes the old copy in one step', async (t) => {
+  const root = scratchDir(t);
+  const store = createArtifactStore({ root, label: 'unit' });
+  await store.write('old.json', { name: 'old' });
+  const renamed = await store.rename('old.json', 'new.json', (doc) => ({
+    ...doc,
+    name: 'new',
+  }));
+  assert.equal(renamed.name, 'new');
+  assert.deepEqual(await store.read('new.json'), { name: 'new' });
+  assert.deepEqual(await store.list(), ['new.json'], 'the old copy must be gone');
+});
+
+test('rename onto an existing name conflicts and keeps both records', async (t) => {
+  const store = createArtifactStore({ root: scratchDir(t), label: 'unit' });
+  await store.write('a.json', { v: 'a' });
+  await store.write('b.json', { v: 'b' });
+  await assert.rejects(store.rename('a.json', 'b.json'), (err) => {
+    assert.equal(err.code, 'EARTIFACTCONFLICT');
+    return true;
+  });
+  assert.deepEqual(await store.read('a.json'), { v: 'a' });
+  assert.deepEqual(await store.read('b.json'), { v: 'b' });
+});
+
+test('record names cannot escape the root directory', async (t) => {
+  const store = createArtifactStore({ root: scratchDir(t), label: 'unit' });
+  for (const bad of [
+    '../escape.json',
+    'sub/escape.json',
+    '/absolute.json',
+    '..',
+    '.',
+    'no-extension',
+    '',
+    null,
+  ]) {
+    await assert.rejects(
+      store.read(/** @type {*} */ (bad)),
+      (err) => err.code === 'EARTIFACTPATH',
+      `expected ${JSON.stringify(bad)} to be refused`
+    );
+  }
+});
+
+test('an interrupted write never damages the stored record', async (t) => {
+  const root = scratchDir(t);
+  const store = createArtifactStore({ root, label: 'unit' });
+  await store.write('rec.json', { generation: 1 });
+
+  // Simulate a crash mid-write: the temporary file is on disk, the rename
+  // never happened. The previous record must still read back whole, and the
+  // orphaned temporary file must not surface as a record.
+  fs.writeFileSync(path.join(root, 'rec.json.999.111.tmp'), '{"generation": 2');
+
+  assert.deepEqual(await store.read('rec.json'), { generation: 1 });
+  assert.deepEqual(await store.list(), ['rec.json']);
+});
+
+test('a failed write cleans its temporary file and leaves the target intact', async (t) => {
+  const root = scratchDir(t);
+  const store = createArtifactStore({ root, label: 'unit' });
+  await store.write('rec.json', { keep: true });
+
+  // Break exactly the rename step: the temp write succeeds, the swap fails.
+  const fsp = require('node:fs/promises');
+  const realRename = fsp.rename;
+  fsp.rename = async () => {
+    throw Object.assign(new Error('disk went away'), { code: 'EACCES' });
+  };
+  t.after(() => {
+    fsp.rename = realRename;
+  });
+
+  await assert.rejects(store.write('rec.json', { gone: true }, { overwrite: true }));
+  assert.deepEqual(await store.read('rec.json'), { keep: true });
+  const leftovers = fs.readdirSync(root).filter((f) => f.endsWith('.tmp'));
+  assert.deepEqual(leftovers, [], 'the failed temporary file must be cleaned up');
+});
+
+test('an unparsable record is quarantined, not served or deleted', async (t) => {
+  const root = scratchDir(t);
+  const store = createArtifactStore({ root, label: 'unit' });
+  fs.writeFileSync(path.join(root, 'broken.json'), '{"truncated": tru');
+
+  await assert.rejects(store.read('broken.json'), (err) => {
+    assert.equal(err.code, 'EARTIFACTCORRUPT');
+    return true;
+  });
+  assert.deepEqual(await store.list(), [], 'the broken record no longer lists');
+  const quarantined = fs.readdirSync(root).filter((f) => f.startsWith('broken.json.corrupt-'));
+  assert.equal(quarantined.length, 1, 'the content stays inspectable beside the original');
+});
+
+test('concurrent writes all land - none is lost, the file always parses', async (t) => {
+  const root = scratchDir(t);
+  const store = createArtifactStore({ root, label: 'unit' });
+
+  const writes = [];
+  for (let i = 0; i < 30; i++) {
+    writes.push(store.write(`rec-${i}.json`, { i }, { overwrite: true }));
+  }
+  await Promise.all(writes);
+
+  const listed = await store.list();
+  assert.equal(listed.length, 30);
+  for (const fileName of listed) {
+    const doc = await store.read(fileName);
+    assert.ok(Number.isInteger(doc.i), `${fileName} must hold one complete record`);
+  }
+});
+
+test('overlapping edits of one record serialize instead of discarding', async (t) => {
+  const root = scratchDir(t);
+  const store = createArtifactStore({ root, label: 'unit' });
+  await store.write('counter.json', { count: 0 });
+
+  // The lost-update shape from the issue: two writers each read the current
+  // state and write their own change back. Under the old full-file
+  // read-modify-write one writer's change silently vanished; serialized
+  // through the store, every increment survives.
+  const bump = () =>
+    store.withExclusive(async (unlocked) => {
+      const doc = await unlocked.read('counter.json');
+      await unlocked.writeRaw('counter.json', { count: doc.count + 1 });
+    });
+  await Promise.all([bump(), bump(), bump(), bump(), bump()]);
+
+  assert.deepEqual(await store.read('counter.json'), { count: 5 });
+});
+
+test('a lock left behind by a crashed holder is stolen once stale', async (t) => {
+  const root = scratchDir(t);
+  const store = createArtifactStore({ root, label: 'unit' });
+  const staleLock = path.join(root, '.unit.lock');
+  fs.writeFileSync(staleLock, '');
+  // Backdate far past LOCK_STALE_MS so the first retry steals it. utimesSync
+  // takes Date objects here - raw numbers are interpreted as seconds.
+  const staleTime = new Date(Date.now() - 60000);
+  fs.utimesSync(staleLock, staleTime, staleTime);
+
+  await store.write('after.json', { ok: true });
+  assert.deepEqual(await store.read('after.json'), { ok: true });
+});

--- a/test/config-reload.test.js
+++ b/test/config-reload.test.js
@@ -1,0 +1,138 @@
+// Configuration freshness (issue #30): the service configuration used to be
+// snapshotted into a module-level variable on first read and never revisited,
+// so a configuration change needed a server restart to reach every code path.
+// `getDataStorage` now reads through the artifact store on every call, which
+// these suites pin down.
+//
+// No live MongoDB: ENACTDB.prototype.connect is stubbed at the prototype seam
+// (the technique of test/data-storage-save.test.js), and the connector points
+// at a scratch directory through TAS_DATA_DIR, so no repository file and no
+// database is touched.
+const { test, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const express = require('express');
+const { request } = require('./_http');
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tas-config-'));
+process.env.TAS_DATA_DIR = dataDir;
+
+const dbcPath = require.resolve('../src/server/routes/db-connector');
+const routerPath = require.resolve('../src/server/routes/data-storage');
+const enactPath = require.resolve('../src/core/enact-mongoose');
+
+const dataStorageFile = path.join(dataDir, 'data-storage.json');
+
+const storedConfig = {
+  protocol: 'MONGODB',
+  connConfig: {
+    host: 'first-host',
+    port: 27017,
+    username: null,
+    password: null,
+    dbname: 'first_db',
+    options: null,
+  },
+};
+
+/**
+ * A fresh connector + router pair over the scratch directory.
+ *
+ * enact-mongoose deliberately stays cached so one prototype patch keeps
+ * applying, and the patch is (re)installed on every fresh build: the save
+ * path probes connectivity through it before anything is written, and no
+ * live database exists here. Patching per build rather than once in a hook
+ * keeps the stub in place no matter how the runner orders hooks.
+ */
+function freshApp() {
+  const enact = require(enactPath);
+  const originalConnect = enact.ENACTDB.prototype.connect;
+  enact.ENACTDB.prototype.connect = function (callback) {
+    this.isConnected = true;
+    return callback(null);
+  };
+  after(() => {
+    enact.ENACTDB.prototype.connect = originalConnect;
+  });
+  delete require.cache[dbcPath];
+  delete require.cache[routerPath];
+  const dataStorageRouter = require(routerPath);
+  const app = express();
+  app.use(express.json());
+  app.use('/api/data-storage', dataStorageRouter);
+  return app;
+}
+
+after(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+test('a configuration edited behind the running process is served without a restart', async () => {
+  fs.writeFileSync(dataStorageFile, JSON.stringify(storedConfig));
+  let app = freshApp();
+  let server = app.listen(0);
+
+  try {
+    const first = await request(server, 'GET', '/api/data-storage');
+    assert.equal(first.status, 200);
+    assert.equal(first.body.dataStorage.connConfig.host, 'first-host');
+
+    // An external change lands - an operator script, a deploy tool, another
+    // process. Nothing in this process is told about it; there is no cache to
+    // invalidate and none needed.
+    const editedConfig = {
+      ...storedConfig,
+      connConfig: { ...storedConfig.connConfig, host: 'second-host', dbname: 'second_db' },
+    };
+    fs.writeFileSync(dataStorageFile, JSON.stringify(editedConfig));
+
+    const second = await request(server, 'GET', '/api/data-storage');
+    assert.equal(second.status, 200);
+    assert.equal(
+      second.body.dataStorage.connConfig.host,
+      'second-host',
+      'the very next read must serve the new configuration - no restart'
+    );
+    assert.equal(second.body.dataStorage.connConfig.dbname, 'second_db');
+  } finally {
+    server.close();
+  }
+});
+
+test('saving through the API takes effect immediately, including on disk', async () => {
+  fs.writeFileSync(dataStorageFile, JSON.stringify(storedConfig));
+  const app = freshApp();
+  const server = app.listen(0);
+
+  try {
+    const updatedConfig = {
+      protocol: 'MONGODB',
+      connConfig: {
+        host: 'api-host',
+        port: 27119,
+        username: null,
+        password: null,
+        dbname: 'api_db',
+        options: null,
+      },
+    };
+    const saved = await request(server, 'POST', '/api/data-storage', {
+      dataStorage: updatedConfig,
+    });
+    assert.equal(saved.status, 200);
+    assert.equal(saved.body.dataStorage.connConfig.host, 'api-host');
+
+    // The response already carries the new configuration, and so does the
+    // store - atomically written, complete and parsable.
+    const onDisk = JSON.parse(fs.readFileSync(dataStorageFile, 'utf8'));
+    assert.equal(onDisk.connConfig.host, 'api-host');
+
+    // And a later read serves it back with no restart anywhere in between.
+    const readBack = await request(server, 'GET', '/api/data-storage');
+    assert.equal(readBack.body.dataStorage.connConfig.host, 'api-host');
+  } finally {
+    server.close();
+  }
+});

--- a/test/model-persistence.test.js
+++ b/test/model-persistence.test.js
@@ -1,0 +1,229 @@
+// Route-level tests for the durable artifact stores behind the topology and
+// data-recorder endpoints (issue #30).
+//
+// The loose JSON files these routes used to rewrite in full are now records
+// of the shared artifact store. These suites pin what that change buys at the
+// HTTP surface: concurrent creates of one name cannot both win, concurrent
+// updates cannot discard one another, a rename leaves exactly one record,
+// import/export still round-trip verbatim, and records that predate the
+// upgrade - plain files on disk - are adopted with no migration step.
+//
+// Both routers point at scratch directories through their environment
+// overrides before they are required; no repository data file is touched.
+const { test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const express = require('express');
+const { request } = require('./_http');
+
+const modelsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tas-models-'));
+const recordersDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tas-recorders-'));
+process.env.TAS_MODELS_DIR = modelsDir;
+process.env.TAS_DATA_RECORDERS_DIR = recordersDir;
+
+const modelRouter = require('../src/server/routes/model');
+const recorderRouter = require('../src/server/routes/data-recorders');
+
+let server;
+let app;
+
+before(() => {
+  app = express();
+  app.use(express.json());
+  app.use('/api/models', modelRouter);
+  app.use('/api/data-recorders', recorderRouter);
+  server = app.listen(0);
+});
+
+after(() => {
+  server.close();
+  fs.rmSync(modelsDir, { recursive: true, force: true });
+  fs.rmSync(recordersDir, { recursive: true, force: true });
+});
+
+const unique = (prefix) => `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+const modelBody = (name, marker) => ({
+  model: { name, devices: [{ id: 'dev-1', marker }] },
+});
+const recorderBody = (name) => ({
+  dataRecorder: { name, dataRecorders: [{ sensor: 's1' }] },
+});
+
+test('a topology round-trips: create, list, read back verbatim, delete', async () => {
+  const name = unique('roundtrip');
+  const fileName = `${name}.json`;
+  const body = modelBody(name, 'export-marker');
+
+  const created = await request(server, 'POST', '/api/models', body);
+  assert.equal(created.status, 200);
+  assert.equal(created.body.modelFileName, fileName);
+
+  const listed = await request(server, 'GET', '/api/models');
+  assert.ok(listed.body.models.includes(fileName), 'the created record must be listed');
+
+  // Export path: the dashboard downloads exactly this URL, so the stored
+  // record must come back complete and unchanged.
+  const exported = await request(server, 'GET', `/api/models/${encodeURIComponent(fileName)}`);
+  assert.equal(exported.status, 200);
+  assert.equal(exported.body.model.name, name);
+  assert.equal(exported.body.model.devices[0].marker, 'export-marker');
+
+  const removed = await request(server, 'DELETE', `/api/models/${encodeURIComponent(fileName)}`);
+  assert.equal(removed.status, 200);
+  const afterDelete = await request(server, 'GET', `/api/models/${encodeURIComponent(fileName)}`);
+  assert.equal(afterDelete.status, 404);
+});
+
+test('concurrent creates of the same topology name: exactly one wins', async () => {
+  const name = unique('race-create');
+  const fileName = `${name}.json`;
+  try {
+    const attempts = await Promise.all(
+      Array.from({ length: 5 }, () => request(server, 'POST', '/api/models', modelBody(name)))
+    );
+    const won = attempts.filter((res) => res.status === 200);
+    const conflicted = attempts.filter((res) => res.status === 409);
+    assert.equal(won.length, 1, `exactly one create may win, got ${won.length}`);
+    assert.equal(conflicted.length, 4, `the losers must conflict, got ${conflicted.length}`);
+
+    // No silently renamed copies may be left behind either.
+    const leftovers = fs
+      .readdirSync(modelsDir)
+      .filter((f) => f.startsWith(`${name}-`) && f.endsWith('.json'));
+    assert.deepEqual(leftovers, [], 'no timestamped leftover copies may appear');
+  } finally {
+    fs.rmSync(path.join(modelsDir, fileName), { force: true });
+  }
+});
+
+test('concurrent edits of different topologies both survive intact', async () => {
+  const first = unique('concurrent-a');
+  const second = unique('concurrent-b');
+  try {
+    await request(server, 'POST', '/api/models', modelBody(first));
+    await request(server, 'POST', '/api/models', modelBody(second));
+
+    // Both edits run at the same time and each writes its own record twice;
+    // neither may end up holding the other's content or a torn mixture.
+    const [editA, editB] = await Promise.all([
+      request(server, 'POST', `/api/models/${encodeURIComponent(`${first}.json`)}`, {
+        model: { name: first, devices: [{ id: 'd', owner: 'A' }] },
+      }),
+      request(server, 'POST', `/api/models/${encodeURIComponent(`${second}.json`)}`, {
+        model: { name: second, devices: [{ id: 'd', owner: 'B' }] },
+      }),
+    ]);
+    assert.equal(editA.status, 200);
+    assert.equal(editB.status, 200);
+
+    const readBackA = await request(
+      server,
+      'GET',
+      `/api/models/${encodeURIComponent(`${first}.json`)}`
+    );
+    const readBackB = await request(
+      server,
+      'GET',
+      `/api/models/${encodeURIComponent(`${second}.json`)}`
+    );
+    assert.equal(readBackA.body.model.devices[0].owner, 'A');
+    assert.equal(readBackB.body.model.devices[0].owner, 'B');
+  } finally {
+    fs.rmSync(path.join(modelsDir, `${first}.json`), { force: true });
+    fs.rmSync(path.join(modelsDir, `${second}.json`), { force: true });
+  }
+});
+
+test('renaming a topology leaves exactly one record under the new name', async () => {
+  const original = unique('rename-src');
+  const target = unique('rename-dst');
+  await request(server, 'POST', '/api/models', modelBody(original));
+
+  const renamed = await request(
+    server,
+    'POST',
+    `/api/models/${encodeURIComponent(`${original}.json`)}`,
+    { model: { name: target, devices: [] } }
+  );
+  assert.equal(renamed.status, 200);
+  assert.equal(renamed.body.modelFileName, `${target}.json`);
+
+  const oldGone = await request(
+    server,
+    'GET',
+    `/api/models/${encodeURIComponent(`${original}.json`)}`
+  );
+  const newPresent = await request(
+    server,
+    'GET',
+    `/api/models/${encodeURIComponent(`${target}.json`)}`
+  );
+  assert.equal(oldGone.status, 404, 'the old record must not linger');
+  assert.equal(newPresent.status, 200, 'the record must live under the new name');
+  fs.rmSync(path.join(modelsDir, `${target}.json`), { force: true });
+});
+
+test('records stored by an earlier version are adopted with no migration step', async () => {
+  // A file written by the previous release straight into the store directory:
+  // the upgraded server must list it, serve it and allow editing it as-is.
+  const legacyName = unique('legacy');
+  const legacyFile = `${legacyName}.json`;
+  fs.writeFileSync(
+    path.join(modelsDir, legacyFile),
+    JSON.stringify({ name: legacyName, devices: [{ id: 'legacy-dev' }] })
+  );
+
+  const listed = await request(server, 'GET', '/api/models');
+  assert.ok(listed.body.models.includes(legacyFile), 'the pre-upgrade record must be listed');
+
+  const read = await request(server, 'GET', `/api/models/${encodeURIComponent(legacyFile)}`);
+  assert.equal(read.status, 200);
+  assert.deepEqual(read.body.model.devices, [{ id: 'legacy-dev' }]);
+
+  // And it stays editable through the normal update route.
+  const updated = await request(server, 'POST', `/api/models/${encodeURIComponent(legacyFile)}`, {
+    model: { name: legacyName, devices: [{ id: 'legacy-dev', edited: true }] },
+  });
+  assert.equal(updated.status, 200);
+  const readEdited = await request(server, 'GET', `/api/models/${encodeURIComponent(legacyFile)}`);
+  assert.equal(readEdited.body.model.devices[0].edited, true);
+  fs.rmSync(path.join(modelsDir, legacyFile), { force: true });
+});
+
+test('data recorder CRUD rides the same store: duplicate answers its own name', async () => {
+  const name = unique('recorder');
+  const created = await request(server, 'POST', '/api/data-recorders/models', recorderBody(name));
+  assert.equal(created.status, 200);
+  assert.equal(created.body.dataRecorderFileName, `${name}.json`);
+
+  const duplicated = await request(
+    server,
+    'POST',
+    `/api/data-recorders/models/${encodeURIComponent(`${name}.json`)}`,
+    { isDuplicated: true }
+  );
+  assert.equal(duplicated.status, 200);
+  assert.equal(duplicated.body.dataRecorderFileName, `${name} [Duplicated].json`);
+
+  const dupRead = await request(
+    server,
+    'GET',
+    `/api/data-recorders/models/${encodeURIComponent(`${name} [Duplicated].json`)}`
+  );
+  assert.equal(dupRead.status, 200);
+  assert.equal(dupRead.body.dataRecorder.name, `${name} [Duplicated]`);
+  assert.deepEqual(dupRead.body.dataRecorder.dataRecorders, [{ sensor: 's1' }]);
+
+  await request(
+    server,
+    'DELETE',
+    `/api/data-recorders/models/${encodeURIComponent(`${name}.json`)}`
+  );
+  await request(
+    server,
+    'DELETE',
+    `/api/data-recorders/models/${encodeURIComponent(`${name} [Duplicated].json`)}`
+  );
+});


### PR DESCRIPTION
Closes #30

## Summary

Topologies, data-recorder definitions and the service configuration were stored as loose JSON files that every route read and rewrote in full: two concurrent edits silently discarded one another, a crash partway through a write could leave a truncated file that no longer parsed, and the service configuration was snapshotted into a module variable on first read so some changes needed a restart. All three artefact sets are now records of one durable artifact store that serialises concurrent edits under an advisory lock and lands every write via fsync + atomic rename; the configuration is served fresh on every read. Existing files are adopted in place - upgrading needs no manual step - and topology import/export still round-trip the same JSON.

## Approach

Shared durable artifact store (the issue's explicit fallback path): records keep one file each under the existing directories, but all I/O goes through a store whose mutations run under an O_EXCL advisory lock (stale locks stolen, as in the runtime-state registry) and whose writes land in an fsynced temporary file renamed over the target, so a concurrent reader sees either the old record or the new one and a crash can never leave an unparsable record. Unparsable records are quarantined beside the original instead of being served or silently deleted.

## Decision Record

- **Root cause:** full-file read-modify-write with no locking and no atomicity across three route modules, plus a never-invalidated in-memory snapshot of the service configuration.
- **Options considered:** Option 1 — move records into MongoDB via Mongoose schemas; Option 2 — shared artifact store writing atomically under a lock, records adopted in place; Option 3 — inline tmp+rename and lockfiles sprinkled through each route.
- **Options rejected:** Option 1 — makes every topology edit hard-depend on a reachable MongoDB (an availability regression for the primary editor workflow), contradicts the documented lazy-data-layer constraint (#18) and the runtime-state precedent (#29), breaks the DB-less route test suites, and cannot host data-storage.json itself (it configures the connection it would live in); Option 3 — duplicates lock/quarantine logic three times, leaves simulation start reading outside the store, no single seam to test.
- **Selected option:** Option 2 — shared durable artifact store.
- **Residual risk:** on cross-process lock contention beyond the 5s timeout a mutation proceeds unlocked (inherited from the reviewed #29 precedent); single-process correctness never depends on it.
- **Design-confirm:** auto-selected Option 2 (complexity: high)

Analyzed at: `refactor/30-replace-the-json-file-datastore-for @ 9415d38` (2026-08-25)

## Changes

| File | Change |
|------|--------|
| `src/server/artifact-store/index.js` | New: locked, atomic, quarantine-on-corruption record store over one directory of JSON records |
| `src/server/routes/model.js` | Topology CRUD routed through the store; create conflicts enforced by the store; rename is one atomic locked step; duplicate name search runs inside an exclusive section |
| `src/server/routes/data-recorders.js` | Recorder CRUD, duplicate and start-by-file routed through the same store; identical response shapes preserved |
| `src/server/routes/simulation.js` | Start-by-file reads topologies through the store, never a half-written file |
| `src/server/routes/db-connector.js` | Configuration read fresh from the store on every call (no stale cache); save persists through the atomic locked write; fresh-volume bootstrap unchanged |
| `env.example` | Documents TAS_MODELS_DIR / TAS_DATA_RECORDERS_DIR / TAS_DATA_DIR overrides |
| `test/artifact-store.test.js` | New: atomicity, serialization, quarantine, containment, crash-artifact cleanup, stale-lock recovery |
| `test/model-persistence.test.js` | New: route-level concurrency (one winner out of five racing creates), rename leaves exactly one record, pre-upgrade files adopted verbatim, export round-trip |
| `test/config-reload.test.js` | New: external configuration edit served without restart; API save effective immediately and complete on disk |

## Test Results

- Unit tests: 528 passed, 5 skipped (full suite, `npm test`)
- Integration tests: included above (route-level suites)
- E2e tests: included above (unchanged browser/e2e suites green)
- Build: lint clean (0 errors; the 2 warnings pre-exist on origin/master)
- QA cycles: 2

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Topologies and data recorders are stored durably with no full-file rewrite on each change | pass | Each change rewrites only its own record via fsync + atomic rename (`artifact-store/index.js`, `writeRecordAtomic`); `test/artifact-store.test.js` "write then read round-trips" + interrupted-write suite |
| Two concurrent edits to the same record cannot silently discard one another | pass | Mutations serialize under the store lock; `test/artifact-store.test.js` "overlapping edits of one record serialize" (5 concurrent bumps → count 5) and `test/model-persistence.test.js` racing creates (exactly one 200, four 409) |
| A crash during a write cannot leave a record unreadable | pass | Temp+rename swap; `test/artifact-store.test.js` interrupted-write and failed-write cleanup suites; unparsable records are quarantined, not served or deleted |
| A configuration change takes effect without a restart | pass | `getDataStorage` reads fresh per call (`db-connector.js:144`); `test/config-reload.test.js` external-edit suite serves the new host on the next request |
| Existing records stored as files are migrated automatically on upgrade | pass | Records are adopted in place - nothing moves; `test/model-persistence.test.js` "records stored by an earlier version are adopted with no migration step" lists, reads and edits a legacy plain file |
| Import and export of a topology as a JSON file still work for users | pass | Same names, same routes, same shapes; dashboard export URL `GET /api/models/:fileName` round-trips verbatim in `test/model-persistence.test.js` |

<!-- gitissue:qa v1 head=9415d385dc0ee8a0c698ec4259c9acff8763ae29 profile=full cycles=2 review=clean tests=528@9415d385dc0ee8a0c698ec4259c9acff8763ae29 ui=none -->
