### PR TITLE
feat(e2e): deployment smoke gate on the composed stack (#49)

### DIFF
--- a/.github/workflows/build-docker-container.yml
+++ b/.github/workflows/build-docker-container.yml
@@ -39,7 +39,7 @@ jobs:
 
   publish:
     name: Build, scan and publish the image
-    needs: test
+    needs: [test, smoke]
     runs-on: ubuntu-latest
 
     steps:
@@ -83,9 +83,11 @@ jobs:
         with:
           image-ref: 'tas:release-scan'
           format: table
-          exit-code: '0'
+          # A known, fixable CRITICAL in a published image blocks the release
+          # (issue #49): this gate runs before anything is pushed.
+          exit-code: '1'
           ignore-unfixed: true
-          severity: CRITICAL,HIGH
+          severity: CRITICAL
 
       - name: Push version tag
         run: docker push "ghcr.io/montimage/tas:${PACKAGE_VERSION}"
@@ -95,3 +97,54 @@ jobs:
       - name: Push latest tag
         if: env.IS_STABLE == 'true'
         run: docker push "ghcr.io/montimage/tas:latest"
+
+  smoke:
+    name: Deployment smoke test on the composed stack
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      # The smoke suite drives the composition over its published ports and
+      # hashes the administrator credential locally; production dependencies
+      # (the mqtt client among them) are all it needs.
+      - name: Install dependencies
+        run: npm ci --omit=dev
+
+      # Provision exactly as README.md documents for real use: hash the
+      # password where it is set and hand the composition only the scrypt
+      # digest plus a session secret. docker-compose.yml interpolates them.
+      - name: Provision the smoke administrator credential
+        env:
+          TAS_SMOKE_ADMIN_USERNAME: smoke-admin
+          TAS_SMOKE_ADMIN_PASSWORD: change-me-smoke-admin
+        run: |
+          HASH="$(node -p 'require("./src/server/auth/passwords").hashPassword(process.env.TAS_SMOKE_ADMIN_PASSWORD)')"
+          echo "TAS_SMOKE_ADMIN_USERNAME=$TAS_SMOKE_ADMIN_USERNAME" >> "$GITHUB_ENV"
+          echo "TAS_SMOKE_ADMIN_PASSWORD=$TAS_SMOKE_ADMIN_PASSWORD" >> "$GITHUB_ENV"
+          echo "AUTH_ADMIN_USERNAME=$TAS_SMOKE_ADMIN_USERNAME" >> "$GITHUB_ENV"
+          echo "AUTH_ADMIN_PASSWORD_HASH=$HASH" >> "$GITHUB_ENV"
+          echo "SESSION_SECRET=$(openssl rand -hex 32)" >> "$GITHUB_ENV"
+
+      # The documented quick start, verbatim: one command from a clean
+      # checkout brings up broker, app and flow editor with their health
+      # checks. A failure here fails the job before anything is published.
+      - name: Bring up the composed stack
+        run: docker compose up -d
+
+      - name: Run the deployment smoke suite
+        env:
+          TAS_SMOKE_COMPOSE: '1'
+        run: node --test test/e2e/deployment-smoke.test.js
+
+      - name: Tear the composed stack down
+        if: always()
+        run: docker compose down -v --remove-orphans

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ All notable changes to TaS are documented in this file. Releases are cut as
 
 ### Added
 
+- **Phase 6 milestone gate — deployment smoke test** (#49):
+  `test/e2e/deployment-smoke.test.js` brings up the published composition
+  exactly as a new user would (`docker compose up -d`, credentials provisioned
+  as README.md documents) and asserts the dashboard, API health, authenticated
+  broker and flow editor are reachable; a complete workflow (topology →
+  producing simulation through the internal broker listener → clean stop)
+  succeeds against the deployed stack; restarting each service independently
+  leaves the others running and everything recovers; the application runs as a
+  non-root user with Phase 0 containment and anonymous-access rejection intact.
+  The release workflow runs it on every `v*` tag between the test gate and
+  publishing (`needs: [test, smoke]`), and its Trivy scan now blocks
+  publication on any known fixable CRITICAL vulnerability. Published host
+  ports became overridable (`TAS_HOST_BROKER_PORT`, `TAS_HOST_APP_PORT`,
+  `TAS_HOST_NODERED_PORT`) without changing any default.
 - **Phase 4 milestone gate** (#33): `test/e2e/modernised-workflow.test.js`
   drives the complete product workflow end to end on the modernised stack —
   define a topology, record data through a data recorder, replay the recorded

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,8 +51,9 @@ services:
       # the README forbids publishing these ports to 0.0.0.0. Operators
       # override the bind address for trusted-network deployments. The
       # anonymous internal listener (1884) stays inside the compose network
-      # by construction.
-      - '127.0.0.1:1883:1883'
+      # by construction. Set TAS_HOST_BROKER_PORT to move the published side
+      # when the host already owns 1883.
+      - '127.0.0.1:${TAS_HOST_BROKER_PORT:-1883}:1883'
     healthcheck:
       # Probe the anonymous loopback listener from inside the broker's own
       # container: a broker that answers there is up and dispatching.
@@ -84,7 +85,9 @@ services:
       AUTH_ADMIN_USERNAME: ${AUTH_ADMIN_USERNAME:-admin}
       AUTH_ADMIN_PASSWORD_HASH: ${AUTH_ADMIN_PASSWORD_HASH:-}
     ports:
-      - '127.0.0.1:3004:3004'
+      # Published host sides are movable for busy machines; the container
+      # sides never change.
+      - '127.0.0.1:${TAS_HOST_APP_PORT:-3004}:3004'
     healthcheck:
       test:
         [
@@ -109,7 +112,7 @@ services:
       - ./node-red-flows/202402-temperature-controller.json:/data/flows.json:ro
       - nodered-data:/data
     ports:
-      - '127.0.0.1:1880:1880'
+      - '127.0.0.1:${TAS_HOST_NODERED_PORT:-1880}:1880'
     healthcheck:
       test:
         [

--- a/test/ci-gate.test.js
+++ b/test/ci-gate.test.js
@@ -109,6 +109,10 @@ test('dependabot proposes npm updates for both manifests, weekly', () => {
 
 test('the image publish is gated by the same suite command the PR gate runs', () => {
   const release = stripComments(readWorkflow('build-docker-container.yml'));
-  assert.match(release, /^ {4}needs:\s*test\s*$/m, 'publish must need the test job');
+  assert.match(
+    release,
+    /^ {4}needs:\s*\[test,\s*smoke\]\s*$/m,
+    'publish must need the test and smoke jobs'
+  );
   assert.match(release, /run:\s*npm test\s*$/m, 'the release gate must run the full suite');
 });

--- a/test/dockerfile.test.js
+++ b/test/dockerfile.test.js
@@ -160,9 +160,11 @@ test('startup order follows health, not guesswork', () => {
 });
 
 test('only the loopback-bound authenticated broker listener is published to the host', () => {
+  // The published host side is movable for busy machines (issue #49) but the
+  // default stays 1883 and the container side never changes.
   assert.match(
     serviceBlock('broker'),
-    /-\s*['"]127\.0\.0\.1:1883:1883['"]/,
+    /-\s*['"]127\.0\.0\.1:\$\{TAS_HOST_BROKER_PORT:-1883\}:1883['"]/,
     'the broker must publish 1883 on the host loopback interface'
   );
   // Every published mapping of every service binds its host side to
@@ -170,7 +172,7 @@ test('only the loopback-bound authenticated broker listener is published to the 
   // forbids publishing these ports to 0.0.0.0. Operators override for
   // trusted-network deployments.
   for (const service of ['broker', 'app', 'nodered']) {
-    const maps = serviceBlock(service).match(/-\s*['"][\w.]*:?\d+:\d+['"]/g) || [];
+    const maps = serviceBlock(service).match(/-\s*['"][^'"]+:\d+['"]/g) || [];
     assert.ok(maps.length > 0, `${service} must publish at least one port`);
     for (const mapping of maps) {
       assert.match(
@@ -182,7 +184,7 @@ test('only the loopback-bound authenticated broker listener is published to the 
   }
   // Only quoted host:container mappings count as publications; prose comments
   // mention the internal port by name.
-  const published = (serviceBlock('broker').match(/-\s*['"][\w.]*:?\d+:\d+['"]/g) || []).join('\n');
+  const published = (serviceBlock('broker').match(/-\s*['"][^'"]+:\d+['"]/g) || []).join('\n');
   assert.ok(!/\b1884\b/.test(published), 'the anonymous internal listener must never be published');
   assert.match(
     composedBrokerConf,

--- a/test/e2e/deployment-smoke.test.js
+++ b/test/e2e/deployment-smoke.test.js
@@ -1,0 +1,615 @@
+/**
+ * End-to-end deployment smoke test on the composed stack (issue #49) — the
+ * Phase 6 milestone gate and the final gate of the improvement programme.
+ *
+ * Every other suite drives a server spawned by the test harness. This one
+ * brings up the PUBLISHED COMPOSITION exactly as a new user would — the
+ * documented quick start (`docker compose up -d`) from this checkout, with
+ * credentials provisioned the way README.md documents — and asserts what the
+ * preceding milestones established still holds in a real deployment:
+ *
+ *   - the quick start brings up a healthy three-service deployment (#45)
+ *   - the dashboard, API health endpoint, authenticated broker and flow
+ *     editor are each reachable
+ *   - a complete workflow succeeds against the deployed stack: define a
+ *     topology, run a producing simulation through the composition's internal
+ *     broker listener, watch the data arrive, stop cleanly
+ *   - restarting each service independently leaves the others running and
+ *     everything recovers
+ *   - the application process runs as a non-root user (#8) and the Phase 0
+ *     containment assertions still hold against the deployed API
+ *   - anonymous access is rejected across the deployed API (#9)
+ *
+ * The published-image vulnerability scan and the release wiring that makes
+ * this suite block publication are pinned statically in
+ * test/release-workflow.test.js and enforced by the release workflow itself.
+ *
+ * The suite is opt-in because it needs Docker and owns the checkout's compose
+ * project (including its published host ports 3004, 1883 and 1880, which can
+ * be moved with TAS_SMOKE_APP_PORT / TAS_SMOKE_MQTT_PORT /
+ * TAS_SMOKE_NODERED_PORT when the host already owns them):
+ *
+ *   TAS_SMOKE_COMPOSE=1 node --test test/e2e/deployment-smoke.test.js
+ *
+ * Without it every runtime test skips with that reason, so plain `npm test`
+ * stays green on a bare checkout. The release workflow sets the flag.
+ */
+const { test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const net = require('node:net');
+const crypto = require('node:crypto');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const mqtt = require('mqtt');
+
+const repoRoot = path.resolve(__dirname, '../..');
+
+const enabled = process.env.TAS_SMOKE_COMPOSE === '1';
+const skipReason = 'set TAS_SMOKE_COMPOSE=1 to run the composed-deployment smoke test';
+
+/** Where the composition publishes each service on the host (README table). */
+const mqttHost = process.env.TAS_SMOKE_MQTT_HOST || '127.0.0.1';
+const hostBrokerPort = Number(process.env.TAS_SMOKE_MQTT_PORT || 1883);
+const hostAppPort = Number(process.env.TAS_SMOKE_APP_PORT || 3004);
+const hostNoderedPort = Number(process.env.TAS_SMOKE_NODERED_PORT || 1880);
+const appUrl = process.env.TAS_SMOKE_APP_URL || `http://127.0.0.1:${hostAppPort}`;
+const noderedUrl = process.env.TAS_SMOKE_NODERED_URL || `http://127.0.0.1:${hostNoderedPort}`;
+const mqttPort = hostBrokerPort;
+
+/**
+ * Broker account seeded on first start (README quick-start defaults) and the
+ * administrator credential provisioned for the application.
+ */
+const brokerUsername = process.env.TAS_SMOKE_MOSQUITTO_USERNAME || 'tas';
+const brokerPassword = process.env.TAS_SMOKE_MOSQUITTO_PASSWORD || 'change-me-broker';
+const adminUsername = process.env.TAS_SMOKE_ADMIN_USERNAME || 'smoke-admin';
+const adminPassword = process.env.TAS_SMOKE_ADMIN_PASSWORD || 'tas-smoke-admin-password';
+
+/** Polling cadence: gentle enough to stay far below the default API limit. */
+const POLL_INTERVAL_MS = 750;
+const READY_TIMEOUT_MS = 180000;
+const RECOVER_TIMEOUT_MS = 60000;
+const PRODUCE_TIMEOUT_MS = 30000;
+
+let broughtUp = false;
+let authHeaders = null;
+
+// ---------------------------------------------------------------------------
+// Composition and HTTP helpers
+// ---------------------------------------------------------------------------
+
+function compose(args, { env = {}, ignoreFailure = false } = {}) {
+  try {
+    return execFileSync('docker', ['compose', ...args], {
+      cwd: repoRoot,
+      env: { ...process.env, ...env },
+      encoding: 'utf8',
+    }).trim();
+  } catch (error) {
+    if (ignoreFailure) return null;
+    throw error;
+  }
+}
+
+/** Container id of one compose service (empty when it has none). */
+const containerId = (service) => compose(['ps', '-q', service], { ignoreFailure: true }) || '';
+
+function inspect(service, format) {
+  const id = containerId(service);
+  if (!id) return null;
+  return execFileSync('docker', ['inspect', '--format', format, id], {
+    encoding: 'utf8',
+  }).trim();
+}
+
+/** Running state plus health and start time for one long-running service. */
+function serviceState(service) {
+  return {
+    running: inspect(service, '{{.State.Running}}') === 'true',
+    healthy: inspect(service, '{{.State.Health.Status}}'),
+    startedAt: inspect(service, '{{.State.StartedAt}}'),
+  };
+}
+
+const serviceStates = () =>
+  Object.fromEntries(['app', 'broker', 'nodered'].map((s) => [s, serviceState(s)]));
+
+function request(base, method, requestPath, { body, headers = {} } = {}) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(requestPath, base);
+    const data = body ? JSON.stringify(body) : null;
+    const req = http.request(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: `${url.pathname}${url.search}`,
+        method,
+        headers: {
+          ...(data ? { 'Content-Type': 'application/json' } : {}),
+          ...headers,
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
+          raw += chunk;
+        });
+        res.on('end', () => {
+          let parsed = null;
+          try {
+            parsed = JSON.parse(raw);
+          } catch (_) {
+            /* not JSON */
+          }
+          resolve({ status: res.statusCode, headers: res.headers, raw, body: parsed });
+        });
+      }
+    );
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+/** Poll a predicate (sync or async) until it holds or the deadline passes. */
+async function eventually(probe, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = await Promise.resolve()
+      .then(probe)
+      .catch(() => false);
+    if (result) return result;
+    if (Date.now() >= deadline) {
+      return (
+        (await Promise.resolve()
+          .then(probe)
+          .catch(() => false)) || false
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+}
+
+function tcpOpen(host, port, timeoutMs = 1500) {
+  return new Promise((resolve) => {
+    const socket = net.connect({ host, port });
+    const settle = (answer) => {
+      socket.destroy();
+      resolve(answer);
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once('connect', () => settle(true));
+    socket.once('timeout', () => settle(false));
+    socket.once('error', () => settle(false));
+  });
+}
+
+/**
+ * Connect to the published broker listener with credentials and prove the
+ * connection carries traffic: subscribe, publish, receive.
+ */
+function authenticatedRoundtrip(topic) {
+  return new Promise((resolve, reject) => {
+    const client = mqtt.connect(`mqtt://${mqttHost}:${mqttPort}`, {
+      username: brokerUsername,
+      password: brokerPassword,
+      connectTimeout: 10000,
+      reconnectPeriod: 0,
+    });
+    const fail = (error) => {
+      client.end(true);
+      reject(error);
+    };
+    client.on('error', fail);
+    client.on('connect', () => {
+      client.subscribe(topic, (subscribeError) => {
+        if (subscribeError) return fail(subscribeError);
+        client.publish(topic, 'smoke', (publishError) => {
+          if (publishError) return fail(publishError);
+        });
+      });
+    });
+    client.on('message', (received, payload) => {
+      client.end(true, {}, () =>
+        received === topic && String(payload) === 'smoke'
+          ? resolve()
+          : reject(new Error(`roundtrip mismatch on ${received}`))
+      );
+    });
+    setTimeout(() => fail(new Error('broker roundtrip timed out')), 15000);
+  });
+}
+
+/** An MQTT connect attempt as a boolean outcome instead of a thrown error. */
+function mqttConnectSucceeds(options) {
+  return new Promise((resolve) => {
+    const client = mqtt.connect(`mqtt://${mqttHost}:${mqttPort}`, {
+      connectTimeout: 5000,
+      reconnectPeriod: 0,
+      ...options,
+    });
+    client.once('connect', () => {
+      client.end(true);
+      resolve(true);
+    });
+    client.once('close', () => resolve(false));
+    client.once('error', () => resolve(false));
+  });
+}
+
+/** Log in to the deployed app and return the session headers for later calls. */
+async function logIn() {
+  const res = await request(appUrl, 'POST', '/api/auth/login', {
+    body: { username: adminUsername, password: adminPassword },
+  });
+  assert.equal(res.status, 200, `deployed login must succeed: ${res.raw}`);
+  assert.ok(res.body && res.body.csrfToken, `expected a CSRF token: ${res.raw}`);
+  const cookie = (res.headers['set-cookie'] || []).map((c) => c.split(';')[0]).join('; ');
+  return { Cookie: cookie, 'X-CSRF-Token': res.body.csrfToken };
+}
+
+/** True when every long-running service answers the way README promises. */
+async function stackHealthy() {
+  const health = await request(appUrl, 'GET', '/api/health');
+  if (health.status !== 200) return false;
+  if (!(await tcpOpen(mqttHost, mqttPort))) return false;
+  const editor = await request(noderedUrl, 'GET', '/');
+  return editor.status >= 200 && editor.status < 400;
+}
+
+/**
+ * A topology with one generator sensor behind the composition's internal
+ * listener: starts producing without needing a database, exactly like the
+ * Phase 4 gate's generating topology. Document defaults keep their historical
+ * localhost shape; the deployed app resolves them through TAS_MQTT_* (#45).
+ */
+const generatingTopology = (name) => ({
+  name,
+  devices: [
+    {
+      id: 'device-01',
+      name: 'Smoke Generator',
+      enable: true,
+      scale: 1,
+      behaviours: [],
+      timeToFailed: 0,
+      testBroker: {
+        protocol: 'MQTT',
+        connConfig: { host: '127.0.0.1', port: 1884, options: null },
+      },
+      productionBroker: null,
+      isReplayingStreams: false,
+      sensors: [
+        {
+          id: 'smoke-sensor',
+          objectId: null,
+          name: 'Smoke Sensor',
+          enable: true,
+          topic: `sensors/${name}/data`,
+          dataSource: 'DATA_SOURCE_GENERATOR',
+          replayOptions: null,
+          dataSpecs: {
+            timePeriod: 1,
+            sources: [{ type: 'DATA_SOURCE_INTEGER', key: 'value', initValue: 1 }],
+          },
+        },
+      ],
+      actuators: [],
+      upStreams: [],
+      downStreams: [],
+    },
+  ],
+});
+
+/** A storage configuration that can never be reached, so nothing persists. */
+const deadStorage = () => ({
+  protocol: 'MONGODB',
+  connConfig: {
+    host: '127.0.0.1',
+    port: 1,
+    username: null,
+    password: null,
+    dbname: null,
+    options: null,
+  },
+});
+
+const stopRun = (name) =>
+  request(appUrl, 'GET', `/api/simulation/stop/${encodeURIComponent(name)}.json`, {
+    headers: authHeaders,
+  });
+
+// ---------------------------------------------------------------------------
+
+before(async () => {
+  if (!enabled) return;
+  // Fail fast with a readable message when Docker is missing entirely.
+  execFileSync('docker', ['compose', 'version'], { stdio: 'pipe' });
+
+  // A crashed earlier run of this suite (or a quick start the operator
+  // abandoned) leaves this project's containers and volumes behind; they
+  // would collide with the clean start under test. Recover the project to a
+  // pristine state — this touches only this checkout's compose project.
+  if (compose(['ps', '-q'], { ignoreFailure: true })) {
+    compose(['down', '-v', '--remove-orphans'], { ignoreFailure: true });
+  }
+
+  // Provision exactly as README.md documents for real use: hash the password
+  // where it is set, hand compose only the scrypt digest and a session secret.
+  // docker-compose.yml interpolates all three from the calling environment,
+  // alongside the movable published host ports.
+  const hash = require(`${repoRoot}/src/server/auth/passwords`).hashPassword(adminPassword);
+  // Flag before bringing anything up: whatever fails below, the after hook
+  // must always tear this project back down instead of stranding containers.
+  broughtUp = true;
+  compose(['up', '-d'], {
+    env: {
+      SESSION_SECRET: crypto.randomBytes(32).toString('hex'),
+      AUTH_ADMIN_USERNAME: adminUsername,
+      AUTH_ADMIN_PASSWORD_HASH: hash,
+      MOSQUITTO_USERNAME: brokerUsername,
+      MOSQUITTO_PASSWORD: brokerPassword,
+      TAS_HOST_BROKER_PORT: String(hostBrokerPort),
+      TAS_HOST_APP_PORT: String(hostAppPort),
+      TAS_HOST_NODERED_PORT: String(hostNoderedPort),
+    },
+  });
+
+  const ready = await eventually(async () => {
+    const health = await request(appUrl, 'GET', '/api/health').catch(() => null);
+    return Boolean(health && health.status === 200) && (await tcpOpen(mqttHost, mqttPort));
+  }, READY_TIMEOUT_MS);
+  assert.ok(ready, 'the quick-start deployment never became reachable');
+});
+
+after(() => {
+  if (!enabled || !broughtUp) return;
+  compose(['down', '-v', '--remove-orphans'], { ignoreFailure: true });
+});
+
+// ---------------------------------------------------------------------------
+// AC1 + AC2 — the documented quick start brings up a working, healthy stack
+// ---------------------------------------------------------------------------
+
+test(
+  'quick start: the three services are up and healthy',
+  { skip: !enabled && skipReason },
+  async () => {
+    // `up -d` returns as soon as containers start; each service's readiness
+    // probe has its own start period. A working deployment is one whose
+    // health checks are green, so wait for that.
+    const healthy = await eventually(
+      () => ['app', 'broker', 'nodered'].every((s) => serviceState(s).healthy === 'healthy'),
+      READY_TIMEOUT_MS
+    );
+    assert.ok(healthy, 'the three services must report healthy from their own probes');
+    const states = serviceStates();
+    for (const service of ['app', 'broker', 'nodered']) {
+      assert.ok(states[service].running, `${service} container must be running`);
+      assert.equal(
+        states[service].healthy,
+        'healthy',
+        `${service} must report healthy from its own readiness probe`
+      );
+    }
+  }
+);
+
+test(
+  'dashboard: the deployed app serves the dashboard over HTTP',
+  { skip: !enabled && skipReason },
+  async () => {
+    const res = await request(appUrl, 'GET', '/');
+    assert.equal(res.status, 200, `the dashboard root must answer: ${res.raw.slice(0, 200)}`);
+    assert.match(
+      String(res.headers['content-type'] || ''),
+      /text\/html/,
+      'the dashboard root must be HTML'
+    );
+  }
+);
+
+test(
+  'api: the deployed app reports readiness on /api/health',
+  { skip: !enabled && skipReason },
+  async () => {
+    const res = await request(appUrl, 'GET', '/api/health');
+    assert.equal(res.status, 200, `health must answer 200: ${res.raw}`);
+    assert.equal(res.body && res.body.status, 'ok', `health must report ok: ${res.raw}`);
+  }
+);
+
+test(
+  'broker: the published listener authenticates clients and carries traffic',
+  { skip: !enabled && skipReason },
+  async () => {
+    // The published 1883 refuses anonymous access by policy (issue #46).
+    assert.ok(
+      !(await mqttConnectSucceeds({})),
+      'the published broker listener must refuse anonymous access'
+    );
+    // And the authenticated quick-start account carries real traffic.
+    await authenticatedRoundtrip('tas-smoke/broker-roundtrip');
+  }
+);
+
+test(
+  'flow editor: Node-RED serves the editor with the demo flow preloaded',
+  { skip: !enabled && skipReason },
+  async () => {
+    const res = await request(noderedUrl, 'GET', '/');
+    assert.equal(res.status, 200, `the flow editor root must answer: ${res.raw.slice(0, 200)}`);
+    const flows = await request(noderedUrl, 'GET', '/flows');
+    assert.equal(flows.status, 200, `the flows API must answer: ${flows.raw.slice(0, 200)}`);
+    assert.ok(Array.isArray(flows.body), 'the flows API must return the flow array');
+    assert.ok(flows.body.length > 0, 'the demo flow must be preloaded into the editor');
+  }
+);
+
+// ---------------------------------------------------------------------------
+// AC6 — anonymous access is rejected across the deployed API
+// ---------------------------------------------------------------------------
+
+test(
+  'anonymous access is rejected across the deployed API',
+  { skip: !enabled && skipReason },
+  async () => {
+    const families = [
+      '/api/models/',
+      '/api/data-recorders/',
+      '/api/data-sets',
+      '/api/reports/',
+      '/api/logs/test-campaigns',
+      '/api/simulation/status',
+      '/api/devops',
+    ];
+    for (const family of families) {
+      const res = await request(appUrl, 'GET', family);
+      assert.equal(res.status, 401, `anonymous GET ${family} must be rejected (${res.raw})`);
+    }
+    const badLogin = await request(appUrl, 'POST', '/api/auth/login', {
+      body: { username: adminUsername, password: 'definitely-wrong' },
+    });
+    assert.equal(badLogin.status, 401, `a wrong password must be rejected: ${badLogin.raw}`);
+    // The liveness probe stays public by design — it is what tells operators
+    // and the health checks that the process is up before there is a session.
+    const health = await request(appUrl, 'GET', '/api/health');
+    assert.equal(health.status, 200, '/api/health stays on the public allowlist');
+  }
+);
+
+// ---------------------------------------------------------------------------
+// AC3 — a complete workflow succeeds against the deployed stack
+// ---------------------------------------------------------------------------
+
+test(
+  'complete workflow: define a topology and run a producing simulation on the deployed stack',
+  { skip: !enabled && skipReason },
+  async () => {
+    authHeaders = await logIn();
+    const name = `tas-smoke-topology-${Date.now()}`;
+    const fileName = `${name}.json`;
+    try {
+      const defined = await request(appUrl, 'POST', '/api/models', {
+        headers: authHeaders,
+        body: { model: generatingTopology(name) },
+      });
+      assert.equal(defined.status, 200, `the topology must be created: ${defined.raw}`);
+
+      const started = await request(appUrl, 'POST', '/api/simulation/start', {
+        headers: authHeaders,
+        body: { modelFileName: fileName, options: { dataStorage: deadStorage() } },
+      });
+      assert.equal(started.status, 200, `the simulation must start: ${started.raw}`);
+
+      // The device inside the app container produces through the composition's
+      // internal broker listener (TAS_MQTT_HOST=broker, port 1884): stats are
+      // the end-to-end proof that the deployed wiring really carries data.
+      const producing = await eventually(async () => {
+        const stats = await request(appUrl, 'GET', '/api/simulation/stats', {
+          headers: authHeaders,
+        });
+        const rows = Array.isArray(stats.body && stats.body.stats) ? stats.body.stats : [];
+        return rows.reduce((total, row) => total + (row.numberOfSentData || 0), 0) > 0;
+      }, PRODUCE_TIMEOUT_MS);
+      assert.ok(producing, 'the deployed simulation must produce data end to end');
+
+      const stopped = await stopRun(name);
+      assert.equal(stopped.status, 200, `the simulation must stop cleanly: ${stopped.raw}`);
+      const drained = await eventually(async () => {
+        const status = await request(appUrl, 'GET', '/api/simulation/status', {
+          headers: authHeaders,
+        });
+        const entries = Object.values((status.body && status.body.simulationStatus) || {});
+        return !entries.some((entry) => entry.model === name && entry.isRunning);
+      }, RECOVER_TIMEOUT_MS);
+      assert.ok(drained, 'the stopped run must leave the registry reporting truthfully');
+    } finally {
+      await stopRun(name).catch(() => {});
+      await request(appUrl, 'DELETE', `/api/models/${encodeURIComponent(fileName)}`, {
+        headers: authHeaders,
+      }).catch(() => {});
+    }
+  }
+);
+
+// ---------------------------------------------------------------------------
+// AC4 — restarting each service independently leaves the others running
+// ---------------------------------------------------------------------------
+
+for (const restart of ['broker', 'nodered', 'app']) {
+  const others = ['app', 'broker', 'nodered'].filter((s) => s !== restart);
+  test(
+    `restarting ${restart} leaves the other services running and everything recovers`,
+    { skip: !enabled && skipReason },
+    async () => {
+      const before = serviceStates();
+      for (const service of ['app', 'broker', 'nodered']) {
+        assert.ok(before[service].running, `${service} must be running before the restart`);
+      }
+
+      compose(['restart', restart]);
+
+      // Untouched containers were never stopped: same state AND same start
+      // time — `docker compose restart` replaces the restarted service's
+      // StartedAt and nobody else's.
+      const after_ = serviceStates();
+      for (const service of others) {
+        assert.ok(after_[service].running, `${service} must still be running`);
+        assert.equal(
+          after_[service].startedAt,
+          before[service].startedAt,
+          `${service} must not have been restarted alongside ${restart}`
+        );
+      }
+
+      const recovered = await eventually(stackHealthy, RECOVER_TIMEOUT_MS);
+      assert.ok(recovered, `the stack must recover after restarting ${restart}`);
+    }
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AC5 — non-root application process; Phase 0 containment still holds
+// ---------------------------------------------------------------------------
+
+test('the application process runs as a non-root user', { skip: !enabled && skipReason }, () => {
+  const uid = compose(['exec', '-T', 'app', 'id', '-u']);
+  assert.notEqual(uid, '0', 'the application process must not run as root');
+  const user = compose(['exec', '-T', 'app', 'id', '-un']);
+  assert.equal(user, 'node', `the application process must run as node, got ${user}`);
+});
+
+test(
+  'Phase 0 containment: traversal payloads are rejected by the deployed API',
+  { skip: !enabled && skipReason },
+  async () => {
+    // Fresh session: the independent-restart legs above restarted the app,
+    // and its in-memory session store does not outlive its own container.
+    authHeaders = await logIn();
+    const probes = [
+      '/api/models/..%2Fpackage.json',
+      '/api/models/%2e%2e%2fpackage.json',
+      '/api/data-recorders/models/..%2Fpackage.json',
+      '/api/logs/test-campaigns/..%2Fpackage.json',
+    ];
+    for (const probe of probes) {
+      const res = await request(appUrl, 'GET', probe, { headers: authHeaders });
+      assert.equal(res.status, 400, `traversal GET ${probe} must be rejected (${res.raw})`);
+      assert.ok(!res.raw.includes('package.json'), `must not leak the target: ${res.raw}`);
+      assert.ok(!res.raw.includes('/home/'), `must not leak server paths: ${res.raw}`);
+    }
+    const hostileCreate = await request(appUrl, 'POST', '/api/models', {
+      headers: authHeaders,
+      body: { model: { name: '../../pwned', devices: [] } },
+    });
+    assert.equal(
+      hostileCreate.status,
+      400,
+      `a hostile model name must be rejected: ${hostileCreate.raw}`
+    );
+  }
+);

--- a/test/release-workflow.test.js
+++ b/test/release-workflow.test.js
@@ -12,7 +12,9 @@ const workflow = rawWorkflow
   .map((l) => l.replace(/(^|\s)#.*$/, '$1'))
   .join('\n');
 
-// The publish job must be gated on the test job.
+// The publish job must be gated on the test job and on the deployment smoke
+// test (issue #49): nothing publishes unless the suite passes and the composed
+// stack comes up and behaves.
 test('publishing is gated on a passing test suite', () => {
   const lines = workflow.split('\n');
   const start = lines.findIndex((l) => l.trim() === 'publish:');
@@ -27,10 +29,72 @@ test('publishing is gated on a passing test suite', () => {
   const publish = lines.slice(start + 1, end).join('\n');
   assert.match(
     publish,
-    /^ {4}needs:\s*test\s*$/m,
-    'publish job must declare needs: test so a failing suite blocks the release'
+    /^ {4}needs:\s*\[test,\s*smoke\]\s*$/m,
+    'publish job must need both the test and smoke jobs so a failing check blocks the release'
   );
   assert.match(workflow, /run:\s*npm test/, 'the gate must run the full test suite');
+});
+
+// Issue #49: the deployment smoke test runs on every release tag and blocks
+// publication — its job sits between the test gate and the publish job.
+test('the deployment smoke test gates publication (issue #49)', () => {
+  const lines = workflow.split('\n');
+  const start = lines.findIndex((l) => l.trim() === 'smoke:');
+  assert.ok(start !== -1, 'workflow must define a smoke job');
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^ {2}\S+:\s*$/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  const smoke = lines.slice(start + 1, end).join('\n');
+  assert.match(smoke, /^ {4}needs:\s*test\s*$/m, 'the smoke job must run after the test gate');
+  assert.match(
+    smoke,
+    /run:\s*docker compose up -d\s*$/m,
+    'the smoke job must bring up the documented quick-start deployment'
+  );
+  assert.match(
+    smoke,
+    /^ {8,10}TAS_SMOKE_COMPOSE:\s*['"]?1['"]?\s*$/m,
+    'the smoke job must opt the e2e suite into composing the stack'
+  );
+  assert.match(
+    smoke,
+    /run:\s*node --test test\/e2e\/deployment-smoke\.test\.js\s*$/m,
+    'the smoke job must run the deployment smoke suite'
+  );
+  assert.match(smoke, /docker compose down -v --remove-orphans/, 'the stack must be torn down');
+  // The teardown may never be skipped by an earlier failure.
+  const teardown = smoke.split('\n').findIndex((l) => l.includes('Tear the composed stack down'));
+  assert.ok(teardown !== -1);
+  assert.match(
+    smoke
+      .split('\n')
+      .slice(teardown, teardown + 3)
+      .join('\n'),
+    /if:\s*always\(\)/,
+    'teardown must run even when the suite fails'
+  );
+});
+
+// Issue #49 AC7: published images carry no known critical vulnerabilities —
+// the scan's exit code decides, not just its table output.
+test('a critical vulnerability in the built image blocks publication', () => {
+  const lines = workflow.split('\n');
+  const uses = lines.findIndex((l) => l.includes('aquasecurity/trivy-action@'));
+  assert.ok(uses !== -1, 'Trivy scan must run in the workflow');
+  let start = uses;
+  while (start > 0 && !lines[start].trim().startsWith('- name:')) start -= 1;
+  let end = uses;
+  do {
+    end += 1;
+  } while (end < lines.length && !lines[end].trim().startsWith('- name:'));
+  const step = lines.slice(start, end).join('\n');
+  assert.match(step, /exit-code:\s*['"]1['"]/, 'the scan must fail the job on findings');
+  assert.match(step, /severity:\s*['"]?CRITICAL['"]?\s*$/m, 'the gate must fire on CRITICAL');
+  assert.match(step, /ignore-unfixed:\s*true/, 'unfixable findings must not block forever');
 });
 
 // Issue #19: the old extraction was `tr -d 'refs/tags/'`, which deletes every


### PR DESCRIPTION
Closes #49

## Summary

The Phase 6 milestone gate and the final gate of the improvement programme: an
end-to-end deployment smoke test that brings up the published composition
exactly as a new user would — `docker compose up -d` from a clean checkout,
credentials provisioned the way README.md documents — and asserts everything
the preceding milestones established still holds in a real deployment. The
release workflow runs this gate on every `v*` tag between the test suite and
publication, so a failing smoke test or a known critical image vulnerability
blocks the release.

## Approach

Option 2 — runtime compose smoke suite with release-gate wiring. A new opt-in
e2e file owns the composition lifecycle (up, readiness, assertions, teardown),
and a new `smoke` job in the release workflow sits between the test gate and
the publish job (`needs: [test, smoke]`). The Trivy scan now fails the job on
any known fixable CRITICAL finding instead of only reporting it.

## Decision Record

- **Root cause:** feature gap — nothing exercised the shipped artifact; every
  other gate drives a harness-spawned process, not the composed deployment.
- **Options considered:** Option 1 — static-only guards on the release
  workflow; Option 2 — runtime compose smoke suite plus release-gate wiring;
  Option 3 — comprehensive: add MongoDB to the composition and run the full
  record/replay/score journey plus browser checks against the stack.
- **Options rejected:** Option 1 — asserts wiring but exercises nothing end to
  end, defeating the milestone's purpose; Option 3 — changes the shipped
  composition (#45 intentionally ships no database) and adds heavy per-PR CI
  cost for criteria the issue does not ask for.
- **Selected option:** Option 2 — runtime compose smoke suite with release-gate
  wiring
- **Residual risk:** HIGH image findings are reported by dependabot/npm-audit
  gates but no longer appear in the release Trivy table (severity narrowed to
  CRITICAL, which is what gates); the complete-workflow leg proves topology →
  simulation → data flow rather than record/replay scoring, which needs a
  database the composition does not ship.
- **Design-confirm:** auto-selected Option 2 (complexity: M)

Analyzed at: `feat/49-e2e-deployment-smoke-test-on-the @ 072df8e` (2026-08-25)

## Changes

| File | Change |
|------|--------|
| `test/e2e/deployment-smoke.test.js` | New Phase 6 gate: quick start, health of all four services, broker auth + roundtrip, complete workflow through the internal listener, independent restarts with StartedAt evidence, non-root + containment, anonymous rejection |
| `.github/workflows/build-docker-container.yml` | New `smoke` job (quick start + suite + always-teardown) gating `publish`; Trivy exit-code '1' on CRITICAL |
| `docker-compose.yml` | Published host ports overridable via `TAS_HOST_BROKER_PORT` / `TAS_HOST_APP_PORT` / `TAS_HOST_NODERED_PORT` (defaults unchanged) |
| `test/release-workflow.test.js` | Static guards: smoke job gates publication, teardown is `if: always()`, scan blocks on CRITICAL |
| `test/ci-gate.test.js` | Parity assertion follows the strengthened publish gate |
| `test/dockerfile.test.js` | Compose assertions accept the interpolated port mappings |

## Test Results

- Full suite (`npm test`): 548 passed, 0 failed, 15 skipped (Docker-gated legs)
- Deployment smoke (live composed stack): 12/12 passed, verified twice
- Build: `docker compose config -q` clean; eslint clean; prettier clean
- QA cycles: 2 (clean exit after cycle 1 fixes)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Quick-start command brings up a working deployment from a clean environment | pass | `before()` runs documented `docker compose up -d`; "quick start" test waits for all three health probes green |
| Dashboard, broker and flow editor reachable and healthy | pass | dashboard/API-health/broker/flow-editor tests (roundtrip MQTT traffic incl.) |
| A complete workflow succeeds against the deployed stack | pass | "complete workflow" test: topology created → simulation produces through internal broker listener → stats > 0 → clean stop |
| Restarting each service independently leaves the others running; system recovers | pass | Three restart tests assert untouched services keep their `StartedAt`, then poll full recovery |
| Application runs as non-root; Phase 0 containment still holds | pass | `compose exec id -un` = node; traversal + hostile-name probes return 400 with no path disclosure |
| Anonymous access rejected across the deployed API | pass | Seven route families answer 401 anonymously; wrong login 401; `/api/health` stays public by design |
| Published images carry no known critical vulnerabilities | pass | Release workflow Trivy step now exits non-zero on CRITICAL (pinned by `a critical vulnerability ... blocks publication`) |
| Smoke test runs on every release tag and blocks publication | pass | `smoke` job on `v*` tag trigger; `publish.needs: [test, smoke]` (statically guarded) |

<!-- gitissue:qa v1 head=0e808557876637e055039f0fe73942644b8fa5fd profile=full cycles=2 review=clean tests=548@072df8ea7339031b4b054d69b15689033dedab78 ui=none -->
