### PR TITLE
feat(server): structured logging, correlation ids and API spec (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ All notable changes to TaS are documented in this file. Releases are cut as
 
 ### Added
 
+- **Structured logging with correlation ids and a published API specification**
+  (#47): log records are one machine-parseable JSON object per line carrying
+  `timestamp`, `level`, `label` and structured fields; every request is assigned
+  a correlation id (an incoming `X-Request-Id` is honoured) that is echoed in
+  the response header and attached to the access record and any failure record,
+  and each simulation, data-recorder or test-campaign run stamps all of its own
+  lines with its run id. Verbosity is operator-configurable via `LOG_LEVEL`
+  (`error|warn|info|debug`, default `info`; an unsupported value falls back to
+  `info` with a warning). Values reached through sensitive keys are redacted
+  before anything is written, on top of the existing credential-redaction
+  guarantees (#72). The API specification is generated from the mounted routers
+  and the compiled validation schemas the server enforces — served live at
+  `GET /openapi.json` and committed at the repository root (`npm run spec`
+  regenerates it) — so it cannot drift from the implementation.
 - **Phase 6 milestone gate — deployment smoke test** (#49):
   `test/e2e/deployment-smoke.test.js` brings up the published composition
   exactly as a new user would (`docker compose up -d`, credentials provisioned

--- a/README.md
+++ b/README.md
@@ -313,6 +313,39 @@ response body never carries a stack trace, a server filesystem path or the raw
 underlying error — that detail is written to the server log instead, where it
 stays available for diagnosis.
 
+## API specification
+
+The complete API — every endpoint, its parameters, request bodies and
+responses, with the exact constraints the server validates — is published as an
+OpenAPI 3.0 document:
+
+- **Served live:** `GET /openapi.json` (no session required).
+- **Committed:** [`openapi.json`](openapi.json) at the repository root,
+  regenerated with `npm run spec`.
+
+The document is generated from the same mounted routers and validation schemas
+the server enforces (`src/server/openapi/`), so it cannot drift from the
+implementation: an endpoint added to a router appears in the next generated
+specification with exactly what its schema accepts.
+
+## Structured logs and correlation ids
+
+Log records are one machine-parseable JSON object per line, carrying `timestamp`,
+`level`, `label`, `message` and any structured fields. Two correlation
+identifiers tie records together (issue #47):
+
+- **Requests:** every request is assigned an id (an incoming trusted
+  `X-Request-Id` header is honoured), echoed back in the `X-Request-Id`
+  response header, and attached to the access record written when the response
+  finishes plus any failure record the central handler writes.
+- **Runs:** a simulation, data recorder or test campaign writes all of its own
+  lines into its log file under its run id as `correlationId`.
+
+Verbosity is configurable without a code change via `LOG_LEVEL`
+(`error` | `warn` | `info` | `debug`, default `info`; see `env.example`). Values
+reached through sensitive keys — passwords, tokens, secrets — are redacted
+before anything is written.
+
 ## DEVELOPMENT
 
 ### Run the E2E security regression suite

--- a/env.example
+++ b/env.example
@@ -2,6 +2,12 @@ SERVER_HOST=0.0.0.0
 SERVER_PORT=3004
 DEV_DASHBOARD_PORT=8080
 
+# Log verbosity for the structured run and server logs (issue #47): one of
+# error, warn, info or debug. Records are one JSON object per line, carrying a
+# correlation id per request (X-Request-Id) and per simulation run. An
+# unsupported value falls back to info.
+#LOG_LEVEL=info
+
 # Optional hardening limits. The defaults shown here are what the server applies
 # when they are unset, so leave them commented out unless you need to change
 # one. See the "Security-related configuration" section of the README.

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,4114 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "TaS API",
+    "description": "Test and Simulation Enabler API. Generated from the request validation schemas the server enforces, so it cannot drift from the implementation.",
+    "version": "2.0.0"
+  },
+  "servers": [
+    {
+      "url": "/"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "A caller-safe failure message."
+          },
+          "details": {
+            "type": "array",
+            "description": "Per-field breakdown, carried by validation failures.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "location": {
+                  "type": "string",
+                  "enum": ["params", "query", "body"]
+                },
+                "field": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "required": ["error"]
+      }
+    },
+    "responses": {
+      "ValidationError": {
+        "description": "The request was malformed or failed validation.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "No session, or it has expired.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "The session may not do this (missing CSRF token, disallowed origin).",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "The addressed resource does not exist.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "Conflict": {
+        "description": "The request cannot be applied to the current resource state.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "RateLimited": {
+        "description": "Too many requests from this client; retry later.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "InternalError": {
+        "description": "An unclassified server-side failure.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/health": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/auth/login": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string",
+                    "maxLength": 256
+                  },
+                  "password": {
+                    "type": "string",
+                    "maxLength": 1024
+                  }
+                },
+                "required": ["password", "username"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/logout": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/auth/session": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/models": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "model": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()[\\]+@'#]*$",
+                        "maxLength": 128
+                      },
+                      "devices": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "datasetId": {
+                        "type": "string",
+                        "maxLength": 256,
+                        "nullable": true
+                      },
+                      "newDataset": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "maxLength": 256
+                          },
+                          "name": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          },
+                          "description": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 256
+                            }
+                          },
+                          "source": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          }
+                        },
+                        "additionalProperties": true,
+                        "nullable": true
+                      },
+                      "replayOptions": {
+                        "type": "object",
+                        "properties": {
+                          "startTime": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "nullable": true
+                          },
+                          "endTime": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "nullable": true
+                          },
+                          "repeat": {
+                            "type": "boolean"
+                          },
+                          "speedup": {
+                            "type": "number",
+                            "exclusiveMinimum": 0
+                          }
+                        },
+                        "additionalProperties": true,
+                        "nullable": true
+                      },
+                      "dataStorage": {
+                        "type": "object",
+                        "properties": {
+                          "protocol": {
+                            "type": "string",
+                            "enum": ["MONGODB"]
+                          },
+                          "connConfig": {
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "type": "string",
+                                "pattern": "^[A-Za-z0-9._-]+$",
+                                "maxLength": 253
+                              },
+                              "port": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 65535
+                              },
+                              "username": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "password": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "dbname": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "options": {
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "string",
+                                    "maxLength": 2048
+                                  }
+                                ]
+                              }
+                            },
+                            "required": ["host", "port"],
+                            "additionalProperties": true
+                          }
+                        },
+                        "required": ["connConfig", "protocol"],
+                        "additionalProperties": true,
+                        "nullable": true
+                      },
+                      "testCampaignId": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()[\\]+@'#]*$",
+                        "maxLength": 128,
+                        "nullable": true
+                      },
+                      "evaluationParameters": {
+                        "type": "object",
+                        "properties": {
+                          "threshold": {
+                            "type": "number"
+                          },
+                          "eventType": {
+                            "type": "string",
+                            "maxLength": 256
+                          },
+                          "metricType": {
+                            "type": "string",
+                            "maxLength": 256
+                          }
+                        },
+                        "additionalProperties": true,
+                        "nullable": true
+                      }
+                    },
+                    "required": ["devices", "name"],
+                    "additionalProperties": true
+                  }
+                },
+                "required": ["model"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/models/{fileName}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "fileName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()\\[\\]+@'#]*\\.json$",
+              "maxLength": 133
+            }
+          }
+        ]
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "fileName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()\\[\\]+@'#]*\\.json$",
+              "maxLength": 133
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "model": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()[\\]+@'#]*$",
+                        "maxLength": 128
+                      },
+                      "devices": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "datasetId": {
+                        "type": "string",
+                        "maxLength": 256,
+                        "nullable": true
+                      },
+                      "newDataset": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "maxLength": 256
+                          },
+                          "name": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          },
+                          "description": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 256
+                            }
+                          },
+                          "source": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          }
+                        },
+                        "additionalProperties": true,
+                        "nullable": true
+                      },
+                      "replayOptions": {
+                        "type": "object",
+                        "properties": {
+                          "startTime": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "nullable": true
+                          },
+                          "endTime": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "nullable": true
+                          },
+                          "repeat": {
+                            "type": "boolean"
+                          },
+                          "speedup": {
+                            "type": "number",
+                            "exclusiveMinimum": 0
+                          }
+                        },
+                        "additionalProperties": true,
+                        "nullable": true
+                      },
+                      "dataStorage": {
+                        "type": "object",
+                        "properties": {
+                          "protocol": {
+                            "type": "string",
+                            "enum": ["MONGODB"]
+                          },
+                          "connConfig": {
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "type": "string",
+                                "pattern": "^[A-Za-z0-9._-]+$",
+                                "maxLength": 253
+                              },
+                              "port": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 65535
+                              },
+                              "username": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "password": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "dbname": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "options": {
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "string",
+                                    "maxLength": 2048
+                                  }
+                                ]
+                              }
+                            },
+                            "required": ["host", "port"],
+                            "additionalProperties": true
+                          }
+                        },
+                        "required": ["connConfig", "protocol"],
+                        "additionalProperties": true,
+                        "nullable": true
+                      },
+                      "testCampaignId": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()[\\]+@'#]*$",
+                        "maxLength": 128,
+                        "nullable": true
+                      },
+                      "evaluationParameters": {
+                        "type": "object",
+                        "properties": {
+                          "threshold": {
+                            "type": "number"
+                          },
+                          "eventType": {
+                            "type": "string",
+                            "maxLength": 256
+                          },
+                          "metricType": {
+                            "type": "string",
+                            "maxLength": 256
+                          }
+                        },
+                        "additionalProperties": true,
+                        "nullable": true
+                      }
+                    },
+                    "required": ["devices", "name"],
+                    "additionalProperties": true
+                  },
+                  "isDuplicated": {
+                    "type": "string",
+                    "enum": [true]
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "fileName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()\\[\\]+@'#]*\\.json$",
+              "maxLength": 133
+            }
+          }
+        ]
+      }
+    },
+    "/api/data-recorders/status": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/data-recorders/stop/{fileName}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "fileName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()\\[\\]+@'#]*\\.json$",
+              "maxLength": 133
+            }
+          }
+        ]
+      }
+    },
+    "/api/data-recorders/start": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "model": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()[\\]+@'#]*$",
+                        "maxLength": 128
+                      },
+                      "dataRecorders": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "dataStorage": {
+                        "type": "object",
+                        "properties": {
+                          "protocol": {
+                            "type": "string",
+                            "enum": ["MONGODB"]
+                          },
+                          "connConfig": {
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "type": "string",
+                                "pattern": "^[A-Za-z0-9._-]+$",
+                                "maxLength": 253
+                              },
+                              "port": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 65535
+                              },
+                              "username": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "password": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "dbname": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "options": {
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "string",
+                                    "maxLength": 2048
+                                  }
+                                ]
+                              }
+                            },
+                            "required": ["host", "port"],
+                            "additionalProperties": true
+                          }
+                        },
+                        "required": ["connConfig", "protocol"],
+                        "additionalProperties": true,
+                        "nullable": true
+                      },
+                      "dataset": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "maxLength": 256
+                          },
+                          "name": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          },
+                          "description": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 256
+                            }
+                          },
+                          "source": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          }
+                        },
+                        "additionalProperties": true,
+                        "nullable": true
+                      }
+                    },
+                    "required": ["dataRecorders", "name"],
+                    "additionalProperties": true
+                  },
+                  "dataRecorderFileName": {
+                    "type": "string",
+                    "maxLength": 133
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data-recorders/models/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/data-recorders/models/{fileName}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "fileName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()\\[\\]+@'#]*\\.json$",
+              "maxLength": 133
+            }
+          }
+        ]
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "fileName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()\\[\\]+@'#]*\\.json$",
+              "maxLength": 133
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "dataRecorder": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()[\\]+@'#]*$",
+                        "maxLength": 128
+                      },
+                      "dataRecorders": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "dataStorage": {
+                        "type": "object",
+                        "properties": {
+                          "protocol": {
+                            "type": "string",
+                            "enum": ["MONGODB"]
+                          },
+                          "connConfig": {
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "type": "string",
+                                "pattern": "^[A-Za-z0-9._-]+$",
+                                "maxLength": 253
+                              },
+                              "port": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 65535
+                              },
+                              "username": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "password": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "dbname": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "options": {
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "string",
+                                    "maxLength": 2048
+                                  }
+                                ]
+                              }
+                            },
+                            "required": ["host", "port"],
+                            "additionalProperties": true
+                          }
+                        },
+                        "required": ["connConfig", "protocol"],
+                        "additionalProperties": true,
+                        "nullable": true
+                      },
+                      "dataset": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "maxLength": 256
+                          },
+                          "name": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          },
+                          "description": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 256
+                            }
+                          },
+                          "source": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          }
+                        },
+                        "additionalProperties": true,
+                        "nullable": true
+                      }
+                    },
+                    "required": ["dataRecorders", "name"],
+                    "additionalProperties": true
+                  },
+                  "isDuplicated": {
+                    "type": "string",
+                    "enum": [true]
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "fileName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()\\[\\]+@'#]*\\.json$",
+              "maxLength": 133
+            }
+          }
+        ]
+      }
+    },
+    "/api/data-recorders/models": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "dataRecorder": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()[\\]+@'#]*$",
+                        "maxLength": 128
+                      },
+                      "dataRecorders": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "dataStorage": {
+                        "type": "object",
+                        "properties": {
+                          "protocol": {
+                            "type": "string",
+                            "enum": ["MONGODB"]
+                          },
+                          "connConfig": {
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "type": "string",
+                                "pattern": "^[A-Za-z0-9._-]+$",
+                                "maxLength": 253
+                              },
+                              "port": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 65535
+                              },
+                              "username": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "password": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "dbname": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "options": {
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "string",
+                                    "maxLength": 2048
+                                  }
+                                ]
+                              }
+                            },
+                            "required": ["host", "port"],
+                            "additionalProperties": true
+                          }
+                        },
+                        "required": ["connConfig", "protocol"],
+                        "additionalProperties": true,
+                        "nullable": true
+                      },
+                      "dataset": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "maxLength": 256
+                          },
+                          "name": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          },
+                          "description": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 256
+                            }
+                          },
+                          "source": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          }
+                        },
+                        "additionalProperties": true,
+                        "nullable": true
+                      }
+                    },
+                    "required": ["dataRecorders", "name"],
+                    "additionalProperties": true
+                  }
+                },
+                "required": ["dataRecorder"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data-storage": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "dataStorage": {
+                    "type": "object",
+                    "properties": {
+                      "protocol": {
+                        "type": "string",
+                        "enum": ["MONGODB"]
+                      },
+                      "connConfig": {
+                        "type": "object",
+                        "properties": {
+                          "host": {
+                            "type": "string",
+                            "pattern": "^[A-Za-z0-9._-]+$",
+                            "maxLength": 253
+                          },
+                          "port": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535
+                          },
+                          "username": {
+                            "type": "string",
+                            "maxLength": 256,
+                            "nullable": true
+                          },
+                          "password": {
+                            "type": "string",
+                            "maxLength": 256,
+                            "nullable": true
+                          },
+                          "dbname": {
+                            "type": "string",
+                            "maxLength": 256,
+                            "nullable": true
+                          },
+                          "options": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              {
+                                "type": "string",
+                                "maxLength": 2048
+                              }
+                            ]
+                          }
+                        },
+                        "required": ["host", "port"],
+                        "additionalProperties": true
+                      }
+                    },
+                    "required": ["connConfig", "protocol"],
+                    "additionalProperties": true
+                  }
+                },
+                "required": ["dataStorage"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data-storage/test": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/logs/data-recorders": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/logs/data-recorders/{fileName}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "fileName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()\\[\\]+@'#]*\\.log$",
+              "maxLength": 146
+            }
+          }
+        ]
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "fileName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()\\[\\]+@'#]*\\.log$",
+              "maxLength": 146
+            }
+          }
+        ]
+      }
+    },
+    "/api/logs/simulations": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/logs/simulations/{fileName}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "fileName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()\\[\\]+@'#]*\\.log$",
+              "maxLength": 146
+            }
+          }
+        ]
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "fileName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()\\[\\]+@'#]*\\.log$",
+              "maxLength": 146
+            }
+          }
+        ]
+      }
+    },
+    "/api/logs/test-campaigns": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/logs/test-campaigns/{fileName}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "fileName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()\\[\\]+@'#]*\\.log$",
+              "maxLength": 146
+            }
+          }
+        ]
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "fileName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()\\[\\]+@'#]*\\.log$",
+              "maxLength": 146
+            }
+          }
+        ]
+      }
+    },
+    "/api/data-sets": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          }
+        ]
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "dataset": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "maxLength": 256
+                      },
+                      "name": {
+                        "type": "string",
+                        "maxLength": 1024
+                      },
+                      "tags": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "maxLength": 256
+                        }
+                      },
+                      "description": {
+                        "type": "string",
+                        "maxLength": 1024,
+                        "nullable": true
+                      },
+                      "source": {
+                        "type": "string",
+                        "maxLength": 1024,
+                        "nullable": true
+                      }
+                    },
+                    "required": ["id", "name"],
+                    "additionalProperties": true
+                  }
+                },
+                "required": ["dataset"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data-sets/{datasetId}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "datasetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 256
+            }
+          }
+        ]
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "datasetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 256
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "dataset": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "maxLength": 256
+                      },
+                      "name": {
+                        "type": "string",
+                        "maxLength": 1024
+                      },
+                      "tags": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "maxLength": 256
+                        }
+                      },
+                      "description": {
+                        "type": "string",
+                        "maxLength": 1024,
+                        "nullable": true
+                      },
+                      "source": {
+                        "type": "string",
+                        "maxLength": 1024,
+                        "nullable": true
+                      }
+                    },
+                    "additionalProperties": true
+                  }
+                },
+                "required": ["dataset"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "datasetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 256
+            }
+          }
+        ]
+      }
+    },
+    "/api/test-cases": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "testCase": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "maxLength": 256
+                      },
+                      "name": {
+                        "type": "string",
+                        "maxLength": 1024
+                      },
+                      "tags": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "maxLength": 256
+                        }
+                      },
+                      "description": {
+                        "type": "string",
+                        "maxLength": 1024,
+                        "nullable": true
+                      },
+                      "datasetIds": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "maxLength": 256
+                        }
+                      },
+                      "modelFileName": {
+                        "type": "string",
+                        "maxLength": 133,
+                        "nullable": true
+                      }
+                    },
+                    "required": ["id"],
+                    "additionalProperties": true
+                  }
+                },
+                "required": ["testCase"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/test-cases/{testCaseId}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "testCaseId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 256
+            }
+          }
+        ]
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "testCaseId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 256
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "testCase": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "maxLength": 256
+                      },
+                      "name": {
+                        "type": "string",
+                        "maxLength": 1024
+                      },
+                      "tags": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "maxLength": 256
+                        }
+                      },
+                      "description": {
+                        "type": "string",
+                        "maxLength": 1024,
+                        "nullable": true
+                      },
+                      "datasetIds": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "maxLength": 256
+                        }
+                      },
+                      "modelFileName": {
+                        "type": "string",
+                        "maxLength": 133,
+                        "nullable": true
+                      }
+                    },
+                    "additionalProperties": true
+                  }
+                },
+                "required": ["testCase"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "testCaseId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 256
+            }
+          }
+        ]
+      }
+    },
+    "/api/test-campaigns": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "testCampaign": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "maxLength": 256
+                      },
+                      "name": {
+                        "type": "string",
+                        "maxLength": 1024
+                      },
+                      "isDefault": {
+                        "type": "boolean"
+                      },
+                      "description": {
+                        "type": "string",
+                        "maxLength": 1024,
+                        "nullable": true
+                      },
+                      "testCaseIds": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "maxLength": 256
+                        }
+                      },
+                      "webhookURL": {
+                        "type": "string",
+                        "format": "uri",
+                        "maxLength": 2048,
+                        "nullable": true
+                      }
+                    },
+                    "required": ["id"],
+                    "additionalProperties": true
+                  }
+                },
+                "required": ["testCampaign"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/test-campaigns/{testCampaignId}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "testCampaignId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 256
+            }
+          }
+        ]
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "testCampaignId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 256
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "testCampaign": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "maxLength": 256
+                      },
+                      "name": {
+                        "type": "string",
+                        "maxLength": 1024
+                      },
+                      "isDefault": {
+                        "type": "boolean"
+                      },
+                      "description": {
+                        "type": "string",
+                        "maxLength": 1024,
+                        "nullable": true
+                      },
+                      "testCaseIds": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "maxLength": 256
+                        }
+                      },
+                      "webhookURL": {
+                        "type": "string",
+                        "format": "uri",
+                        "maxLength": 2048,
+                        "nullable": true
+                      }
+                    },
+                    "additionalProperties": true
+                  }
+                },
+                "required": ["testCampaign"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "testCampaignId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 256
+            }
+          }
+        ]
+      }
+    },
+    "/api/events": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "startTime",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "endTime",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "datasetId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 256
+            }
+          },
+          {
+            "name": "topic",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 1024
+            }
+          }
+        ]
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "event": {
+                    "type": "object",
+                    "properties": {
+                      "timestamp": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "topic": {
+                        "type": "string",
+                        "maxLength": 1024
+                      },
+                      "datasetId": {
+                        "type": "string",
+                        "maxLength": 256
+                      },
+                      "isSensorData": {
+                        "type": "boolean"
+                      },
+                      "values": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "array"
+                          },
+                          {
+                            "type": "string",
+                            "maxLength": 8192
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "boolean"
+                          }
+                        ]
+                      }
+                    },
+                    "required": ["datasetId", "isSensorData", "timestamp", "topic", "values"],
+                    "additionalProperties": true
+                  }
+                },
+                "required": ["event"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{eventId}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "eventId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 256
+            }
+          }
+        ]
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "eventId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 256
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "event": {
+                    "type": "object",
+                    "properties": {
+                      "timestamp": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "topic": {
+                        "type": "string",
+                        "maxLength": 1024
+                      },
+                      "datasetId": {
+                        "type": "string",
+                        "maxLength": 256
+                      },
+                      "isSensorData": {
+                        "type": "boolean"
+                      },
+                      "values": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "array"
+                          },
+                          {
+                            "type": "string",
+                            "maxLength": 8192
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "boolean"
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": true
+                  }
+                },
+                "required": ["event"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "eventId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 256
+            }
+          }
+        ]
+      }
+    },
+    "/api/reports": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "topologyFileName",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 1024
+            }
+          },
+          {
+            "name": "testCampaignId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 256
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500,
+              "default": 50
+            }
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          }
+        ]
+      }
+    },
+    "/api/reports/{reportId}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "reportId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 256
+            }
+          }
+        ]
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "reportId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 256
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "report": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "maxLength": 256
+                      },
+                      "testCampaignId": {
+                        "type": "string",
+                        "maxLength": 256,
+                        "nullable": true
+                      },
+                      "originalDatasetId": {
+                        "type": "string",
+                        "maxLength": 256,
+                        "nullable": true
+                      },
+                      "newDatasetId": {
+                        "type": "string",
+                        "maxLength": 256,
+                        "nullable": true
+                      },
+                      "topologyFileName": {
+                        "type": "string",
+                        "maxLength": 1024,
+                        "nullable": true
+                      },
+                      "createdAt": {
+                        "type": "number"
+                      },
+                      "startTime": {
+                        "type": "number"
+                      },
+                      "endTime": {
+                        "type": "number"
+                      },
+                      "score": {
+                        "type": "number"
+                      },
+                      "evaluationParameters": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "nullable": true
+                      }
+                    },
+                    "additionalProperties": true
+                  },
+                  "newScore": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "reportId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 256
+            }
+          }
+        ]
+      }
+    },
+    "/api/simulation/start": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "model": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()[\\]+@'#]*$",
+                        "maxLength": 128
+                      },
+                      "devices": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "datasetId": {
+                        "type": "string",
+                        "maxLength": 256,
+                        "nullable": true
+                      },
+                      "newDataset": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "maxLength": 256
+                          },
+                          "name": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          },
+                          "description": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 256
+                            }
+                          },
+                          "source": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          }
+                        },
+                        "additionalProperties": true,
+                        "nullable": true
+                      },
+                      "replayOptions": {
+                        "type": "object",
+                        "properties": {
+                          "startTime": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "nullable": true
+                          },
+                          "endTime": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "nullable": true
+                          },
+                          "repeat": {
+                            "type": "boolean"
+                          },
+                          "speedup": {
+                            "type": "number",
+                            "exclusiveMinimum": 0
+                          }
+                        },
+                        "additionalProperties": true,
+                        "nullable": true
+                      },
+                      "dataStorage": {
+                        "type": "object",
+                        "properties": {
+                          "protocol": {
+                            "type": "string",
+                            "enum": ["MONGODB"]
+                          },
+                          "connConfig": {
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "type": "string",
+                                "pattern": "^[A-Za-z0-9._-]+$",
+                                "maxLength": 253
+                              },
+                              "port": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 65535
+                              },
+                              "username": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "password": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "dbname": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "options": {
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "string",
+                                    "maxLength": 2048
+                                  }
+                                ]
+                              }
+                            },
+                            "required": ["host", "port"],
+                            "additionalProperties": true
+                          }
+                        },
+                        "required": ["connConfig", "protocol"],
+                        "additionalProperties": true,
+                        "nullable": true
+                      },
+                      "testCampaignId": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()[\\]+@'#]*$",
+                        "maxLength": 128,
+                        "nullable": true
+                      },
+                      "evaluationParameters": {
+                        "type": "object",
+                        "properties": {
+                          "threshold": {
+                            "type": "number"
+                          },
+                          "eventType": {
+                            "type": "string",
+                            "maxLength": 256
+                          },
+                          "metricType": {
+                            "type": "string",
+                            "maxLength": 256
+                          }
+                        },
+                        "additionalProperties": true,
+                        "nullable": true
+                      }
+                    },
+                    "required": ["devices", "name"],
+                    "additionalProperties": true
+                  },
+                  "modelFileName": {
+                    "type": "string",
+                    "maxLength": 133
+                  },
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "datasetId": {
+                        "type": "string",
+                        "maxLength": 256,
+                        "nullable": true
+                      },
+                      "newDataset": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "maxLength": 256
+                          },
+                          "name": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          },
+                          "description": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 256
+                            }
+                          },
+                          "source": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "nullable": true
+                          }
+                        },
+                        "additionalProperties": true,
+                        "nullable": true
+                      },
+                      "replayOptions": {
+                        "type": "object",
+                        "properties": {
+                          "startTime": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "nullable": true
+                          },
+                          "endTime": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "nullable": true
+                          },
+                          "repeat": {
+                            "type": "boolean"
+                          },
+                          "speedup": {
+                            "type": "number",
+                            "exclusiveMinimum": 0
+                          }
+                        },
+                        "additionalProperties": true,
+                        "nullable": true
+                      },
+                      "dataStorage": {
+                        "type": "object",
+                        "properties": {
+                          "protocol": {
+                            "type": "string",
+                            "enum": ["MONGODB"]
+                          },
+                          "connConfig": {
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "type": "string",
+                                "pattern": "^[A-Za-z0-9._-]+$",
+                                "maxLength": 253
+                              },
+                              "port": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 65535
+                              },
+                              "username": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "password": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "dbname": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "options": {
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "string",
+                                    "maxLength": 2048
+                                  }
+                                ]
+                              }
+                            },
+                            "required": ["host", "port"],
+                            "additionalProperties": true
+                          }
+                        },
+                        "required": ["connConfig", "protocol"],
+                        "additionalProperties": true,
+                        "nullable": true
+                      },
+                      "testCampaignId": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()[\\]+@'#]*$",
+                        "maxLength": 128,
+                        "nullable": true
+                      },
+                      "evaluationParameters": {
+                        "type": "object",
+                        "properties": {
+                          "threshold": {
+                            "type": "number"
+                          },
+                          "eventType": {
+                            "type": "string",
+                            "maxLength": 256
+                          },
+                          "metricType": {
+                            "type": "string",
+                            "maxLength": 256
+                          }
+                        },
+                        "additionalProperties": true,
+                        "nullable": true
+                      }
+                    },
+                    "additionalProperties": false,
+                    "default": {}
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/simulation/stop/{fileName}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "fileName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()\\[\\]+@'#]*\\.json$",
+              "maxLength": 133
+            }
+          }
+        ]
+      }
+    },
+    "/api/simulation/status": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/simulation/stats": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/devops/status": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/devops": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "devops": {
+                    "type": "object",
+                    "properties": {
+                      "webhookURL": {
+                        "type": "string",
+                        "format": "uri",
+                        "maxLength": 2048,
+                        "nullable": true
+                      },
+                      "testCampaignId": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.()[\\]+@'#]*$",
+                        "maxLength": 128,
+                        "nullable": true
+                      },
+                      "dataStorage": {
+                        "type": "object",
+                        "properties": {
+                          "protocol": {
+                            "type": "string",
+                            "enum": ["MONGODB"]
+                          },
+                          "connConfig": {
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "type": "string",
+                                "pattern": "^[A-Za-z0-9._-]+$",
+                                "maxLength": 253
+                              },
+                              "port": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 65535
+                              },
+                              "username": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "password": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "dbname": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "nullable": true
+                              },
+                              "options": {
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "string",
+                                    "maxLength": 2048
+                                  }
+                                ]
+                              }
+                            },
+                            "required": ["host", "port"],
+                            "additionalProperties": true
+                          }
+                        },
+                        "required": ["connConfig", "protocol"],
+                        "additionalProperties": true,
+                        "nullable": true
+                      },
+                      "evaluationParameters": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "nullable": true
+                      }
+                    },
+                    "additionalProperties": true
+                  }
+                },
+                "required": ["devops"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/devops/start": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/devops/stop": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prepare": "husky || true"
+    "prepare": "husky || true",
+    "spec": "node scripts/generate-openapi.js"
   },
   "nodemonConfig": {
     "verbose": true,

--- a/scripts/generate-openapi.js
+++ b/scripts/generate-openapi.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * Generate the published API specification (issue #47).
+ *
+ * Requires the real application - the same routers, mounted the same way the
+ * server runs them - and writes the OpenAPI 3.0 document to docs/openapi.json.
+ * Run it after changing any endpoint or schema:
+ *
+ *   npm run spec
+ *
+ * The served document (GET /openapi.json) is produced by the same generator
+ * from the same mounts at process start; this script exists so the committed
+ * copy integrators read stays current without running the server.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const appModule = require('../src/server/app');
+const { buildOpenApiDocument } = require('../src/server/openapi/generate-openapi');
+
+const document = buildOpenApiDocument({
+  mounts: appModule.getApiMounts(),
+  version: require('../package.json').version,
+});
+
+// The repo root, deliberately: `docs/` is gitignored in this repository, and
+// the published specification must be tracked so a PR that changes the API
+// visibly changes the spec with it.
+const outPath = path.join(__dirname, '..', 'openapi.json');
+fs.writeFileSync(outPath, `${JSON.stringify(document, null, 2)}\n`);
+
+const operations = Object.values(document.paths).reduce(
+  (count, pathItem) => count + Object.keys(pathItem).length,
+  0
+);
+console.log(
+  `[SPEC] Wrote ${outPath} (${Object.keys(document.paths).length} paths, ${operations} operations)`
+);

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -8,6 +8,8 @@ var { errorHandler, apiNotFound, forbidden, ApiError, sendError } = require('./m
 var { securityHeaders } = require('./middleware/security-headers');
 var { createAuthMiddleware } = require('./middleware/auth');
 var { createCsrfMiddleware } = require('./middleware/csrf');
+var { requestContext } = require('./middleware/request-context');
+var { buildOpenApiDocument } = require('./openapi/generate-openapi');
 var { createCredential } = require('./auth/credentials');
 var { createSessionStore } = require('./auth/session-store');
 
@@ -174,6 +176,13 @@ app.use(
 app.use(cookieParser(config.sessionSecret));
 app.use(express.static(path.join(__dirname, '../public')));
 
+/**
+ * Request correlation (issue #47): every request gets an id (an incoming
+ * `X-Request-Id` is honoured), echoed back in the response header, and carried
+ * on the structured access and error records the server writes.
+ */
+app.use(requestContext());
+
 // Per-client rate limiting on the unauthenticated API surface.
 const apiLimiter = rateLimit({
   windowMs: config.rateLimitWindowMs,
@@ -220,29 +229,61 @@ app.use('/api/auth/login', loginLimiter);
 app.use('/api', createAuthMiddleware({ sessions: sessions, config: config }));
 app.use('/api', createCsrfMiddleware());
 
-app.use('/api/health', healthRouter);
-app.use(
-  '/api/auth',
-  createAuthRouter({ credential: credential, sessions: sessions, config: config })
-);
+/**
+ * The API surface, declared once (issue #47).
+ *
+ * The same array drives both the mounting below and the OpenAPI generator:
+ * the specification is produced from what is actually mounted, so a router
+ * added here appears in it and one removed here disappears - there is no
+ * second list to forget. `public: true` marks routers whose endpoints answer
+ * without a session (`middleware/auth.js` allowlist), which the generator
+ * documents without the authentication error.
+ */
+const apiMounts = [
+  { prefix: '/api/health', router: healthRouter, public: true },
+  {
+    prefix: '/api/auth',
+    router: createAuthRouter({ credential: credential, sessions: sessions, config: config }),
+    public: true,
+  },
+  { prefix: '/api/models', router: modelRouter },
+  { prefix: '/api/data-recorders', router: dataRecorderRouter },
+  { prefix: '/api/data-storage', router: dataStorageRouter },
+  { prefix: '/api/logs/data-recorders', router: createLogRouter('data-recorders') },
+  { prefix: '/api/logs/simulations', router: createLogRouter('simulations') },
+  { prefix: '/api/logs/test-campaigns', router: createLogRouter('test-campaigns') },
+  { prefix: '/api/data-sets', router: dataSetRouter },
+  { prefix: '/api/test-cases', router: testCaseRouter },
+  { prefix: '/api/test-campaigns', router: testCampaignRouter },
+  { prefix: '/api/events', router: eventRouter },
+  { prefix: '/api/reports', router: reportRouter },
+  { prefix: '/api/simulation', router: simulationRouter },
+  { prefix: '/api/devops', router: devopsRouter },
+];
 
-app.use('/api/models', modelRouter);
-app.use('/api/data-recorders', dataRecorderRouter);
-app.use('/api/data-storage', dataStorageRouter);
-app.use('/api/logs/data-recorders', createLogRouter('data-recorders'));
-app.use('/api/logs/simulations', createLogRouter('simulations'));
-app.use('/api/logs/test-campaigns', createLogRouter('test-campaigns'));
-app.use('/api/data-sets', dataSetRouter);
-app.use('/api/test-cases', testCaseRouter);
-app.use('/api/test-campaigns', testCampaignRouter);
-app.use('/api/events', eventRouter);
-app.use('/api/reports', reportRouter);
-app.use('/api/simulation', simulationRouter);
-app.use('/api/devops', devopsRouter);
+for (const { prefix, router } of apiMounts) {
+  app.use(prefix, router);
+}
 // An API path no router claimed is a missing resource, not the dashboard: it
 // must not fall through to the single-page app below, which would answer 200
 // with an HTML page a client cannot tell from a successful call.
 app.use('/api', apiNotFound);
+
+/**
+ * The published API specification (issue #47), generated from the mounted
+ * routers and their validation schemas. Served outside `/api`, before the
+ * authentication middleware: an integrator reads the spec to learn how to
+ * authenticate, and a description of shapes discloses nothing the route list
+ * does not already announce. Built once per process; the routes cannot change
+ * while it runs.
+ */
+const openApiDocument = buildOpenApiDocument({
+  mounts: apiMounts,
+  version: require('../../package.json').version,
+});
+app.get('/openapi.json', function serveOpenApi(req, res) {
+  res.json(openApiDocument);
+});
 
 /**
  * The single-page app catch-all (Express 5 / path-to-regexp v8).
@@ -270,6 +311,10 @@ app.get('/*splat', serveDashboard);
 app.use(errorHandler);
 
 module.exports = app;
+// For tooling that needs the mount manifest without re-deriving it (the
+// specification generator, tests). Assigned after the module export above,
+// which replaces `module.exports` wholesale.
+module.exports.getApiMounts = () => apiMounts;
 
 if (require.main === module) {
   var _server = app.listen(app.get('port'), config.host, function () {

--- a/src/server/logger/index.js
+++ b/src/server/logger/index.js
@@ -1,13 +1,154 @@
 const { createLogger, format, transports } = require('winston');
-const { combine, timestamp, label, printf } = format;
+const { combine, label, timestamp, printf } = format;
 const util = require('util');
 
 /**
- * Define the format of the log
+ * Structured run logging (issue #47).
+ *
+ * Every record is one machine-parseable JSON object per line, carrying the
+ * time, the level, the run's label and - when the caller supplied one - the
+ * correlation identifier that ties all of a request's or a run's records
+ * together. The level comes from LOG_LEVEL so an operator can turn it without
+ * touching code, and values reached through sensitive keys (passwords, tokens,
+ * secrets) are replaced before anything is written.
+ *
+ * The returned object keeps mirroring the console method signatures - every
+ * method accepts any number of arguments and formats them exactly like
+ * `console.log` does - so existing call sites (including the common
+ * `logger.error('message', err)` pair) keep working unchanged. A trailing
+ * plain-object argument is treated as structured metadata: its entries are
+ * hoisted to the top level of the JSON record instead of being formatted into
+ * the message text.
  */
-const myFormat = printf(({ level, message, label, timestamp }) => {
-  return `${timestamp} [${label}] ${level}: ${message}`;
-});
+
+/** Levels winston's npm scale knows, quietest-first. */
+const LEVELS = ['error', 'warn', 'info', 'debug'];
+
+/** The level used when nothing is configured or the configured value is unusable. */
+const DEFAULT_LEVEL = 'info';
+
+/**
+ * Keys whose values must never reach a log line: passwords, tokens, session
+ * identifiers, credentials and similar. Matched case-insensitively against
+ * each key of an object being logged; a match replaces the value wholesale
+ * rather than trying to sanitise it in place.
+ */
+const SENSITIVE_KEY =
+  /^(pass(word|wd|phrase)?|secret|token|authorization|auth|cookie|credential(s)?|api[-_]?key|access[-_]?key|private[-_]?key|session[-_]?id|session[-_]?secret)$/i;
+
+/** The placeholder a redacted value leaves behind. */
+const REDACTED = '[REDACTED]';
+
+/** How deep into a nested value redaction follows before giving up. */
+const MAX_REDACTION_DEPTH = 8;
+
+/**
+ * Return a redacted copy of `value`. Plain objects and arrays are copied and
+ * walked (cycle-safe, depth-bounded); sensitive keys lose their value; every
+ * other kind of value passes through untouched. Errors are copied with their
+ * message and stack intact but their own enumerable properties redacted, so a
+ * library error carrying a document or a connection string cannot leak either.
+ *
+ * @param {*} value Any value about to be logged
+ * @param {Number} [depth] Current recursion depth (internal)
+ * @param {WeakSet} [seen] Already-visited objects (internal)
+ * @returns {*} A safe copy, or the value itself when nothing needs copying
+ */
+const redactValue = (value, depth = 0, seen = new WeakSet()) => {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (depth >= MAX_REDACTION_DEPTH || seen.has(value)) {
+    return '[Truncated]';
+  }
+  if (value instanceof Error) {
+    const safe = { message: value.message, stack: value.stack };
+    for (const key of Object.keys(value)) {
+      safe[key] = SENSITIVE_KEY.test(key) ? REDACTED : redactValue(value[key], depth + 1, seen);
+    }
+    return safe;
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactValue(entry, depth + 1, seen));
+  }
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) {
+    // Class instances (a Mongoose document, say) are formatted by util.inspect
+    // as before rather than walked - their constructors decide what is safe.
+    return value;
+  }
+  const safe = {};
+  for (const key of Object.keys(value)) {
+    safe[key] = SENSITIVE_KEY.test(key) ? REDACTED : redactValue(value[key], depth + 1, seen);
+  }
+  return safe;
+};
+
+/**
+ * Read the configured log level from the environment once per logger creation.
+ * An unusable value falls back to the default with a warning on the process
+ * console, so a typo degrades to the safe verbosity instead of silencing logs.
+ *
+ * @returns {String} One of LEVELS
+ */
+const resolveLogLevel = () => {
+  const configured = String(process.env.LOG_LEVEL || '')
+    .trim()
+    .toLowerCase();
+  if (configured === '') return DEFAULT_LEVEL;
+  if (LEVELS.includes(configured)) return configured;
+  console.error(
+    `[LOG] Unsupported LOG_LEVEL "${process.env.LOG_LEVEL}" — falling back to ${DEFAULT_LEVEL}`
+  );
+  return DEFAULT_LEVEL;
+};
+
+/**
+ * Split variadic arguments into message parts and a metadata object.
+ *
+ * A trailing plain object is metadata: its entries are recorded as top-level
+ * JSON fields next to the message instead of being formatted into it. This is
+ * what lets call sites pass `{ requestId }` alongside free-form text while
+ * every other argument combination formats exactly like console.log would.
+ *
+ * @param {Array} args The arguments a log method received
+ * @returns {{parts: Array, meta: Object}}
+ */
+const splitMeta = (args) => {
+  const last = args[args.length - 1];
+  const proto = last === null || last === undefined ? null : Object.getPrototypeOf(last);
+  if (proto === Object.prototype || proto === null) {
+    return { parts: args.slice(0, -1), meta: args[args.length - 1] };
+  }
+  return { parts: args, meta: {} };
+};
+
+/** Fields every record owns; metadata entries may not overwrite them. */
+const RESERVED_FIELDS = new Set(['timestamp', 'level', 'label', 'message', 'correlationId']);
+
+/**
+ * The one-line JSON renderer. Everything a machine needs is at the top level:
+ * `timestamp`, `level`, `label`, optional `correlationId`, the `message`,
+ * then any metadata fields the caller attached.
+ */
+const jsonFormat = printf(
+  ({ level, message, label: runLabel, timestamp: ts, correlationId, ...rest }) => {
+    const record = {
+      timestamp: ts,
+      level,
+      label: runLabel,
+      ...(correlationId !== undefined ? { correlationId } : {}),
+      message,
+    };
+    for (const [key, value] of Object.entries(rest)) {
+      if (!RESERVED_FIELDS.has(key)) {
+        record[key] = value;
+      }
+    }
+    return JSON.stringify(record);
+  }
+);
 
 /**
  * Get a logger
@@ -17,19 +158,29 @@ const myFormat = printf(({ level, message, label, timestamp }) => {
  * only their own lines to their own file, and code that does not receive a
  * logger keeps writing to the process console.
  *
- * The returned object mirrors the console method signatures - every method
- * accepts any number of arguments and formats them exactly like
- * `console.log` does - so it can be used anywhere `console` was used before,
- * including the common `logger.error('message', err)` pair whose error object
- * the old single-argument console replacement silently dropped.
- *
  * @param {String} _label the label of the log
  * @param {String} _filename The file name
+ * @param {Object} [options]
+ * @param {String} [options.correlationId] Correlation identifier written on
+ *   every record this logger emits - a request id, a simulation run id, a
+ *   campaign id - so all of one request's or one run's lines can be pulled
+ *   out of a log with a single filter.
  * @returns {{log: Function, info: Function, warn: Function, error: Function, debug: Function, close: Function}}
  */
-const getLogger = (_label, _filename) => {
+const getLogger = (_label, _filename, options = {}) => {
+  const correlationId =
+    options && options.correlationId !== undefined ? String(options.correlationId) : undefined;
+
+  // Stamped onto every record before rendering, so all of one request's or
+  // one run's lines carry the same identifier.
+  const attachCorrelation = format((info) => {
+    if (correlationId !== undefined) info.correlationId = correlationId;
+    return info;
+  });
+
   const logger = createLogger({
-    format: combine(label({ label: _label }), timestamp(), myFormat, format.colorize()),
+    level: resolveLogLevel(),
+    format: combine(label({ label: _label }), timestamp(), attachCorrelation(), jsonFormat),
     transports: [new transports.File({ filename: _filename })],
   });
 
@@ -39,15 +190,24 @@ const getLogger = (_label, _filename) => {
 
   let closed = false;
   const write = (level, args) => {
+    const { parts, meta } = splitMeta(args);
+    const safeParts = parts.map((part) => redactValue(part));
+    const safeMeta = {};
+    for (const [key, value] of Object.entries(redactValue(meta))) {
+      if (!RESERVED_FIELDS.has(key)) safeMeta[key] = value;
+    }
     if (closed) {
       // The run that owned this file has stopped and its handle has been
       // released. A late asynchronous callback may still try to log; keep the
       // line visible on the process console rather than writing into a closed
       // stream.
-      console[level === 'info' ? 'log' : level](...args);
+      const line = `${util.format(...safeParts)}${
+        Object.keys(safeMeta).length > 0 ? ` ${JSON.stringify(safeMeta)}` : ''
+      }`;
+      console[level === 'info' ? 'log' : level](line);
       return;
     }
-    logger.log(level, util.format(...args));
+    logger.log(level, util.format(...safeParts), safeMeta);
   };
 
   return {
@@ -71,3 +231,9 @@ const getLogger = (_label, _filename) => {
 };
 
 module.exports = getLogger;
+module.exports.getLogger = getLogger;
+module.exports.redactValue = redactValue;
+module.exports.resolveLogLevel = resolveLogLevel;
+module.exports.LEVELS = LEVELS;
+module.exports.DEFAULT_LEVEL = DEFAULT_LEVEL;
+module.exports.REDACTED = REDACTED;

--- a/src/server/middleware/errors.js
+++ b/src/server/middleware/errors.js
@@ -199,22 +199,29 @@ const describe = (value) => {
 /**
  * Record the full detail of a failure server-side.
  *
- * Deliberately one string: `logger/index.js` replaces `console.error` with a
- * single-argument function, so anything passed as a second argument is dropped
- * on the floor once a logger exists — which is how the detail that is no longer
- * in the response would otherwise be lost altogether.
+ * Written to the structured server log (issue #47): the record carries the
+ * request's correlation id when the request context middleware assigned one,
+ * so a client reporting the `X-Request-Id` response header leads straight to
+ * every line this failure produced. The underlying cause travels as its own
+ * argument so the logger's secret redaction walks it before anything lands
+ * in the file.
  *
  * @param {Object} req The request, when there is one
  * @param {ApiError} apiError The normalised failure
  */
 const logFailure = (req, apiError) => {
   const where = req && req.method ? `${req.method} ${req.originalUrl || req.url}` : 'request';
-  const detail = apiError.cause === undefined ? '' : describe(apiError.cause);
   const details = apiError.details ? ` details=${describe(apiError.details)}` : '';
-  console.error(
-    `[SERVER] ${where} -> ${apiError.status} ${apiError.message}${details}${
-      detail ? ` | ${detail}` : ''
-    }`
+  const message = `${where} -> ${apiError.status} ${apiError.message}${details}`;
+  const requestId = req && req.requestId;
+  // Lazy-required: errors.js sits below half the server in the require graph,
+  // and the server log must exist wherever a failure is reported - including
+  // routers mounted standalone in tests.
+  const { getServerLogger } = require('./request-context');
+  getServerLogger().error(
+    message,
+    ...(apiError.cause !== undefined ? [apiError.cause] : []),
+    ...(requestId ? [{ requestId }] : [])
   );
 };
 

--- a/src/server/middleware/request-context.js
+++ b/src/server/middleware/request-context.js
@@ -1,0 +1,79 @@
+const { randomUUID } = require('crypto');
+const path = require('path');
+const getLogger = require('../logger');
+
+/**
+ * Request correlation (issue #47).
+ *
+ * Every request is given a correlation identifier - an incoming trusted
+ * `X-Request-Id` is honoured, anything else gets a fresh UUID - which is
+ * echoed back in the response header, attached to the access record written
+ * when the response finishes, and read by the central error handler so its
+ * failure records carry it too. All of one request's lines can therefore be
+ * pulled out of the server log with a single filter.
+ *
+ * The identifier is bounded to characters that are safe in a header and a
+ * JSON log line, so a caller cannot smuggle markup or control characters into
+ * either through their own header.
+ */
+
+/** The process-wide server logger: one structured stream for request traffic. */
+let serverLogger = null;
+
+/**
+ * The server access/error log lives beside the run logs. Created once per
+ * process; failures opening it are winston's to surface, exactly as for run
+ * logs.
+ */
+const getServerLogger = () => {
+  if (!serverLogger) {
+    serverLogger = getLogger('SERVER', path.join(__dirname, '..', 'logs', 'server.log'));
+  }
+  return serverLogger;
+};
+
+/**
+ * Characters a correlation id may carry: letters, digits and the separators
+ * an operator's own tracing headers plausibly use. Anything else - and any
+ * id longer than 64 characters - is discarded in favour of a fresh UUID.
+ */
+const SAFE_REQUEST_ID = /^[A-Za-z0-9._-]{1,64}$/;
+
+/**
+ * Build the middleware.
+ *
+ * @param {Object} [options]
+ * @param {Function} [options.logger] Overrides the shared server logger
+ *   (tests inject one rather than touching files)
+ * @param {Boolean} [options.accessLog] Write one record per completed
+ *   request (default true)
+ * @returns {Function} Express middleware
+ */
+const requestContext = (options = {}) => {
+  const accessLog = options.accessLog !== false;
+  return function requestContextMiddleware(req, res, next) {
+    const incoming = String((req.get && req.get('x-request-id')) || '').trim();
+    const requestId = SAFE_REQUEST_ID.test(incoming) ? incoming : randomUUID();
+    req.requestId = requestId;
+    res.setHeader('X-Request-Id', requestId);
+
+    if (!accessLog) return next();
+
+    const startedAt = Date.now();
+    res.on('finish', () => {
+      // One line per request: what was asked, what was answered, how long it
+      // took, under which correlation id. Emitted after the response so the
+      // status it reports is final.
+      getServerLogger().info(`${req.method} ${req.originalUrl || req.url}`, {
+        requestId,
+        method: req.method,
+        path: req.originalUrl || req.url,
+        status: res.statusCode,
+        durationMs: Date.now() - startedAt,
+      });
+    });
+    return next();
+  };
+};
+
+module.exports = { requestContext, getServerLogger, SAFE_REQUEST_ID };

--- a/src/server/middleware/validate.js
+++ b/src/server/middleware/validate.js
@@ -68,6 +68,7 @@ const validate = (schemas = {}) => {
   const compiled = SECTIONS.map(({ key, options }) => ({
     key,
     options,
+    declared: schemas[key] !== undefined && schemas[key] !== null,
     schema: compileSchema(
       schemas[key] === undefined || schemas[key] === null ? NOTHING_DECLARED : schemas[key]
     ),
@@ -75,7 +76,7 @@ const validate = (schemas = {}) => {
 
   // Named so a route's middleware stack can be inspected for it: the test
   // suite asserts every endpoint declares a schema by looking for this layer.
-  return function validateRequest(req, res, next) {
+  const validateRequest = function validateRequest(req, res, next) {
     const details = [];
     const validated = [];
 
@@ -110,6 +111,18 @@ const validate = (schemas = {}) => {
 
     return next();
   };
+
+  // Published on the middleware itself (issue #47): the OpenAPI generator
+  // reads these compiled schemas off each route's stack instead of anyone
+  // restating them elsewhere, which is what makes a generated specification
+  // unable to drift from what actually validates a request. Sections the
+  // endpoint did not declare are absent rather than empty-schema entries.
+  validateRequest.validationSchemas = compiled.reduce((acc, { key, declared, schema }) => {
+    if (declared) acc[key] = schema;
+    return acc;
+  }, {});
+
+  return validateRequest;
 };
 
 /**

--- a/src/server/openapi/generate-openapi.js
+++ b/src/server/openapi/generate-openapi.js
@@ -1,0 +1,272 @@
+const { toOpenApiSchema } = require('./joi-to-openapi');
+
+/**
+ * Build the API specification from the mounted routers (issue #47).
+ *
+ * The generator walks the mount manifest the application itself declares -
+ * the same array its `app.use` calls iterate - and, for every route in every
+ * mounted router, reads the compiled `joi` schemas off the `validate`
+ * middleware layer. Nothing about an endpoint's inputs is restated here, so
+ * the published specification cannot drift from what actually validates a
+ * request: a route added to a router appears the next time this runs, with
+ * exactly the constraints its schema declares.
+ *
+ * Responses are documented from the single error shape every failure takes
+ * (`middleware/errors.js`) plus the statuses the shared middleware can answer
+ * with; success bodies are described as JSON objects because handler shapes
+ * are code, not declared schemas.
+ */
+
+/** HTTP methods Express stores on a route, in documentation order. */
+const METHODS = ['get', 'post', 'put', 'patch', 'delete'];
+
+/**
+ * Convert an Express-style path (`/stop/:fileName`) into an OpenAPI template
+ * (`/stop/{fileName}`).
+ */
+const toOpenApiPath = (value) => value.replace(/:([A-Za-z0-9_]+)/g, (_, name) => `{${name}}`);
+
+/**
+ * Collect the parameter names an Express path declares.
+ */
+const pathParamNames = (value) => {
+  const names = [];
+  for (const match of value.matchAll(/:([A-Za-z0-9_]+)/g)) names.push(match[1]);
+  return names;
+};
+
+/**
+ * The reusable responses every operation documents: the central error shape
+ * plus the statuses the app-wide middleware (authentication, CSRF, rate
+ * limiting) can answer with before any handler runs.
+ */
+const standardResponses = ({ authenticated }) => {
+  const responses = {
+    400: { $ref: '#/components/responses/ValidationError' },
+    // The app-wide rate limiter covers every endpoint, public or not.
+    429: { $ref: '#/components/responses/RateLimited' },
+    500: { $ref: '#/components/responses/InternalError' },
+  };
+  if (authenticated) {
+    responses[401] = { $ref: '#/components/responses/Unauthorized' };
+    // CSRF refusal lands on state-changing requests from an authenticated
+    // session that did not echo the token.
+    responses[403] = { $ref: '#/components/responses/Forbidden' };
+  }
+  return responses;
+};
+
+/**
+ * Describe one operation from its route layer.
+ */
+const buildOperation = ({ method, validateLayer, authenticated }) => {
+  // The compiled schemas live on the middleware function itself (`validate()`
+  // publishes them there); the layer merely carries the function.
+  const middleware = validateLayer && validateLayer.handle;
+  const schemas = (middleware && middleware.validationSchemas) || {};
+  const operation = {
+    responses: {
+      200: {
+        description: 'Successful response',
+        content: { 'application/json': { schema: { type: 'object' } } },
+      },
+      ...standardResponses({ authenticated }),
+    },
+  };
+
+  const parameters = [];
+  if (schemas.params) {
+    const converted = toOpenApiSchema(schemas.params);
+    for (const [name, schema] of Object.entries(converted.properties || {})) {
+      parameters.push({
+        name,
+        in: 'path',
+        required: true,
+        schema,
+      });
+    }
+  }
+  if (schemas.query) {
+    const converted = toOpenApiSchema(schemas.query);
+    for (const [name, schema] of Object.entries(converted.properties || {})) {
+      parameters.push({
+        name,
+        in: 'query',
+        required: Boolean(converted.required && converted.required.includes(name)),
+        schema,
+      });
+    }
+  }
+  if (parameters.length > 0) operation.parameters = parameters;
+
+  if (schemas.body) {
+    const converted = toOpenApiSchema(schemas.body);
+    if (converted.properties && Object.keys(converted.properties).length > 0) {
+      operation.requestBody = {
+        required: Array.isArray(converted.required) && converted.required.length > 0,
+        content: { 'application/json': { schema: converted } },
+      };
+    }
+  }
+
+  return operation;
+};
+
+/**
+ * Walk one router's stack and collect its operations keyed by OpenAPI path.
+ *
+ * @param {Object} router An Express router
+ * @param {String} prefix The path the application mounts it under
+ * @param {Object} paths Accumulator mapping OpenAPI paths to operations
+ * @param {Object} options
+ * @param {Boolean} options.publicRouter Endpoints here answer without a session
+ */
+const collectRouterPaths = (router, prefix, paths, options) => {
+  for (const layer of router.stack || []) {
+    if (!layer.route || !layer.route.path || !layer.route.methods) continue;
+    const expressPath = `${prefix}${layer.route.path === '/' ? '' : layer.route.path}`;
+    const openApiPath = toOpenApiPath(expressPath);
+    // Find this route's validation layer by name: `validate()` returns a
+    // function named `validateRequest` carrying its compiled schemas.
+    const validateLayer = (layer.route.stack || []).find(
+      (entry) => entry.handle && entry.handle.name === 'validateRequest'
+    );
+
+    for (const method of METHODS) {
+      if (!layer.route.methods[method]) continue;
+      // eslint-disable-next-line no-param-reassign
+      paths[openApiPath] = paths[openApiPath] || {};
+      // Every operation gets at least the standard success/error envelope;
+      // a declared schema adds its inputs on top.
+      // eslint-disable-next-line no-param-reassign
+      paths[openApiPath][method] = buildOperation({
+        method,
+        validateLayer,
+        authenticated: !options.publicRouter,
+      });
+    }
+  }
+};
+
+/**
+ * Assemble the whole document.
+ *
+ * @param {Object} options
+ * @param {Array<{prefix: String, router: Object, public?: Boolean}>} options.mounts
+ *   The application's own mount declarations, in mounting order
+ * @param {String} [options.title]
+ * @param {String} [options.version]
+ * @param {String} [options.serverUrl]
+ * @returns {Object} An OpenAPI 3.0 document
+ */
+const buildOpenApiDocument = ({
+  mounts,
+  title = 'TaS API',
+  version = '1.0.0',
+  serverUrl = '/',
+}) => {
+  const paths = {};
+  for (const { prefix, router, public: publicRouter } of mounts) {
+    collectRouterPaths(router, prefix, paths, { publicRouter: Boolean(publicRouter) });
+  }
+
+  // OpenAPI requires every `{param}` a template names to be declared per
+  // operation. An endpoint whose schema did not declare one of its own path
+  // parameters still gets an honest (unconstrained) string entry rather than
+  // a document that fails validation.
+  for (const [template, operations] of Object.entries(paths)) {
+    for (const op of Object.values(operations)) {
+      const declared = new Set(
+        (op.parameters || []).filter((p) => p.in === 'path').map((p) => p.name)
+      );
+      const missing = pathParamNames(template).filter((name) => !declared.has(name));
+      if (missing.length === 0) continue;
+      // eslint-disable-next-line no-param-reassign
+      op.parameters = (op.parameters || []).concat(
+        missing.map((name) => ({ name, in: 'path', required: true, schema: { type: 'string' } }))
+      );
+    }
+  }
+
+  return {
+    openapi: '3.0.3',
+    info: {
+      title,
+      description:
+        'Test and Simulation Enabler API. Generated from the request validation schemas the server enforces, so it cannot drift from the implementation.',
+      version,
+    },
+    servers: [{ url: serverUrl }],
+    components: {
+      schemas: {
+        Error: {
+          type: 'object',
+          properties: {
+            error: { type: 'string', description: 'A caller-safe failure message.' },
+            details: {
+              type: 'array',
+              description: 'Per-field breakdown, carried by validation failures.',
+              items: {
+                type: 'object',
+                properties: {
+                  location: { type: 'string', enum: ['params', 'query', 'body'] },
+                  field: { type: 'string' },
+                  message: { type: 'string' },
+                  type: { type: 'string' },
+                },
+              },
+            },
+          },
+          required: ['error'],
+        },
+      },
+      responses: {
+        ValidationError: {
+          description: 'The request was malformed or failed validation.',
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/Error' } },
+          },
+        },
+        Unauthorized: {
+          description: 'No session, or it has expired.',
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/Error' } },
+          },
+        },
+        Forbidden: {
+          description: 'The session may not do this (missing CSRF token, disallowed origin).',
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/Error' } },
+          },
+        },
+        NotFound: {
+          description: 'The addressed resource does not exist.',
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/Error' } },
+          },
+        },
+        Conflict: {
+          description: 'The request cannot be applied to the current resource state.',
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/Error' } },
+          },
+        },
+        RateLimited: {
+          description: 'Too many requests from this client; retry later.',
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/Error' } },
+          },
+        },
+        InternalError: {
+          description: 'An unclassified server-side failure.',
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/Error' } },
+          },
+        },
+      },
+    },
+    paths,
+  };
+};
+
+module.exports = { buildOpenApiDocument, toOpenApiPath, pathParamNames };

--- a/src/server/openapi/joi-to-openapi.js
+++ b/src/server/openapi/joi-to-openapi.js
@@ -1,0 +1,182 @@
+const Joi = require('joi');
+
+/**
+ * Convert the request validation schemas into OpenAPI 3.0 schema objects
+ * (issue #47).
+ *
+ * The specification is generated from exactly the compiled `joi` schemas the
+ * `validate` middleware enforces - read off each route's middleware stack, not
+ * restated anywhere - so what the API accepts and what its specification says
+ * cannot drift apart.
+ *
+ * The converter understands the subset of joi this codebase's schemas use:
+ * objects (with unknown-key and forbidden-pattern rules), strings, numbers,
+ * booleans, arrays, alternatives, enums, length/pattern bounds, defaults and
+ * nullable allows. Anything it does not recognise converts permissively to an
+ * empty schema rather than failing: a specification that omits a constraint it
+ * cannot express is wrong in the safe direction, and one that throws is no
+ * specification at all.
+ */
+
+/** OpenAPI 3.0 format hint for an http(s) URI string. */
+const URI_FORMAT = 'uri';
+
+/**
+ * Normalise a regex the way `describe()` reports pattern rules: either a real
+ * RegExp or the string form `/pattern/flags`.
+ */
+const describeRegex = (regex) => {
+  if (regex instanceof RegExp) return regex.source;
+  const text = String(regex || '');
+  const match = /^\/(.*)\/[a-z]*$/.exec(text);
+  return match ? match[1] : text;
+};
+
+/**
+ * Apply a single named rule from a `describe()` node onto an OpenAPI schema.
+ * Unknown rule names are ignored.
+ */
+const applyRule = (schema, name, args) => {
+  switch (name) {
+    case 'min':
+      if (schema.type === 'string') schema.minLength = args.limit;
+      else schema.minimum = args.limit;
+      break;
+    case 'max':
+      if (schema.type === 'string') schema.maxLength = args.limit;
+      else schema.maximum = args.limit;
+      break;
+    case 'integer':
+      schema.type = 'integer';
+      break;
+    case 'sign':
+      // `positive`/`negative`: expressed as an exclusive bound on zero.
+      if (args.sign === 'positive') {
+        schema.exclusiveMinimum = 0;
+        delete schema.minimum;
+      } else if (args.sign === 'negative') {
+        schema.exclusiveMaximum = 0;
+        delete schema.maximum;
+      }
+      break;
+    case 'pattern':
+    case 'regex':
+      schema.pattern = describeRegex(args.regex);
+      break;
+    case 'uri':
+      schema.format = URI_FORMAT;
+      break;
+    case 'email':
+      schema.format = 'email';
+      break;
+    case 'iso':
+      schema.format = 'date-time';
+      break;
+    default:
+      break;
+  }
+};
+
+/**
+ * Convert one `describe()` node. Returns a fresh object every call; never
+ * mutates the input.
+ */
+const convertNode = (node) => {
+  if (!node || typeof node !== 'object') return {};
+
+  const schema = {};
+  const type = node.type;
+
+  if (type === 'alternatives') {
+    const branches = (node.matches || [])
+      .map((match) => (match.schema ? convertNode(match.schema) : null))
+      .filter(Boolean);
+    return branches.length > 0 ? { anyOf: branches } : {};
+  }
+
+  switch (type) {
+    case 'object': {
+      schema.type = 'object';
+      const properties = {};
+      const required = [];
+      for (const [key, child] of Object.entries(node.keys || {})) {
+        properties[key] = convertNode(child);
+        if (child.flags && child.flags.presence === 'required') required.push(key);
+      }
+      if (Object.keys(properties).length > 0) schema.properties = properties;
+      if (required.length > 0) schema.required = required.sort();
+      // `unknown(true)` tolerates round-tripped fields; anything else is
+      // validated against declared keys only, which OpenAPI spells as a
+      // closed object.
+      schema.additionalProperties = Boolean(node.flags && node.flags.unknown);
+      // Forbidden operator-key patterns are a database-safety rule with no
+      // faithful OpenAPI spelling; they are documented once in the guide
+      // rather than approximated per property here.
+      break;
+    }
+    case 'array':
+      schema.type = 'array';
+      if (Array.isArray(node.items) && node.items.length > 0) {
+        schema.items = convertNode(node.items[0]);
+      }
+      break;
+    case 'number':
+      schema.type = 'number';
+      break;
+    case 'boolean':
+      schema.type = 'boolean';
+      break;
+    case 'function':
+    case 'symbol':
+      return { type: 'string' };
+    case 'string':
+    default:
+      schema.type = 'string';
+      break;
+  }
+
+  for (const rule of node.rules || []) {
+    applyRule(schema, rule.name, rule.args || {});
+  }
+
+  // `valid()` marks the schema `only` and lists its values in `allow`; that
+  // closed set is worth publishing as an enum.
+  const allowed = node.allow || [];
+  if (node.flags && node.flags.only) {
+    const valids = allowed.filter((value) => value !== null && value !== '');
+    if (valids.length > 0 && type !== 'object') schema.enum = valids;
+  }
+
+  // A nullable allow is OpenAPI 3.0's `nullable`; an empty-string allow only
+  // says the field may be blank, which the type already admits.
+  if (allowed.includes(null)) {
+    schema.nullable = true;
+  }
+
+  if (node.flags) {
+    if (node.flags.default !== undefined && typeof node.flags.default !== 'function') {
+      schema.default = node.flags.default;
+    }
+    if (node.flags.description) schema.description = node.flags.description;
+  }
+
+  return schema;
+};
+
+/**
+ * Convert a joi schema (compiled or plain) into an OpenAPI 3.0 schema object.
+ *
+ * @param {Object|Joi.Schema} schema The validation schema as written
+ * @returns {Object} An OpenAPI schema object
+ */
+const toOpenApiSchema = (schema) => {
+  try {
+    const described = Joi.isSchema(schema) ? schema.describe() : Joi.compile(schema).describe();
+    return convertNode(described);
+  } catch (_) {
+    // A schema this converter cannot describe must not break generation.
+    return {};
+  }
+};
+
+module.exports = { toOpenApiSchema };

--- a/src/server/routes/data-recorders.js
+++ b/src/server/routes/data-recorders.js
@@ -247,7 +247,10 @@ const startRecorder = async (model, res, next) => {
   }
   const startedTime = Date.now();
   const logFile = `${name}_${startedTime}.log`;
-  const logger = getLogger('DATA-RECORDER', `${logsPath}${logFile}`);
+  // Every record of this run carries the recorder's id (issue #47).
+  const logger = getLogger('DATA-RECORDER', `${logsPath}${logFile}`, {
+    correlationId: recorderId,
+  });
   // Persistence failures degrade to memory-only tracking (warned once inside
   // the registry); they never fail a start that itself succeeded.
   const registerStarted = (recorder, record) =>

--- a/src/server/routes/devops.js
+++ b/src/server/routes/devops.js
@@ -220,7 +220,7 @@ router.get('/start', validate(), loadValidatedDevops, dbConnector, (req, res, ne
       releaseSlot();
       return sendBadRequest(res, 'Invalid test campaign id');
     }
-    const logger = getLogger('TEST-CAMPAIGN', logFilePath);
+    const logger = getLogger('TEST-CAMPAIGN', logFilePath, { correlationId: testCampaignId });
     logger.log('[devops] A test campaign is going to be started ...');
 
     const launch = async (storage, withDevops) => {

--- a/src/server/routes/simulation.js
+++ b/src/server/routes/simulation.js
@@ -212,7 +212,9 @@ const startSimulation = async (model, options = {}, res, next, modelFileName = n
   }
   const startedTime = Date.now();
   const logFile = `${name}_${Date.now()}.log`;
-  const logger = getLogger('SIMULATION', `${logsPath}${logFile}`);
+  // The run's own records all carry the run id, so everything one simulation
+  // wrote can be pulled out of its file (and the server log) with one filter.
+  const logger = getLogger('SIMULATION', `${logsPath}${logFile}`, { correlationId: simId });
   if (!model.dataStorage && !options.dataStorage) {
     // Use default data storage
     getDataStorage(async (err, ds) => {

--- a/test/e2e/simulation-lifecycle.test.js
+++ b/test/e2e/simulation-lifecycle.test.js
@@ -651,7 +651,9 @@ test('a run whose data storage fails logs the message together with the underlyi
 
     // The message alone is not enough: the same output must carry the
     // underlying error and the connection parameters the logger was handed,
-    // exactly the detail a single-argument console replacement drops.
+    // exactly the detail a single-argument console replacement drops. Records
+    // are structured now (issue #47): the connection parameters arrive as
+    // top-level JSON fields rather than inspected into the message text.
     assert.match(
       content,
       /ECONNREFUSED/,
@@ -659,7 +661,7 @@ test('a run whose data storage fails logs the message together with the underlyi
     );
     assert.match(
       content,
-      /dbname:\s*'tas-e2e-unreachable'/,
+      /"dbname"\s*:\s*"tas-e2e-unreachable"/,
       `the logged context must name the failed connection:\n${content}`
     );
   } finally {

--- a/test/http-status.test.js
+++ b/test/http-status.test.js
@@ -465,22 +465,19 @@ test('a database failure the schemas cannot express maps onto its own status', a
 test('an unreadable server configuration answers 500 and keeps the detail in the log', async () => {
   // A Node fs error carries the absolute path it failed to open in its own
   // enumerable properties. The response must carry a constant message, and the
-  // log must still carry enough to diagnose it.
+  // structured server log (issue #47) must still carry enough to diagnose it.
   const modulePath = require.resolve('../src/server/routes/devops');
-  const lines = [];
-  const realConsoleError = console.error;
+  const serverLogPath = path.join(__dirname, '..', 'src', 'server', 'logs', 'server.log');
   fs.unlinkSync(devopsFile);
   delete require.cache[modulePath];
   const coldApp = express();
   coldApp.use(express.json());
   coldApp.use('/api/devops', require(modulePath));
   const coldServer = coldApp.listen(0);
-  console.error = (message) => lines.push(String(message));
   let res;
   try {
     res = await request(coldServer, 'GET', '/api/devops');
   } finally {
-    console.error = realConsoleError;
     coldServer.close();
     fs.writeFileSync(devopsFile, originalDevops);
     delete require.cache[modulePath];
@@ -490,32 +487,67 @@ test('an unreadable server configuration answers 500 and keeps the detail in the
   assert.equal(res.body.error, 'Cannot get devops configuration');
   assert.ok(!res.raw.includes('devops.json'), `must not disclose the config path: ${res.raw}`);
 
-  const logged = lines.join('\n');
-  assert.ok(logged.includes('GET /api/devops'), `the log must name the request: ${logged}`);
-  assert.ok(logged.includes('500'), `the log must carry the status: ${logged}`);
-  assert.ok(
-    logged.includes('ENOENT') && logged.includes('devops.json'),
-    `the log must keep the detail the response no longer carries: ${logged}`
-  );
+  // The failure record is one JSON line naming the request, the status and
+  // the cause detail the response no longer carries. Winston writes
+  // asynchronously, so poll for the line before asserting on it.
+  let record = null;
+  for (let i = 0; i < 50 && !record; i += 1) {
+    try {
+      for (const line of fs.readFileSync(serverLogPath, 'utf8').split('\n')) {
+        if (
+          line.includes('GET /api/devops') &&
+          line.includes('Cannot get devops configuration') &&
+          line.includes('ENOENT') &&
+          line.includes('devops.json')
+        ) {
+          record = JSON.parse(line);
+        }
+      }
+    } catch (_) {
+      /* log not written yet */
+    }
+    if (!record) await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert.ok(record, 'the failure must be recorded as one structured line');
+  assert.match(record.message, /GET \/api\/devops -> 500/);
 });
 
-test('the log keeps the detail of every failure, in one line the file logger keeps', async () => {
-  // `logger/index.js` replaces console.error with a single-argument function,
-  // so a handler that logged the error as a second argument would drop exactly
-  // the detail it removed from the response.
+test('the log keeps the detail of every failure, in one record the file logger keeps', async () => {
+  // A failure is recorded once, as one structured record carrying both the
+  // caller-safe message and the full underlying cause - the detail the
+  // response itself must never disclose.
   const probe = probeApp().listen(0);
-  const lines = [];
-  const realConsoleError = console.error;
-  console.error = (...args) => lines.push(args);
+  const serverLogPath = path.join(__dirname, '..', 'src', 'server', 'logs', 'server.log');
+  const readRecords = () =>
+    fs
+      .readFileSync(serverLogPath, 'utf8')
+      .split('\n')
+      .filter((line) => line.includes('/unclassified'))
+      .map((line) => JSON.parse(line));
+  const before = (() => {
+    try {
+      return readRecords().length;
+    } catch (_) {
+      return 0;
+    }
+  })();
   try {
     await request(probe, 'GET', '/unclassified');
   } finally {
-    console.error = realConsoleError;
     probe.close();
   }
-  assert.equal(lines.length, 1, 'one failure must produce one log line');
-  assert.equal(lines[0].length, 1, 'the whole detail must be in the first argument');
-  const logged = String(lines[0][0]);
+  let records = [];
+  for (let i = 0; i < 50 && records.length === 0; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    try {
+      records = readRecords();
+    } catch (_) {
+      /* log not written yet */
+    }
+  }
+  assert.equal(records.length - before, 1, 'one failure must produce one error record');
+  const logged = JSON.stringify(records[records.length - 1]);
+  assert.match(records[records.length - 1].message, /GET \/unclassified -> 500/);
   assert.ok(logged.includes('/home/secret'), `the log must keep the path: ${logged}`);
   assert.ok(logged.includes('ENOENT'), `the log must keep the cause: ${logged}`);
 });

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,16 +1,19 @@
 /**
- * Per-run logging (issue #15).
+ * Per-run logging (issues #15 and #47).
  *
  * Starting a run used to reassign the global console methods so every line on
  * the server landed in whichever run started most recently, file handles of
  * earlier runs were never released, and the single-argument replacement
  * silently dropped the error object of the very common
- * `console.error('message', err)` pair.
+ * `console.error('message', err)` pair (#15). The records were also free text,
+ * so nothing tied one request's or one run's lines together (#47).
  *
- * These tests pin the replacement shape: the factory never touches the global
- * console, each run writes only its own lines to its own file through a logger
- * passed explicitly to the code that needs it, an error logged next to a
- * message keeps its detail, and stopping a run releases its handle.
+ * These tests pin the current shape: the factory never touches the global
+ * console, each run writes only its own lines to its own file through a
+ * logger passed explicitly to the code that needs it, an error logged next to
+ * a message keeps its detail, stopping a run releases its handle - and every
+ * record is one machine-parseable JSON object carrying the run's correlation
+ * identifier, honouring LOG_LEVEL, and never repeating a secret it was handed.
  */
 const { test, describe } = require('node:test');
 const assert = require('node:assert/strict');
@@ -33,6 +36,25 @@ const openFdCount = () => {
   } catch (_) {
     return null;
   }
+};
+
+/**
+ * Parse every complete JSON line of a log file. Returns the records plus any
+ * line that failed to parse, so a test can assert machine-parseability itself
+ * rather than assuming it.
+ */
+const parseLines = (content) => {
+  const records = [];
+  const unparsable = [];
+  for (const line of content.split('\n')) {
+    if (line.trim() === '') continue;
+    try {
+      records.push(JSON.parse(line));
+    } catch (_) {
+      unparsable.push(line);
+    }
+  }
+  return { records, unparsable };
 };
 
 /**
@@ -98,6 +120,26 @@ test('the logger factory never reassigns global console methods', () => {
   }
 });
 
+test('every record is one machine-parseable JSON object with time, level and label', async () => {
+  const dir = tempLogDir('json-shape');
+  const file = path.join(dir, 'run.log');
+  const logger = getLogger('JSON-SHAPE', file);
+  try {
+    logger.info('the structured record');
+    const content = await waitForFileContent(file, (c) => c.includes('the structured record'));
+    const { records, unparsable } = parseLines(content);
+    assert.deepEqual(unparsable, [], 'every line must parse as JSON');
+    const record = records.find((r) => r.message === 'the structured record');
+    assert.ok(record, 'the record must be present');
+    assert.equal(record.level, 'info');
+    assert.equal(record.label, 'JSON-SHAPE');
+    assert.ok(record.timestamp, 'the record must carry a timestamp');
+    assert.ok(!Number.isNaN(Date.parse(record.timestamp)), 'the timestamp must be ISO-8601');
+  } finally {
+    logger.close();
+  }
+});
+
 test('a message logged together with an error keeps the error detail', async () => {
   const dir = tempLogDir('error-detail');
   const file = path.join(dir, 'run.log');
@@ -105,10 +147,13 @@ test('a message logged together with an error keeps the error detail', async () 
   try {
     logger.error('Cannot update the score for report r-1', new Error('boom-detail'));
     const content = await waitForFileContent(file, (c) => c.includes('boom-detail'));
-    assert.match(content, /Cannot update the score for report r-1/);
-    assert.match(content, /Error: boom-detail/, 'the error itself must be in the log');
-    assert.match(content, /\[ERR-DETAIL\]/, 'the label must identify the run');
-    assert.match(content, /error:/, 'the level must say this is an error');
+    const { records, unparsable } = parseLines(content);
+    assert.deepEqual(unparsable, [], 'every line must parse as JSON');
+    const record = records.find((r) => r.message.includes('Cannot update the score'));
+    assert.ok(record, 'the record must be present');
+    assert.match(record.message, /Error: boom-detail/, 'the error itself must be in the message');
+    assert.equal(record.label, 'ERR-DETAIL', 'the label must identify the run');
+    assert.equal(record.level, 'error', 'the level must say this is an error');
   } finally {
     logger.close();
   }
@@ -129,10 +174,17 @@ test('two runs started concurrently write only their own lines to their own file
       waitForFileContent(fileA, (c) => c.includes('line-that-belongs-to-a')),
       waitForFileContent(fileB, (c) => c.includes('line-that-belongs-to-b')),
     ]);
+    const [a, b] = [parseLines(contentA), parseLines(contentB)];
+    assert.ok(
+      a.records.every((r) => r.label === 'RUN-A'),
+      'A records must be labelled RUN-A'
+    );
+    assert.ok(
+      b.records.every((r) => r.label === 'RUN-B'),
+      'B records must be labelled RUN-B'
+    );
     assert.ok(!contentA.includes('line-that-belongs-to-b'), 'A must not receive B lines');
     assert.ok(!contentB.includes('line-that-belongs-to-a'), 'B must not receive A lines');
-    assert.match(contentA, /\[RUN-A\]/);
-    assert.match(contentB, /\[RUN-B\]/);
   } finally {
     loggerA.close();
     loggerB.close();
@@ -181,17 +233,194 @@ test('closing a run logger releases its handle and stays safe afterwards', async
   );
 });
 
-test('the wrapper formats multiple arguments like console.log does', async () => {
-  const dir = tempLogDir('variadic');
+test('a trailing plain object becomes top-level metadata fields', async () => {
+  const dir = tempLogDir('meta');
   const file = path.join(dir, 'run.log');
-  const logger = getLogger('VARIADIC', file);
+  const logger = getLogger('META', file);
   try {
     logger.log('values:', 42, { a: 1 });
-    const content = await waitForFileContent(file, (c) => c.includes('42'));
-    assert.match(content, /values: 42 \{ a: 1 \}/);
+    const content = await waitForFileContent(file, (c) => c.includes('"a"'));
+    const { records } = parseLines(content);
+    const record = records.find((r) => r.a === 1);
+    assert.ok(record, 'the metadata must land on the record');
+    assert.equal(record.message, 'values: 42', 'non-object arguments stay in the message');
+    assert.equal(record.a, 1, 'object entries are hoisted to top-level fields');
   } finally {
     logger.close();
   }
+});
+
+// ---------------------------------------------------------------------------
+// Structured logging (issue #47)
+// ---------------------------------------------------------------------------
+
+describe('correlation identifiers', () => {
+  test('every record carries the correlation id the logger was created with', async () => {
+    const dir = tempLogDir('corr');
+    const file = path.join(dir, 'run.log');
+    const logger = getLogger('CORR', file, { correlationId: 'sim-47-correlation' });
+    try {
+      logger.info('first correlated line');
+      logger.warn('second correlated line');
+      logger.error('third correlated line');
+      const content = await waitForFileContent(file, (c) => c.includes('third correlated line'));
+      const { records, unparsable } = parseLines(content);
+      assert.deepEqual(unparsable, []);
+      const mine = records.filter((r) => r.correlationId !== undefined);
+      assert.ok(mine.length >= 3, 'all three records must be present');
+      assert.ok(
+        mine.every((r) => r.correlationId === 'sim-47-correlation'),
+        'every record must repeat the same correlation id'
+      );
+    } finally {
+      logger.close();
+    }
+  });
+
+  test('records from two correlated loggers never mix identifiers', async () => {
+    const dirA = tempLogDir('corr-a');
+    const dirB = tempLogDir('corr-b');
+    const loggerA = getLogger('RUN-A', path.join(dirA, 'a.log'), { correlationId: 'run-a-id' });
+    const loggerB = getLogger('RUN-B', path.join(dirB, 'b.log'), { correlationId: 'run-b-id' });
+    try {
+      loggerA.log('a-line');
+      loggerB.log('b-line');
+      const [contentA, contentB] = await Promise.all([
+        waitForFileContent(path.join(dirA, 'a.log'), (c) => c.includes('a-line')),
+        waitForFileContent(path.join(dirB, 'b.log'), (c) => c.includes('b-line')),
+      ]);
+      for (const record of parseLines(contentA).records) {
+        if (record.correlationId !== undefined) assert.equal(record.correlationId, 'run-a-id');
+      }
+      for (const record of parseLines(contentB).records) {
+        if (record.correlationId !== undefined) assert.equal(record.correlationId, 'run-b-id');
+      }
+    } finally {
+      loggerA.close();
+      loggerB.close();
+    }
+  });
+
+  test('a logger created without one omits the field entirely', async () => {
+    const dir = tempLogDir('no-corr');
+    const file = path.join(dir, 'run.log');
+    const logger = getLogger('NO-CORR', file);
+    try {
+      logger.log('uncorrelated line');
+      const content = await waitForFileContent(file, (c) => c.includes('uncorrelated line'));
+      const { records } = parseLines(content);
+      const record = records.find((r) => r.message === 'uncorrelated line');
+      assert.ok(record, 'the record must be present');
+      assert.equal(
+        Object.prototype.hasOwnProperty.call(record, 'correlationId'),
+        false,
+        'no correlation id means no correlationId field'
+      );
+    } finally {
+      logger.close();
+    }
+  });
+});
+
+describe('secret redaction', () => {
+  test('sensitive keys are redacted wherever they appear in logged objects', async () => {
+    const dir = tempLogDir('redact');
+    const file = path.join(dir, 'run.log');
+    const logger = getLogger('REDACT', file);
+    try {
+      logger.log('connection attempt', {
+        username: 'operator',
+        password: 'super-secret-pw-47',
+        token: 'tok-abc',
+        nested: { sessionSecret: 'sess-secret', host: '127.0.0.1' },
+        apiKey: 'key-xyz',
+        safe: 'plain-value',
+      });
+      const content = await waitForFileContent(file, (c) => c.includes('plain-value'));
+      const { records } = parseLines(content);
+      const record = records.find((r) => typeof r.safe === 'string' && r.safe === 'plain-value');
+      assert.ok(record, 'the record with safe fields must exist');
+      assert.ok(!content.includes('super-secret-pw-47'), 'password value must never appear');
+      assert.ok(!content.includes('tok-abc'), 'token value must never appear');
+      assert.ok(!content.includes('sess-secret'), 'nested secret value must never appear');
+      assert.ok(!content.includes('key-xyz'), 'api key value must never appear');
+      assert.equal(record.username, 'operator', 'non-sensitive fields survive');
+      assert.equal(record.nested.host, '127.0.0.1', 'nested non-sensitive fields survive');
+      assert.equal(record.password, '[REDACTED]', 'password becomes the redaction marker');
+      assert.equal(record.token, '[REDACTED]');
+      assert.equal(record.apiKey, '[REDACTED]');
+      assert.equal(record.nested.sessionSecret, '[REDACTED]');
+    } finally {
+      logger.close();
+    }
+  });
+
+  test('an error carrying a credential-shaped property does not leak it either', async () => {
+    const dir = tempLogDir('redact-err');
+    const file = path.join(dir, 'run.log');
+    const logger = getLogger('REDACT-ERR', file);
+    try {
+      const err = new Error('connect failed');
+      err.connConfig = { password: 'leaky-pw-47', host: 'db.internal' };
+      logger.error('cannot store data', err);
+      const content = await waitForFileContent(file, (c) => c.includes('connect failed'));
+      assert.ok(!content.includes('leaky-pw-47'), 'the credential property must be redacted');
+      assert.match(content, /db\.internal/, 'harmless detail stays');
+    } finally {
+      logger.close();
+    }
+  });
+});
+
+describe('log level configuration', () => {
+  test('debug records are suppressed at the default level and kept under LOG_LEVEL=debug', async () => {
+    const quietDir = tempLogDir('level-default');
+    const quietLogger = getLogger('LEVEL-QUIET', path.join(quietDir, 'run.log'));
+    try {
+      quietLogger.debug('too verbose by default');
+      quietLogger.info('info gets through by default');
+      const content = await waitForFileContent(path.join(quietDir, 'run.log'), (c) =>
+        c.includes('info gets through by default')
+      );
+      assert.ok(!content.includes('too verbose by default'), 'debug must be filtered at default');
+    } finally {
+      quietLogger.close();
+    }
+
+    process.env.LOG_LEVEL = 'debug';
+    try {
+      const loudDir = tempLogDir('level-debug');
+      const loudLogger = getLogger('LEVEL-DEBUG', path.join(loudDir, 'run.log'));
+      try {
+        loudLogger.debug('verbose when configured');
+        const loud = await waitForFileContent(path.join(loudDir, 'run.log'), (c) =>
+          c.includes('verbose when configured')
+        );
+        const { records } = parseLines(loud);
+        assert.ok(
+          records.some((r) => r.level === 'debug'),
+          'LOG_LEVEL=debug must admit debug'
+        );
+      } finally {
+        loudLogger.close();
+      }
+    } finally {
+      delete process.env.LOG_LEVEL;
+    }
+  });
+
+  test('an unsupported LOG_LEVEL falls back to info instead of silencing the log', async () => {
+    const original = process.env.LOG_LEVEL;
+    process.env.LOG_LEVEL = 'chatty';
+    try {
+      assert.equal(getLogger('unused', '/dev/null').close ? 'ok' : 'bad', 'ok');
+      const level = require('../src/server/logger').resolveLogLevel();
+      assert.equal(level, 'info', 'an unusable level must fall back to info');
+    } finally {
+      if (original === undefined) delete process.env.LOG_LEVEL;
+      else process.env.LOG_LEVEL = original;
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -275,7 +504,13 @@ describe('simulation routes', () => {
         waitForFileContent(fileA, (c) => c.includes(nameA)),
         waitForFileContent(fileB, (c) => c.includes(nameB)),
       ]);
-      assert.match(contentA, /\[SIMULATION\]/);
+      const [parsedA, parsedB] = [parseLines(contentA), parseLines(contentB)];
+      assert.deepEqual(parsedA.unparsable, [], 'run A lines must all parse');
+      assert.deepEqual(parsedB.unparsable, [], 'run B lines must all parse');
+      assert.ok(
+        parsedA.records.some((r) => r.label === 'SIMULATION'),
+        'run A records must be labelled SIMULATION'
+      );
       assert.ok(!contentA.includes(nameB), 'run A must not receive run B lines');
       assert.ok(!contentB.includes(nameA), 'run B must not receive run A lines');
     } finally {
@@ -283,6 +518,30 @@ describe('simulation routes', () => {
       await stopRun(server, nameB);
       removeRunLogs(nameA);
       removeRunLogs(nameB);
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  test('a started run writes every line under its own correlation id', async () => {
+    const server = buildApp();
+    const name = `logger-corr-${Date.now()}`;
+    try {
+      const start = await startRun(server, name);
+      assert.equal(start.status, 200, JSON.stringify(start.body));
+      const simId = getObjectId(name);
+      const file = path.join(simulationsLogDir, start.body.simulationStatus[simId].logFile);
+
+      const content = await waitForFileContent(file, (c) => c.includes(name));
+      const { records } = parseLines(content);
+      const correlated = records.filter((r) => r.correlationId !== undefined);
+      assert.ok(correlated.length > 0, 'the run must emit correlated records');
+      assert.ok(
+        correlated.every((r) => r.correlationId === simId),
+        'every correlated record must carry the run id'
+      );
+    } finally {
+      await stopRun(server, name);
+      removeRunLogs(name);
       await new Promise((resolve) => server.close(resolve));
     }
   });

--- a/test/openapi.test.js
+++ b/test/openapi.test.js
@@ -1,0 +1,207 @@
+/**
+ * Published API specification (issue #47).
+ *
+ * The specification is generated from the mounted routers and the compiled
+ * `joi` schemas the `validate` middleware enforces - read off each route's
+ * stack, never restated - so it cannot drift from what actually validates a
+ * request. These tests pin that guarantee: every mounted endpoint appears,
+ * a schema change changes the document, path templates declare their
+ * parameters, and what the server serves at /openapi.json is exactly what
+ * the generator produces.
+ */
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const Joi = require('joi');
+
+const appModule = require('../src/server/app');
+const { buildOpenApiDocument, toOpenApiPath } = require('../src/server/openapi/generate-openapi');
+const { toOpenApiSchema } = require('../src/server/openapi/joi-to-openapi');
+
+/** The document as the application itself generates it. */
+const buildDocument = () =>
+  buildOpenApiDocument({
+    mounts: appModule.getApiMounts(),
+    version: require('../package.json').version,
+  });
+
+const METHODS = ['get', 'post', 'put', 'patch', 'delete'];
+
+/**
+ * Independently count every operation across the mounts, walking each router
+ * exactly the way Express dispatches - the number the specification must
+ * account for.
+ */
+const expectedOperations = (mounts) => {
+  let count = 0;
+  for (const { router } of mounts) {
+    for (const layer of router.stack || []) {
+      if (!layer.route || !layer.route.methods) continue;
+      count += METHODS.filter((method) => layer.route.methods[method]).length;
+    }
+  }
+  return count;
+};
+
+describe('the generated document', () => {
+  const document = buildDocument();
+
+  test('is OpenAPI 3.0 with info and server metadata', () => {
+    assert.equal(document.openapi, '3.0.3');
+    assert.ok(document.info.title);
+    assert.ok(document.info.version);
+    assert.deepEqual(document.servers, [{ url: '/' }]);
+  });
+
+  test('covers every operation of every mounted router', () => {
+    const operations = Object.values(document.paths).reduce(
+      (count, pathItem) => count + Object.keys(pathItem).length,
+      0
+    );
+    assert.equal(
+      operations,
+      expectedOperations(appModule.getApiMounts()),
+      'the specification must not miss or invent endpoints'
+    );
+    assert.equal(Object.keys(document.paths).length, 38);
+  });
+
+  test('names well-known endpoints under their real paths', () => {
+    for (const template of [
+      '/api/health',
+      '/api/auth/login',
+      '/api/simulation/start',
+      '/api/simulation/stop/{fileName}',
+      '/api/data-recorders/start',
+      '/api/devops',
+      '/api/events',
+      '/api/logs/simulations/{fileName}',
+      '/api/models/{fileName}',
+    ]) {
+      assert.ok(document.paths[template], `missing documented endpoint: ${template}`);
+    }
+  });
+
+  test('every operation documents responses, including the shared error shape', () => {
+    for (const [template, pathItem] of Object.entries(document.paths)) {
+      for (const [method, operation] of Object.entries(pathItem)) {
+        assert.ok(operation.responses[200], `${method} ${template} must document success`);
+        assert.ok(
+          operation.responses[400],
+          `${method} ${template} must document validation failure`
+        );
+        assert.ok(operation.responses[500], `${method} ${template} must document server fault`);
+        assert.deepEqual(
+          operation.responses[400],
+          { $ref: '#/components/responses/ValidationError' },
+          'failures reference the one error shape'
+        );
+      }
+    }
+  });
+
+  test('session-guarded endpoints document authentication; public ones do not', () => {
+    assert.ok(!document.paths['/api/health'].get.responses[401], 'health is public');
+    assert.ok(!document.paths['/api/auth/login'].post.responses[401], 'login is public');
+    assert.ok(document.paths['/api/simulation/status'].get.responses[401]);
+    assert.ok(document.paths['/api/simulation/stats'].get.responses[401]);
+  });
+
+  test('every path parameter a template names is declared on each operation', () => {
+    for (const [template, pathItem] of Object.entries(document.paths)) {
+      const named = [...template.matchAll(/\{([^}]+)\}/g)].map((match) => match[1]);
+      if (named.length === 0) continue;
+      for (const [method, operation] of Object.entries(pathItem)) {
+        const declared = new Set(
+          (operation.parameters || []).filter((p) => p.in === 'path').map((p) => p.name)
+        );
+        for (const name of named) {
+          assert.ok(
+            declared.has(name),
+            `${method} ${template} must declare path parameter ${name}`
+          );
+        }
+      }
+    }
+  });
+
+  test('request bodies come from the validating schema, constraints included', () => {
+    const start = document.paths['/api/simulation/start'].post.requestBody;
+    assert.ok(start, 'simulation start must document its body');
+    assert.equal(start.content['application/json'].schema.type, 'object');
+    const properties = start.content['application/json'].schema.properties;
+    assert.ok(properties.model, 'the model field is part of the contract');
+    assert.ok(properties.options, 'the options field is part of the contract');
+
+    // A constraint the schema declares must survive into the document: the
+    // stop parameter's filename allowlist comes from fileNameParam().
+    const stopParam = document.paths['/api/simulation/stop/{fileName}'].get.parameters.find(
+      (parameter) => parameter.name === 'fileName'
+    );
+    assert.equal(stopParam.required, true);
+    assert.ok(stopParam.schema.pattern.includes('\\.json'), 'pattern carries the extension rule');
+    assert.ok(stopParam.schema.maxLength > 0);
+  });
+});
+
+describe('the joi converter', () => {
+  test('converts bounds, enums, nullability and defaults', () => {
+    const converted = toOpenApiSchema(
+      Joi.object({
+        page: Joi.number().integer().min(0),
+        protocol: Joi.string().valid('MONGODB').required(),
+        name: Joi.string().max(64).allow(null, ''),
+        limit: Joi.number().positive(),
+        tags: Joi.array().items(Joi.string()),
+      })
+    );
+    assert.equal(converted.type, 'object');
+    assert.deepEqual(converted.required, ['protocol']);
+    assert.equal(converted.properties.page.type, 'integer');
+    assert.equal(converted.properties.page.minimum, 0);
+    assert.deepEqual(converted.properties.protocol.enum, ['MONGODB']);
+    assert.equal(converted.properties.name.maxLength, 64);
+    assert.equal(converted.properties.name.nullable, true);
+    assert.equal(converted.properties.limit.exclusiveMinimum, 0);
+    assert.equal(converted.properties.tags.items.type, 'string');
+  });
+
+  test('an unknown construct converts permissively instead of throwing', () => {
+    assert.doesNotThrow(() => toOpenApiSchema(Joi.any().meta({ x: 1 })));
+    assert.deepEqual(toOpenApiSchema(undefined), {});
+  });
+
+  test('express-style parameters become OpenAPI templates', () => {
+    assert.equal(toOpenApiPath('/stop/:fileName'), '/stop/{fileName}');
+    assert.deepEqual(
+      [...toOpenApiPath('/a/:one/b/:two').matchAll(/\{([^}]+)\}/g)].map((m) => m[1]),
+      ['one', 'two']
+    );
+  });
+});
+
+describe('publication', () => {
+  test('the committed openapi.json matches what the application generates', () => {
+    const committed = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '..', 'openapi.json'), 'utf8')
+    );
+    assert.deepEqual(committed, buildDocument(), 'run `npm run spec` after API changes');
+  });
+
+  test('GET /openapi.json serves the specification without a session', async () => {
+    const http = require('node:http');
+    const server = http.createServer(appModule);
+    await new Promise((resolve) => server.listen(0, resolve));
+    try {
+      const res = await fetch(`http://127.0.0.1:${server.address().port}/openapi.json`);
+      assert.equal(res.status, 200);
+      const served = await res.json();
+      assert.equal(served.openapi, '3.0.3');
+      assert.ok(served.paths['/api/simulation/start'], 'the served spec documents the API');
+      assert.deepEqual(Object.keys(served.paths).sort(), Object.keys(buildDocument().paths).sort());
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+});

--- a/test/request-correlation.test.js
+++ b/test/request-correlation.test.js
@@ -1,0 +1,154 @@
+/**
+ * Request correlation (issue #47).
+ *
+ * Every request carries a correlation identifier: an incoming trusted
+ * `X-Request-Id` is honoured, anything else gets a fresh UUID, the id is
+ * echoed in the `X-Request-Id` response header, and both the access record
+ * and any failure record the server writes carry it - so all of one request's
+ * lines can be pulled out of the log with a single filter, and credentials or
+ * control characters cannot be smuggled into the log through a caller's own
+ * header value.
+ */
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const express = require('express');
+
+const { requestContext, SAFE_REQUEST_ID } = require('../src/server/middleware/request-context');
+const { errorHandler, badRequest } = require('../src/server/middleware/errors');
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/** The server log every record of this module lands in. */
+const serverLogPath = path.join(__dirname, '..', 'src', 'server', 'logs', 'server.log');
+
+/** Poll the server log until a line satisfies `predicate`. */
+const waitForLine = (predicate, timeout = 3000) =>
+  new Promise((resolve, reject) => {
+    const started = Date.now();
+    const tick = () => {
+      let content = '';
+      try {
+        content = fs.readFileSync(serverLogPath, 'utf8');
+      } catch (_) {
+        /* not written yet */
+      }
+      const hit = content.split('\n').find(predicate);
+      if (hit) return resolve(hit);
+      if (Date.now() - started > timeout) {
+        return reject(new Error('server log never received the expected line'));
+      }
+      setTimeout(tick, 50);
+    };
+    tick();
+  });
+
+describe('request ids', () => {
+  test('every request gets a UUID echoed in X-Request-Id', async () => {
+    const app = express();
+    app.use(requestContext({ accessLog: false }));
+    app.get('/ping', (req, res) => res.send({ requestId: req.requestId }));
+    const server = app.listen(0);
+    try {
+      const res = await fetch(`http://127.0.0.1:${server.address().port}/ping`);
+      assert.equal(res.status, 200);
+      const echoed = res.headers.get('x-request-id');
+      assert.ok(UUID_PATTERN.test(echoed), `the header must carry a UUID: ${echoed}`);
+      const body = await res.json();
+      assert.equal(body.requestId, echoed, 'the handler sees the same id');
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  test('a well-formed incoming X-Request-Id is honoured', async () => {
+    const app = express();
+    app.use(requestContext({ accessLog: false }));
+    app.get('/ping', (req, res) => res.send({ requestId: req.requestId }));
+    const server = app.listen(0);
+    try {
+      const res = await fetch(`http://127.0.0.1:${server.address().port}/ping`, {
+        headers: { 'X-Request-Id': 'caller-trace.42_a' },
+      });
+      assert.equal(res.headers.get('x-request-id'), 'caller-trace.42_a');
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  test('an unsafe incoming id is discarded for a fresh UUID', async () => {
+    assert.deepEqual(
+      ['with space', 'semi;colon', '<script>', 'x'.repeat(65), ''].filter((value) =>
+        SAFE_REQUEST_ID.test(value.trim())
+      ),
+      [],
+      'none of these may pass the safety screen'
+    );
+    const app = express();
+    app.use(requestContext({ accessLog: false }));
+    app.get('/ping', (req, res) => res.send({ requestId: req.requestId }));
+    const server = app.listen(0);
+    try {
+      const res = await fetch(`http://127.0.0.1:${server.address().port}/ping`, {
+        headers: { 'X-Request-Id': '<script>alert(1)</script>' },
+      });
+      const echoed = res.headers.get('x-request-id');
+      assert.ok(UUID_PATTERN.test(echoed), 'an unsafe id must be replaced by a UUID');
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+});
+
+describe('correlated records', () => {
+  test('the access record carries the request id, status and duration', async () => {
+    const app = express();
+    app.use(requestContext());
+    app.get('/access-check', (req, res) => res.send('ok'));
+    const server = app.listen(0);
+    const requestId = `access-${Date.now()}`;
+    try {
+      const res = await fetch(`http://127.0.0.1:${server.address().port}/access-check`, {
+        headers: { 'X-Request-Id': requestId },
+      });
+      assert.equal(res.status, 200);
+      const line = await waitForLine(
+        (candidate) => candidate.includes('/access-check') && candidate.includes(requestId)
+      );
+      const record = JSON.parse(line);
+      assert.equal(record.requestId, requestId);
+      assert.equal(record.method, 'GET');
+      assert.equal(record.path, '/access-check');
+      assert.equal(record.status, 200);
+      assert.equal(typeof record.durationMs, 'number');
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  test('a failure reported through the central handler carries the same id', async () => {
+    const app = express();
+    app.use(requestContext());
+    app.get('/fails', (req, res, next) => next(badRequest('Correlation probe failure')));
+    app.use(errorHandler);
+    const server = app.listen(0);
+    const requestId = `failure-${Date.now()}`;
+    try {
+      const res = await fetch(`http://127.0.0.1:${server.address().port}/fails`, {
+        headers: { 'X-Request-Id': requestId },
+      });
+      assert.equal(res.status, 400);
+      assert.equal(res.headers.get('x-request-id'), requestId);
+      const line = await waitForLine(
+        (candidate) =>
+          candidate.includes(requestId) && candidate.includes('Correlation probe failure')
+      );
+      const record = JSON.parse(line);
+      assert.equal(record.level, 'error');
+      assert.match(record.message, /GET \/fails -> 400/);
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+});


### PR DESCRIPTION
Closes #47

## Summary

Log records are now one machine-parseable JSON object per line, a correlation identifier ties together all of one request's or one simulation run's lines, verbosity is operator-configurable, and the API is published as an OpenAPI 3.0 document generated from the very schemas that validate requests — so it cannot drift from the implementation.

## Approach

Balanced: rework the existing winston logger to emit structured records (keeping its console-mirroring call contract so no run-flow call site changes shape), add request-context middleware that assigns and echoes `X-Request-Id`, stamp run loggers with their run id, and generate OpenAPI by walking the mount manifest `app.js` already iterates plus compiled joi schemas read off each route's own `validate` middleware layer. Zero new dependencies.

## Decision Record

- **Root cause:** the logger emitted free text with no correlation field and a hard-coded level; secrets depended on each call site redacting itself; endpoints were described only by code, so integrators read source to learn the contract.
- **Options considered:** Option 1 — hand-written static spec + text logger touch-ups; Option 2 — structured winston logging with correlation ids and runtime spec generation from mounted routers' validation schemas (zero new deps); Option 3 — migrate validation to zod, add Swagger UI assets and pino.
- **Options rejected:** Option 1 — a static specification drifts from the implementation, which acceptance criterion 5 forbids; Option 3 — large surface churn and new dependencies for no additional acceptance-criterion coverage.
- **Selected option:** Option 2
- **Residual risk:** per-endpoint success bodies are described generically (`{type: object}`) because handler response shapes are code, not declared schemas; the database operator-key rejection rule is documented once in the guide rather than approximated per property.
- **Design-confirm:** auto-selected Option 2 (complexity: high)

Analyzed at: `refactor/47-add-structured-logging-with @ f3b55be` (2026-08-25)

## Changes

| File | Change |
|------|--------|
| `src/server/logger/index.js` | One JSON record per line (`timestamp`, `level`, `label`, optional `correlationId`, `message` + metadata fields); `LOG_LEVEL` support with safe fallback; deep secret redaction; trailing plain-object args become top-level fields |
| `src/server/middleware/request-context.js` | New: assigns/honours `X-Request-Id`, echoes it in responses, writes one correlated access record per finished request |
| `src/server/middleware/errors.js` | The central handler's failure record now goes to the structured server log carrying the request's correlation id |
| `src/server/routes/{simulation,data-recorders,devops}.js` | Run loggers created with the run id as `correlationId` |
| `src/server/middleware/validate.js` | Publishes its compiled schemas on the middleware for the generator to read |
| `src/server/openapi/joi-to-openapi.js` | New: converts the joi subset this codebase declares into OpenAPI 3.0 schema objects |
| `src/server/openapi/generate-openapi.js` | New: assembles the document from the app's own mount declarations |
| `src/server/app.js` | Mount manifest drives both mounting and generation; serves `GET /openapi.json`; mounts request context |
| `scripts/generate-openapi.js`, `package.json` | `npm run spec` regenerates the committed `openapi.json` |
| `openapi.json` | Published specification (38 paths, 62 operations) |
| `env.example`, `README.md`, `CHANGELOG.md` | Documented `LOG_LEVEL`, the spec endpoint and the structured-log format |

## Test Results

- Unit/integration tests: 574 passed (suite total 589, 15 environment-skipped)
- E2e tests: included above; lifecycle gate updated to the structured record format
- Build: lint clean (`eslint`), no server build step
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Log records are emitted in a structured, machine-parseable format (high) | pass | every line parses as one JSON object — `test/logger.test.js` ("every record is one machine-parseable JSON object…") |
| A correlation identifier ties together all records from one request or one simulation run (high) | pass | `test/logger.test.js` ("every record carries the correlation id…", "a started run writes every line under its own correlation id") and `test/request-correlation.test.js` (access + failure records share the request id) |
| Log level is configurable without a code change (high) | pass | `LOG_LEVEL` env — `test/logger.test.js` ("debug records are suppressed at the default level and kept under LOG_LEVEL=debug"), documented in `env.example` |
| An API specification is published covering every endpoint, its inputs and its responses (high) | pass | served at `GET /openapi.json` and committed at the repo root; `test/openapi.test.js` asserts coverage of all 62 operations with inputs and shared response envelope |
| The specification is generated from the validation schemas so it cannot drift from the implementation (high) | pass | schemas read off each route's `validate` middleware (`validationSchemas`); `test/openapi.test.js` pins "covers every operation of every mounted router" and "the committed openapi.json matches what the application generates" |
| Credentials and secrets never appear in log output (high) | pass | deep key-based redaction before rendering — `test/logger.test.js` secret-redaction suite; #72 canary suite still green |

<!-- gitissue:qa v1 head=a38e9713030b71e3a3eba569c940affe0bc5b718 profile=full cycles=1 review=clean tests=574@a38e9713030b71e3a3eba569c940affe0bc5b718 ui=none -->
