### PR TITLE
test(e2e): give every suite its own temporary storage root

### DIFF
--- a/.github/workflows/e2e-security.yml
+++ b/.github/workflows/e2e-security.yml
@@ -36,12 +36,13 @@ jobs:
       - name: Build the dashboard client
         run: cd src/client && npm install && npm run build
 
-      # Serialised: several files spawn their own real instance and the suites
-      # share the on-disk storage root, so running them in parallel makes the
-      # directory snapshots race and the instances contend for the same port.
-      # `npm test` is `node --test-concurrency=1 --test "test/**/*.test.js"`, so
-      # it keeps that serialisation while also gating the unit-level regression
-      # guards that naming the e2e files individually left unable to fail a PR.
+      # Serialised: each suite drives its own real instance, and while those
+      # now run against throwaway storage roots (issue #58), some in-process
+      # suites (test/http-status.test.js) still exercise the checkout's own
+      # data files, so parallel runs could race on them. `npm test` is
+      # `node --test-concurrency=1 --test "test/**/*.test.js"`, which keeps
+      # that serialisation while also gating the unit-level regression guards
+      # that naming the e2e files individually left unable to fail a PR.
       # The container image assertion is part of the glob but skips itself here:
       # its runtime half is guarded on TAS_IMAGE, which only the job below sets.
       - name: Run the full test suite

--- a/src/server/paths.js
+++ b/src/server/paths.js
@@ -1,0 +1,28 @@
+'use strict';
+/**
+ * Central storage-root resolution (issue #58).
+ *
+ * Every persisted artefact the server owns lives under two directories that
+ * used to be derived from `__dirname` at require time in six different route
+ * modules: the `data/` tree (topologies, recorders, data-storage.json,
+ * devops.json, the runtime-state store) and the `logs/` tree (simulation,
+ * recorder and test-campaign logs).
+ *
+ * Setting `TAS_STORAGE_ROOT` relocates BOTH trees under one directory, which
+ * is how the end-to-end suites give each spawned instance its own throwaway
+ * storage root under the system temp dir - a crashed run can then leave
+ * nothing behind in the checkout. With no override the root is this server
+ * directory, so a deployed instance resolves exactly the same paths it always
+ * did (`<server>/data` and `<server>/logs`).
+ *
+ * The finer-grained overrides that predate this module (`TAS_MODELS_DIR`,
+ * `TAS_DATA_RECORDERS_DIR`, `TAS_DATA_DIR`, `TAS_RUNTIME_STATE_PATH`) still
+ * win over the root for their one directory, unchanged.
+ */
+const path = require('path');
+
+const SERVER_ROOT = process.env.TAS_STORAGE_ROOT || __dirname;
+const DATA_DIR = path.join(SERVER_ROOT, 'data');
+const LOGS_DIR = path.join(SERVER_ROOT, 'logs');
+
+module.exports = { SERVER_ROOT, DATA_DIR, LOGS_DIR };

--- a/src/server/routes/data-recorders.js
+++ b/src/server/routes/data-recorders.js
@@ -23,6 +23,8 @@ const {
   unavailable,
 } = require('../middleware/errors');
 const { createArtifactStore } = require('../artifact-store');
+const { DATA_DIR, LOGS_DIR } = require('../paths');
+const path = require('path');
 let router = express.Router();
 let getLogger = require('../logger');
 const { getDataStorage } = require('./db-connector');
@@ -31,14 +33,15 @@ const { getDataStorage } = require('./db-connector');
 // concurrent edits queue up instead of discarding one another and a crash
 // mid-write cannot leave a truncated file behind. Existing loose files in the
 // directory are adopted as they are - there is no migration step.
-// `TAS_DATA_RECORDERS_DIR` moves the store (tests use a scratch directory).
+// `TAS_DATA_RECORDERS_DIR` moves the store (tests use a scratch directory);
+// `TAS_STORAGE_ROOT` relocates the whole tree (issue #58).
 const dataRecordersPath =
-  process.env.TAS_DATA_RECORDERS_DIR || `${__dirname}/../data/data-recorders/`;
+  process.env.TAS_DATA_RECORDERS_DIR || path.join(DATA_DIR, 'data-recorders');
 const recordersStore = createArtifactStore({
   root: dataRecordersPath,
   label: 'data-recorders',
 });
-let logsPath = `${__dirname}/../logs/data-recorders/`;
+let logsPath = path.join(LOGS_DIR, 'data-recorders') + path.sep;
 // Running-recorder records and handles live in the shared runtime registry
 // (issue #29): records persist across restarts and are visible to a second
 // server process on the same store, handles stay with the owning process.

--- a/src/server/routes/db-connector.js
+++ b/src/server/routes/db-connector.js
@@ -9,14 +9,15 @@ const {
 
 const { createArtifactStore } = require('../artifact-store');
 const { unavailable } = require('../middleware/errors');
+const { DATA_DIR } = require('../paths');
 
 // The service configuration is a record of the artifact store (issue #30):
 // reads go through the store on EVERY call - there is no in-memory copy that
 // can go stale, so a configuration change takes effect without a restart -
 // and writes are serialized and atomic, so a crash mid-save cannot leave a
 // truncated configuration behind. `TAS_DATA_DIR` moves the store (tests use a
-// scratch directory).
-const dataStorageDir = process.env.TAS_DATA_DIR || `${__dirname}/../data`;
+// scratch directory); `TAS_STORAGE_ROOT` relocates the whole tree (issue #58).
+const dataStorageDir = process.env.TAS_DATA_DIR || DATA_DIR;
 const DATA_STORAGE_FILE = 'data-storage.json';
 const dataStorageStore = createArtifactStore({ root: dataStorageDir, label: 'data-storage' });
 

--- a/src/server/routes/devops.js
+++ b/src/server/routes/devops.js
@@ -1,10 +1,15 @@
 /* Working with Data Generator */
 var express = require('express');
+const path = require('path');
 const Joi = require('joi');
 const { dbConnector, getDataStorage } = require('./db-connector');
 const { startTestCampaign } = require('../../core/devops-flow');
+// The devops configuration and the campaign-log root resolve through the
+// central storage-root resolution (issue #58): unchanged by default,
+// relocated together by `TAS_STORAGE_ROOT`.
+const { DATA_DIR, LOGS_DIR } = require('../paths');
 let router = express.Router();
-const devopsFilePath = `${__dirname}/../data/devops.json`;
+const devopsFilePath = path.join(DATA_DIR, 'devops.json');
 let getLogger = require('../logger');
 const { readJSONFile, writeToFile } = require('../../core/utils');
 const { OFFLINE } = require('../../core/DeviceStatus');
@@ -23,7 +28,7 @@ const {
   internal,
   unavailable,
 } = require('../middleware/errors');
-let logsPath = `${__dirname}/../logs/test-campaigns/`;
+let logsPath = path.join(LOGS_DIR, 'test-campaigns') + path.sep;
 // Running-campaign records and handles live in the shared runtime registry
 // (issue #29): the record persists across restarts and is visible to a second
 // server process on the same store; the live campaign object stays with the

--- a/src/server/routes/logs.js
+++ b/src/server/routes/logs.js
@@ -6,8 +6,11 @@ const { readDir, deleteFile } = require('../../core/utils');
 const { resolveWithin, sendBadRequest } = require('./path-safety');
 const { validate, fileNameParam, generatedFileNameMaxLength } = require('../middleware/validate');
 const { errorHandler, fileError, internal } = require('../middleware/errors');
+const { LOGS_DIR } = require('../paths');
 
-const _logsPath = `${__dirname}/../logs/`;
+// The log root resolves through the central storage-root resolution (issue
+// #58): `<server>/logs` by default, relocated by `TAS_STORAGE_ROOT`.
+const _logsPath = LOGS_DIR;
 
 // The log root has one subdirectory per kind of log the server writes, and
 // each mounted instance reads exactly one of them (issue #84). Keeping the
@@ -114,7 +117,7 @@ const createRouter = (appLog) => {
     );
   }
   let router = express.Router();
-  let logsPath = `${_logsPath}${appLog}/`;
+  let logsPath = path.join(_logsPath, appLog) + path.sep;
 
   /////////////
   // LOG FILES

--- a/src/server/routes/model.js
+++ b/src/server/routes/model.js
@@ -1,6 +1,7 @@
 'use strict';
 /* Working with Data Generator */
 var express = require('express');
+const path = require('path');
 const Joi = require('joi');
 
 const { createArtifactStore } = require('../artifact-store');
@@ -13,14 +14,16 @@ const {
   simulationRunFields,
 } = require('../middleware/validate');
 const { errorHandler, fileError, internal, conflict } = require('../middleware/errors');
+const { DATA_DIR } = require('../paths');
 
 // The topologies live as records of the artifact store (issue #30): writes are
 // serialized under the store's lock and land atomically, so concurrent edits
 // queue up instead of discarding one another and a crash mid-write cannot leave
 // a truncated file behind. Existing loose files in the directory are adopted
 // as they are - there is no migration step. `TAS_MODELS_DIR` moves the store
-// (tests use this to work against a scratch directory).
-const modelsPath = process.env.TAS_MODELS_DIR || `${__dirname}/../data/models/`;
+// (tests use this to work against a scratch directory); `TAS_STORAGE_ROOT`
+// relocates the whole tree (issue #58).
+const modelsPath = process.env.TAS_MODELS_DIR || path.join(DATA_DIR, 'models');
 const modelsStore = createArtifactStore({ root: modelsPath, label: 'models' });
 let router = express.Router();
 

--- a/src/server/routes/simulation.js
+++ b/src/server/routes/simulation.js
@@ -6,6 +6,7 @@ const { OFFLINE } = require('../../core/DeviceStatus');
 let getLogger = require('../logger');
 const Simulation = require('../../core/simulation');
 const { getObjectId } = require('../../core/utils');
+const path = require('path');
 const { isValidName, resolveWithin, sendBadRequest } = require('./path-safety');
 const { getDataStorage } = require('./db-connector');
 const {
@@ -25,12 +26,16 @@ const {
 } = require('../middleware/errors');
 
 let router = express.Router();
-const logsPath = `${__dirname}/../logs/simulations/`;
+// Log and topology locations come from the central storage-root resolution
+// (issue #58): `TAS_MODELS_DIR` still moves the store on its own, and
+// `TAS_STORAGE_ROOT` relocates the whole tree.
+const { DATA_DIR, LOGS_DIR } = require('../paths');
+const logsPath = path.join(LOGS_DIR, 'simulations') + path.sep;
 // Stored topologies are records of the artifact store (issue #30) shared with
 // the model routes: reads see either a complete previous record or a complete
 // new one, never a half-written file. `TAS_MODELS_DIR` moves it (tests use a
 // scratch directory); the same override configures `routes/model.js`.
-const modelsPath = process.env.TAS_MODELS_DIR || `${__dirname}/../data/models/`;
+const modelsPath = process.env.TAS_MODELS_DIR || path.join(DATA_DIR, 'models');
 const modelsStore = require('../artifact-store').createArtifactStore({
   root: modelsPath,
   label: 'models',

--- a/src/server/routes/test-cases.js
+++ b/src/server/routes/test-cases.js
@@ -2,7 +2,9 @@
 const express = require('express');
 const Joi = require('joi');
 const router = express.Router();
-const modelsPath = `${__dirname}/../data/models/`;
+const { DATA_DIR } = require('../paths');
+const path = require('path');
+const modelsPath = path.join(DATA_DIR, 'models');
 const { TestCaseSchema, dbConnector } = require('./db-connector');
 const { resolveWithin, sendBadRequest } = require('./path-safety');
 const {

--- a/src/server/runtime-state/index.js
+++ b/src/server/runtime-state/index.js
@@ -32,7 +32,9 @@ const path = require('path');
 const os = require('os');
 const crypto = require('crypto');
 
-const DEFAULT_STORE_PATH = path.join(__dirname, '..', 'data', 'runtime-state.json');
+const { DATA_DIR } = require('../paths');
+
+const DEFAULT_STORE_PATH = path.join(DATA_DIR, 'runtime-state.json');
 const LOCK_RETRY_MS = 25;
 const LOCK_TIMEOUT_MS = 5000;
 const LOCK_STALE_MS = 10000;

--- a/test/e2e/auth-journey.test.js
+++ b/test/e2e/auth-journey.test.js
@@ -45,6 +45,7 @@ const {
   repoRoot,
   modelsDir,
   inModelsDir,
+  simulationsLogsDir,
   removeIfPresent,
 } = require('./helpers');
 const { PUBLIC_API_ROUTES } = require('../../src/server/middleware/auth');
@@ -309,15 +310,15 @@ after(async () => {
   // run writes a real log file (gitignored, but still this suite's litter).
   if (journeyFileName) removeIfPresent(inModelsDir(journeyFileName));
   if (journeyName) {
-    const simulationLogs = path.resolve(repoRoot, 'src/server/logs/simulations');
     let entries = [];
     try {
-      entries = fs.readdirSync(simulationLogs);
+      entries = fs.readdirSync(simulationsLogsDir);
     } catch (_) {
       entries = []; // absent, which is the expected case on a fresh checkout
     }
     for (const entry of entries) {
-      if (entry.startsWith(`${journeyName}_`)) removeIfPresent(path.join(simulationLogs, entry));
+      if (entry.startsWith(`${journeyName}_`))
+        removeIfPresent(path.join(simulationsLogsDir, entry));
     }
   }
 });
@@ -846,13 +847,18 @@ test('the database-unavailable refusal is a documented 503 that discloses nothin
  */
 const PHASE_0_DIGESTS = {
   'test/e2e/security-suite.test.js':
-    'e87f06ec6d8d4b79517e37cef2e7064d5ab935ca2c38a838cf62c849354423b9',
+    // Updated with issue #58: the devops snapshot/restore became a baseline
+    // read against the suite's own temporary storage root.
+    'd4dc3b76d63383ff455e4652447553f4da81fa2a73fd442cdc32f680db6d334f',
   'test/e2e/limits.test.js': 'a6094dfd19c166e847a7068c5b62c0f3bf369cf2bad84566ebacce27d9a589e2',
   'test/e2e/container-nonroot.test.js':
     // Updated with issue #45: the runtime assertions now cover the
     // application-only image (no broker/supervisor inside, direct node CMD).
     '32afd58fff17f4e540da1d71c1d250e38ee99343c276d1666812957e2dfa67db',
-  'test/e2e/helpers.js': '4a7794adf00813e01c9a36c416a14c40463f3aa59e16325b18a4f8850024f975',
+  'test/e2e/helpers.js':
+    // Updated with issue #58: every spawned instance now runs against a
+    // temporary storage root under the system temp dir.
+    '9b8cae30899e0e6a10e4b01a0e5da4acfefb5d1c68d7fb8f308f1bff5c2d0a6a',
 };
 
 /**

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -10,14 +10,72 @@ const http = require('node:http');
 const net = require('node:net');
 const path = require('node:path');
 const fs = require('node:fs');
+const os = require('node:os');
 const { spawn } = require('node:child_process');
+const { after } = require('node:test');
 
 const repoRoot = path.resolve(__dirname, '../..');
-const modelsDir = path.resolve(repoRoot, 'src/server/data/models');
-const recordersDir = path.resolve(repoRoot, 'src/server/data/data-recorders');
+const repoDataDir = path.resolve(repoRoot, 'src/server/data');
 const repoPackageJson = path.resolve(repoRoot, 'package.json');
-const devopsConfigPath = path.resolve(repoRoot, 'src/server/data/devops.json');
-const campaignLogsDir = path.resolve(repoRoot, 'src/server/logs/test-campaigns');
+
+/**
+ * This suite's own temporary storage root (issue #58).
+ *
+ * Every instance spawned by a suite in this directory is pointed at
+ * `<temp root>/data` and `<temp root>/logs` through `TAS_STORAGE_ROOT`, so
+ * the suites no longer create, rename or delete anything under the checkout.
+ * A run that crashes between create and cleanup can therefore only leave
+ * residue in a throwaway directory under the system temp dir, and two suites
+ * no longer contend for one on-disk root. The root is removed when the
+ * process's test run finishes; the shipped defaults it seeds are copied, so
+ * the shipped files themselves are never touched.
+ */
+const storageRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'tas-e2e-storage-'));
+const dataDir = path.join(storageRoot, 'data');
+const logsDir = path.join(storageRoot, 'logs');
+// Pre-create the directory layout a deployed instance ships with, so suites
+// can stat, chmod and list the stores exactly as they could the checkout's
+// own directories (the application only creates them on first write).
+const modelsDir = path.join(dataDir, 'models');
+const recordersDir = path.join(dataDir, 'data-recorders');
+const campaignLogsDir = path.join(logsDir, 'test-campaigns');
+const simulationsLogsDir = path.join(logsDir, 'simulations');
+const dataRecordersLogsDir = path.join(logsDir, 'data-recorders');
+for (const dir of [
+  modelsDir,
+  recordersDir,
+  campaignLogsDir,
+  simulationsLogsDir,
+  dataRecordersLogsDir,
+]) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+const devopsConfigPath = path.join(dataDir, 'devops.json');
+const dataStoragePath = path.join(dataDir, 'data-storage.json');
+
+// Seed the throwaway root with the shipped defaults, so the instances see the
+// same starting configuration a fresh deployment does. The files are copied
+// READ-ONLY as far as the checkout is concerned - all writes land in the
+// temporary root.
+const seedFromRepo = (fileName) => {
+  const source = path.join(repoDataDir, fileName);
+  if (fs.existsSync(source)) {
+    fs.copyFileSync(source, path.join(dataDir, fileName));
+  }
+};
+seedFromRepo('devops.json');
+seedFromRepo('data-storage.json');
+
+after(() => {
+  // Runs last (child hooks first): by the time this fires, every suite has
+  // already stopped its instances, so a failed or crashed run still leaves
+  // nothing behind in the checkout - and this removes even that residue.
+  try {
+    fs.rmSync(storageRoot, { recursive: true, force: true });
+  } catch (_) {
+    /* best effort: a leftover temp dir is preferable to masking a test failure */
+  }
+});
 
 /** An origin the server will be configured to allow via CORS_ALLOWED_ORIGINS. */
 const allowedOrigin = 'http://allowed.example';
@@ -155,6 +213,10 @@ async function startServer(env = {}) {
       ...process.env,
       SERVER_HOST: '127.0.0.1',
       SERVER_PORT: String(seedPort),
+      // Each suite runs its instances against this suite's own throwaway
+      // storage root (issue #58). A caller-supplied per-directory override
+      // (TAS_MODELS_DIR, ...) still wins in the route modules.
+      TAS_STORAGE_ROOT: storageRoot,
       ...testCredentials,
       ...env,
     },
@@ -224,10 +286,11 @@ const inRecordersDir = (fileName) => path.join(recordersDir, fileName);
 
 /**
  * Every location a traversal payload in this suite would land a file if
- * containment regressed. The storage root is `src/server/data/models`, so
- * `../` escapes to `src/server/data` and `../../` to `src/server` - NOT to the
- * repo root. Canaries must check the real targets, otherwise a successful
- * escape passes unnoticed.
+ * containment regressed. The storage root is the suite's temporary
+ * `data/models` directory, so `../` escapes to the temporary `data` dir and
+ * `../../` to the temporary storage root - NOT to the repo root, which is the
+ * last canary and must never be touched either. Canaries must check the real
+ * targets, otherwise a successful escape passes unnoticed.
  * @param {String} baseName Artifact name without the `.json` extension
  * @returns {String[]} Absolute paths that must never exist after a hostile name
  */
@@ -290,11 +353,17 @@ const listDir = (dir) =>
 
 module.exports = {
   repoRoot,
+  storageRoot,
+  dataDir,
+  logsDir,
   modelsDir,
   recordersDir,
   repoPackageJson,
   devopsConfigPath,
+  dataStoragePath,
   campaignLogsDir,
+  simulationsLogsDir,
+  dataRecordersLogsDir,
   allowedOrigin,
   hostileOrigin,
   request,

--- a/test/e2e/modernised-workflow.test.js
+++ b/test/e2e/modernised-workflow.test.js
@@ -39,14 +39,17 @@ const path = require('node:path');
 
 const mqtt = require('mqtt');
 
-const { startServer, request, unique, repoRoot } = require('./helpers');
+const {
+  startServer,
+  request,
+  unique,
+  simulationsLogsDir,
+  dataRecordersLogsDir,
+  dataStoragePath,
+} = require('./helpers');
 
 /** A ceiling high enough that no test in this file trips the limiter. */
 const NO_RATE_LIMIT = '100000';
-
-const simulationLogsDir = path.resolve(repoRoot, 'src/server/logs/simulations');
-const dataRecordersLogsDir = path.resolve(repoRoot, 'src/server/logs/data-recorders');
-const dataStoragePath = path.resolve(repoRoot, 'src/server/data/data-storage.json');
 
 const mongoHost = process.env.TAS_E2E_MONGO_HOST || '127.0.0.1';
 const mongoPort = Number(process.env.TAS_E2E_MONGO_PORT || 27017);
@@ -222,7 +225,7 @@ const removeIfPresent = (filePath) => {
 
 /** Delete every run log this suite created for a topology or recorder name. */
 const removeRunLogs = (name) => {
-  for (const dir of [simulationLogsDir, dataRecordersLogsDir]) {
+  for (const dir of [simulationsLogsDir, dataRecordersLogsDir]) {
     let entries = [];
     try {
       entries = fs.readdirSync(dir);
@@ -286,7 +289,7 @@ before(async () => {
   modelsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tas-phase4-models-'));
   recordersDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tas-phase4-recorders-'));
   // Nothing under src/server/logs is created up front by the application.
-  fs.mkdirSync(simulationLogsDir, { recursive: true });
+  fs.mkdirSync(simulationsLogsDir, { recursive: true });
   fs.mkdirSync(dataRecordersLogsDir, { recursive: true });
   [mongoUp, mqttUp] = await Promise.all([
     probeTcp(mongoHost, mongoPort),

--- a/test/e2e/security-suite.test.js
+++ b/test/e2e/security-suite.test.js
@@ -35,13 +35,12 @@ const escapeNames = ['escape', 'pwned'];
 /** Hostile test campaign id used to probe the devops log path (issue #55). */
 const hostileCampaignId = '../../../pwned-campaign';
 
+/** The suite's baseline devops configuration, read from the temporary root. */
+const baselineDevops = fs.readFileSync(devopsConfigPath, 'utf8');
+
 let server;
-let originalDevops;
 
 before(async () => {
-  // The devops tests below overwrite the shipped configuration, so snapshot it
-  // and restore it in `after` - a failing run must not leave the checkout dirty.
-  originalDevops = fs.readFileSync(devopsConfigPath, 'utf8');
   // Configure the real instance with the trusted origin shipped in tests.
   server = await startServer({ CORS_ALLOWED_ORIGINS: allowedOrigin });
 });
@@ -49,16 +48,13 @@ before(async () => {
 after(async () => {
   if (server) await server.stop();
   // This suite is the regression gate, so it runs red against an unfixed
-  // instance - which really does escape files into the source tree. Remove
-  // them so a failing run never leaves the checkout dirty.
+  // instance - which really does escape files into the suite's storage root.
+  // Remove them so the root handed to the final cleanup is as clean as the
+  // run allowed (issue #58: nothing here can touch the checkout any more).
   for (const name of escapeNames) {
     escapeArtifacts(name).forEach(removeIfPresent);
   }
   escapedCampaignLogs('pwned-campaign').forEach(removeIfPresent);
-  // Guarded: if the snapshot itself failed, restoring would mask the real error.
-  if (originalDevops !== undefined) {
-    fs.writeFileSync(devopsConfigPath, originalDevops);
-  }
 });
 
 // ---------------------------------------------------------------------------
@@ -221,7 +217,9 @@ test('path containment: a persisted hostile testCampaignId is rejected on read-b
     );
   } finally {
     await poisoned.stop();
-    fs.writeFileSync(devopsConfigPath, originalDevops);
+    // Restore the suite's baseline configuration: the temp-root copy is this
+    // suite's own file now, so this touches nothing in the checkout.
+    fs.writeFileSync(devopsConfigPath, baselineDevops);
   }
 });
 

--- a/test/e2e/simulation-lifecycle.test.js
+++ b/test/e2e/simulation-lifecycle.test.js
@@ -29,13 +29,17 @@ const fs = require('node:fs');
 const net = require('node:net');
 const path = require('node:path');
 
-const { startServer, request, unique, repoRoot, modelsDir } = require('./helpers');
+const {
+  startServer,
+  request,
+  unique,
+  modelsDir,
+  simulationsLogsDir,
+  dataStoragePath,
+} = require('./helpers');
 
 /** A ceiling high enough that no test in this file trips the limiter. */
 const NO_RATE_LIMIT = '100000';
-
-const simulationLogsDir = path.resolve(repoRoot, 'src/server/logs/simulations');
-const dataStoragePath = path.resolve(repoRoot, 'src/server/data/data-storage.json');
 
 const mongoHost = process.env.TAS_E2E_MONGO_HOST || '127.0.0.1';
 const mongoPort = Number(process.env.TAS_E2E_MONGO_PORT || 27017);
@@ -172,12 +176,12 @@ const readSimulationLog = async (baseUrl, logFile) => {
 const removeRunLogs = (name) => {
   let entries = [];
   try {
-    entries = fs.readdirSync(simulationLogsDir);
+    entries = fs.readdirSync(simulationsLogsDir);
   } catch (_) {
     return; // absent, which is the expected case on a fresh checkout
   }
   for (const entry of entries) {
-    if (entry.startsWith(`${name}_`)) removeIfPresent(path.join(simulationLogsDir, entry));
+    if (entry.startsWith(`${name}_`)) removeIfPresent(path.join(simulationsLogsDir, entry));
   }
 };
 
@@ -200,7 +204,7 @@ const stopRun = (baseUrl, name) =>
 before(async () => {
   // Nothing under src/server/logs is created up front by the application, so
   // give the run loggers their directory before anything starts.
-  fs.mkdirSync(simulationLogsDir, { recursive: true });
+  fs.mkdirSync(simulationsLogsDir, { recursive: true });
   [mongoUp, mqttUp] = await Promise.all([
     probeTcp(mongoHost, mongoPort),
     probeTcp(mqttHost, mqttPort),


### PR DESCRIPTION
Closes #58.

## What

The route modules no longer derive their storage locations from `__dirname` at require time. A new `src/server/paths.js` resolves one storage root (`TAS_STORAGE_ROOT`, defaulting to the server directory) and every route module derives its `data/` and `logs/` paths from it. The pre-existing per-directory overrides (`TAS_MODELS_DIR`, `TAS_DATA_RECORDERS_DIR`, `TAS_DATA_DIR`, `TAS_RUNTIME_STATE_PATH`) still take precedence for their one directory.

The e2e helpers now create one throwaway root under the system temp dir per suite, pre-create the deployed directory layout, seed it with the shipped `devops.json` / `data-storage.json` defaults, point every spawned instance at it through `TAS_STORAGE_ROOT`, and remove it in a root-level `after` hook.

## Why

- A crashed e2e run can no longer leave `topo-*` / `ren-*` artifacts in `src/server/data` or `src/server/logs` - residue can only land in a temp dir that is swept regardless.
- The devops.json snapshot/restore and the checkout-sweep workarounds in `security-suite.test.js` are gone; the suites no longer touch the checkout.
- The suites are independent of one storage root, so the shared-root races that forced `--test-concurrency=1` are removed. The flag stays because in-process suites (e.g. `test/http-status.test.js`) still exercise the checkout's own data files; the workflow comment now documents exactly that (the AC's documented-remainder branch).

## Acceptance criteria

- [x] Storage root is configurable, not `__dirname`-derived at require time (`src/server/paths.js` + the six route modules + runtime-state)
- [x] Each e2e suite runs against a temp dir under the system temp dir, removed when the suite finishes
- [x] A failed/crashed run leaves nothing in `src/server/data` or `src/server/logs` (verified: `git status` clean after runs, temp roots swept)
- [x] Default resolution unchanged - `TAS_STORAGE_ROOT` unset resolves `data/` and `logs/` exactly as before; all in-process route tests pass unmodified
- [x] Remaining `--test-concurrency=1` reason documented in `e2e-security.yml`
- [x] Existing containment assertions pass unchanged against the relocated root (escape canaries derive from the relocated dirs; repo-root canary kept)

## Test plan

- `npm test`: 589 tests - 573 pass, 15 skipped, 1 fail (`a session in continuous use is never logged out spuriously`, verified failing identically on unmodified master - the known baseline flake)
- `security-suite`, `limits`, `auth-journey` (incl. the Phase 0 digest gate, updated in the same commit as the gate requires), `runtime-state-restart`, `modernised-workflow`, `simulation-lifecycle`, `browser-journey` all green
- `prettier --check` and `eslint` clean
