### PR TITLE
refactor(core): remove redundant try/catch in readJSONFileSync (#59)

### DIFF
--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -45,12 +45,8 @@ const readDir = (dirPath, callback) => {
  * @param {String} filePath Path to file
  */
 const readJSONFileSync = (filePath) => {
-  try {
-    const data = fs.readFileSync(filePath);
-    return JSON.parse(data);
-  } catch (error) {
-    throw error;
-  }
+  const data = fs.readFileSync(filePath);
+  return JSON.parse(data);
 };
 
 /**


### PR DESCRIPTION
## Summary

Removes the redundant  wrapper in  that merely rethrows without adding any error handling, logging, or context.

## Changes

- ****: Removed the no-op  from . Errors (ENOENT, JSON parse failures, etc.) now propagate naturally, which is identical to the previous behavior.

## Verification

- The function is exported but not imported by any other module in the codebase — it is a dead export.
- All other helpers in the same file (, , , ) retain their intentional try/catch blocks that route errors to callbacks.
- No behavioral change: a missing or malformed file still throws identically.

Closes #59